### PR TITLE
feat: implement free items support for promotional offers

### DIFF
--- a/POS/src/components/sale/InvoiceCart.vue
+++ b/POS/src/components/sale/InvoiceCart.vue
@@ -190,9 +190,22 @@
 						<div class="flex-1 min-w-0 flex flex-col">
 							<!-- Header: Item Name & Delete -->
 							<div class="flex items-start justify-between gap-1 mb-1">
-								<h4 class="text-[11px] sm:text-xs font-bold text-gray-900 truncate leading-tight">
-									{{ item.item_name }}
-								</h4>
+								<div class="flex items-center gap-1.5 flex-1 min-w-0">
+									<h4 class="text-[11px] sm:text-xs font-bold text-gray-900 truncate leading-tight">
+										{{ item.item_name }}
+									</h4>
+									<!-- Free Item Badge -->
+									<span
+										v-if="item.free_qty && item.free_qty > 0"
+										class="inline-flex items-center px-1.5 py-0.5 bg-green-600 text-white rounded-full text-[9px] font-bold flex-shrink-0"
+										:title="`${item.free_qty} free item(s) included`"
+									>
+										<svg class="w-2.5 h-2.5 mr-0.5" fill="currentColor" viewBox="0 0 20 20">
+											<path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd"/>
+										</svg>
+										+{{ item.free_qty }} FREE
+									</span>
+								</div>
 								<button
 									type="button"
 									@click.stop="$emit('remove-item', item.item_code)"
@@ -744,7 +757,11 @@ watch(customerResults, () => {
 })
 
 const totalQuantity = computed(() => {
-	return props.items.reduce((sum, item) => sum + (item.quantity || 0), 0)
+	return props.items.reduce((sum, item) => {
+		const qty = item.quantity || 0
+		const freeQty = item.free_qty || 0
+		return sum + qty + freeQty
+	}, 0)
 })
 
 // Handle search input with instant reactivity

--- a/POS/src/stores/posOffers.js
+++ b/POS/src/stores/posOffers.js
@@ -63,6 +63,11 @@ export const usePOSOffersStore = defineStore("posOffers", () => {
 		hasFetched.value = false
 	}
 
+	/**
+	 * Checks if an offer is eligible based on current cart state
+	 * @param {Object} offer - The offer to check
+	 * @returns {Object} {eligible: boolean, reason: string|null}
+	 */
 	function checkOfferEligibility(offer) {
 		const subtotal = cartSnapshot.value.subtotal || 0
 		const itemCount = cartSnapshot.value.itemCount || 0
@@ -75,6 +80,14 @@ export const usePOSOffersStore = defineStore("posOffers", () => {
 			return {
 				eligible: false,
 				reason: "Cart is empty",
+			}
+		}
+
+		// Check minimum quantity (e.g., "Buy 2 Get 1 Free" requires at least 2 items)
+		if (offer?.min_qty && itemCount < offer.min_qty) {
+			return {
+				eligible: false,
+				reason: `At least ${offer.min_qty} items required`,
 			}
 		}
 

--- a/pos_next/api/promotions.py
+++ b/pos_next/api/promotions.py
@@ -569,14 +569,15 @@ def get_coupons(company=None, include_disabled=False, coupon_type=None):
 	if coupon_type:
 		filters["coupon_type"] = coupon_type
 
-	# Build field list - only include disabled if it exists
+	# Build field list - only include fields that exist
 	fields = [
 		"name", "coupon_name", "coupon_code", "coupon_type",
-		"customer", "customer_name", "pos_offer",
+		"customer", "customer_name",
 		"valid_from", "valid_upto", "maximum_use", "used",
 		"one_use", "company", "campaign"
 	]
 
+	# Check for optional fields
 	if has_disabled_field:
 		fields.append("disabled")
 
@@ -854,27 +855,6 @@ def delete_coupon(coupon_name):
 			message=frappe.get_traceback()
 		)
 		frappe.throw(_("Failed to delete coupon: {0}").format(str(e)))
-
-
-@frappe.whitelist()
-def get_pos_offers(company=None):
-	"""Get all coupon-based POS offers."""
-	filters = {"coupon_based": 1, "disable": 0}
-
-	if company:
-		filters["company"] = company
-
-	offers = frappe.get_all(
-		"POS Offer",
-		filters=filters,
-		fields=[
-			"name", "title", "discount_percentage", "discount_amount",
-			"apply_on", "valid_from", "valid_upto"
-		],
-		order_by="title"
-	)
-
-	return offers
 
 
 # =============================================================================


### PR DESCRIPTION
- Add processFreeItems() to handle free item quantities from backend
- Display free item badge (+X FREE) in cart UI
- Update totalQuantity to include free items in count
- Add minimum quantity validation for offer eligibility
- Make offer eligibility reactive to cart changes
- Refactor offers.py with type hints and data classes
- Remove unused coupon functions and pos_offer references
- Fix database column checks in promotions.py