### PR TITLE
feat: translation support for frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ dev-dist/
 !docs/screenshots/*.gif
 .playwright-mcp/*
 TODO.md
+
+# I18n
+i18n/

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,3 @@ dev-dist/
 !docs/screenshots/*.gif
 .playwright-mcp/*
 TODO.md
-
-# I18n
-i18n/

--- a/POS/.claude.md
+++ b/POS/.claude.md
@@ -73,6 +73,121 @@ import { createResource } from 'frappe-ui' // BAD in .js files!
 export const myResource = createResource({...})
 ```
 
+## Translation
+
+Use the `__` method to translate all text that is displayed to the user.
+
+```vue
+	<!-- ❌ WRONG - Non-translatable strings -->
+	<template>
+		<input type="text" placeholder="This is an input"></input>
+		<button @click="alert("Button clicked!")">Click Me</button>
+	</template>
+
+	<!-- ✅ CORRECT - Translatable strings -->
+	<template>
+		<input type="text" :placeholder="__("This is an input")" />
+		<button @click="alert(__("Button clicked!"))">{{ __('Click Me') }}</button>
+	</template>
+```
+
+**ALWAYS** wrap translatable string literals directly within the `__` method.
+
+```vue
+	<!-- ❌ WRONG - String literal not marked for translation -->
+	<template>
+		<p>{{ __(message) }}</p>
+	</template>
+	<script setup>
+		const message = ref("This is a message")
+	</script>
+
+	<!-- ✅ CORRECT - String literal marked for translation -->
+	<template>
+		<p>{{ message }}</p>
+	</template>
+	<script setup>
+		const message = ref(__("This is a message"))
+	</script>
+```
+
+When appropriate, leverage Frappe's built-in translation system for server-side data to translate messages or object properties.
+
+```vue
+	<template>
+		<p>{{ __(item.data.label) }}</p>
+	</template>
+	<script setup>
+		const myItem = createResource({
+			url: 'api.get_my_item',
+			auto: false,
+		})	
+	</script>
+```
+
+### Variables
+
+If there are variables in the string, pass them to `__` as the second argument and in array format. 
+In the string, use the positional formatter {0}. Don't split your string into separate blocks of strings and then concatenate them. 
+Don't write multi-line strings. Always write your string in a single even if the string is very large.
+
+```vue
+	<!-- ❌ WRONG - Don't use template literals -->
+	<template>
+		<p>{{ __(`This paragraph contains two variables ${myVar} and ${myOtherVar}.`) }}</p>
+	</template>
+
+	<!-- ❌ WRONG - Don't split strings -->
+	<template>
+		<p>{{ __('This paragraph contains two variables ') + myVar + __('and') + myOtherVar + __('.') }}</p>
+	</template>
+
+	<!-- ❌ WRONG - Don't use multi-line strings -->
+	<template>
+		<p>{{ __('This paragraph contains two variables' + 
+		'{0} and {1}.', [myVar, myOtherVar]) }}</p>
+	</template>
+
+	<!-- ✅ CORRECT - Use positional formatter and pass variables in an array -->
+	<template>
+		<p>{{ __('This paragraph contains two variables {0} and {1}.', [myVar, myOtherVar]) }}</p>
+	</template>
+```
+
+### Plural
+
+When a variable determine whether a string is to be pluralized, wrap each form of the entire string in the `__` method.
+
+```vue
+	<!-- ❌ WRONG - Don't use a single string as a base for multiple forms -->
+	<template>
+		<p>{{ __('There {0} {1} items{2}.', [itemCount === 1 ? 'is' : 'are', itemCount, itemCount === 1 ? '' : 's']) }}</p>
+	</template>
+
+	<!-- ✅ CORRECT - Use an entire string for each form -->
+	<template>
+		<p>{{ itemCount === 1 
+		? __('There is {0} item.', [itemCount])
+		: __('There are {0} items.', [itemCount]) }}</p>
+	</template>
+```
+
+### Context
+
+A string may have different translations depending on the context. When the meaning may be ambiguous, pass a short descriptor string that clarifies the context to `__` as the third argument.
+
+```vue
+	<!-- ❌ WRONG - Ambiguous translation -->
+	<template>
+		<p>{{ __("Change") }}</p>
+	</template>
+
+	<!-- ✅ CORRECT - Context clarifies the appropriate translation -->
+	<template>
+		<p>{{ __("Change", null, "Coins") }}</p>
+	</template>
+```
+
 ## Error Handling
 
 ### Toast Notifications in Vue Components
@@ -86,13 +201,13 @@ import { useToast } from '@/composables/useToast'
 const { showSuccess, showError, showWarning } = useToast()
 
 // Success notifications
-showSuccess('Operation completed successfully')
+showSuccess(__('Operation completed successfully'))
 
 // Error notifications
-showError(error.message || 'Operation failed')
+showError(error.message || __('Operation failed'))
 
 // Warning notifications
-showWarning('Please review your input')
+showWarning(__('Please review your input'))
 ```
 
 ### Never use `window.frappe.msgprint` or `toast.create` from frappe-ui
@@ -114,7 +229,7 @@ toast.create({
 // ✅ CORRECT - Use custom toast composable
 import { useToast } from '@/composables/useToast'
 const { showError } = useToast()
-showError('Something went wrong')
+showError(__('Something went wrong'))
 ```
 
 ## Offline Support
@@ -143,9 +258,9 @@ Always provide screen-reader descriptions for dialogs:
 
 ```vue
 <template>
-	<Dialog v-model="show" :options="{ title: 'Dialog Title', size: 'md' }">
+	<Dialog v-model="show" :options="{ title: __('Dialog Title'), size: 'md' }">
 		<template #body-title>
-			<span class="sr-only">Description for screen readers</span>
+			<span class="sr-only">{{ __('Description for screen readers') }}</span>
 		</template>
 		<template #body-content>
 			<!-- Dialog content -->
@@ -324,7 +439,7 @@ onMounted(async () => {
 
 		// Show success notification
 		const { showSuccess } = useToast()
-		showSuccess("Sync Complete - Data is ready for offline use")
+		showSuccess(__("Sync Complete - Data is ready for offline use"))
 	}
 })
 ```
@@ -387,7 +502,7 @@ import { offlineWorker } from '@/utils/offline/workerClient'
 const { showWarning } = useToast()
 const cacheReady = await offlineWorker.isCacheReady()
 if (isOffline() && !cacheReady) {
-	showWarning("Limited Functionality - POS is offline without cached data")
+	showWarning(__("Limited Functionality - POS is offline without cached data"))
 }
 ```
 

--- a/POS/components.d.ts
+++ b/POS/components.d.ts
@@ -50,6 +50,7 @@ declare module 'vue' {
     ShiftOpeningDialog: typeof import('./src/components/ShiftOpeningDialog.vue')['default']
     StatusBadge: typeof import('./src/components/common/StatusBadge.vue')['default']
     Toast: typeof import('./src/components/common/Toast.vue')['default']
+    TranslatedHTML: typeof import('./src/components/common/TranslatedHTML.vue')['default']
     UserMenu: typeof import('./src/components/common/UserMenu.vue')['default']
     WarehouseAvailabilityDialog: typeof import('./src/components/sale/WarehouseAvailabilityDialog.vue')['default']
   }

--- a/POS/src/components/ShiftClosingDialog.vue
+++ b/POS/src/components/ShiftClosingDialog.vue
@@ -1,11 +1,11 @@
 <template>
-  <Dialog v-model="open" :options="{ title: 'Close POS Shift', size: '4xl' }">
+  <Dialog v-model="open" :options="{ title: __('Close POS Shift'), size: '4xl' }">
     <template #body-content>
       <div class="space-y-3 md:space-y-6">
         <div v-if="closingDataResource.loading" class="text-center py-8 md:py-12">
           <div class="inline-block animate-spin rounded-full h-12 w-12 md:h-16 md:w-16 border-b-4 border-blue-600"></div>
-          <p class="mt-3 md:mt-4 text-base md:text-lg font-medium text-gray-600">Loading shift data...</p>
-          <p class="text-xs md:text-sm text-gray-500">Calculating totals and reconciliation...</p>
+          <p class="mt-3 md:mt-4 text-base md:text-lg font-medium text-gray-600">{{ __('Loading shift data...') }}</p>
+          <p class="text-xs md:text-sm text-gray-500">{{ __('Calculating totals and reconciliation...') }}</p>
         </div>
 
         <div v-else-if="closingData" class="space-y-3 md:space-y-6">
@@ -17,7 +17,7 @@
                 <p class="text-xs md:text-sm text-gray-500 mt-1">{{ formatDateTime(closingData.period_start_date) }}</p>
               </div>
               <div class="text-left sm:text-right">
-                <div class="text-xs text-gray-500 uppercase">Duration</div>
+                <div class="text-xs text-gray-500 uppercase">{{ __('Duration') }}</div>
                 <div class="text-base md:text-lg font-semibold text-gray-900">{{ getShiftDuration() }}</div>
               </div>
             </div>
@@ -26,30 +26,30 @@
             <div class="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-4">
               <!-- Total Sales -->
               <div class="bg-blue-50 border border-blue-200 rounded-lg p-3 md:p-4">
-                <div class="text-blue-600 text-xs uppercase font-medium mb-1">Total Sales</div>
+                <div class="text-blue-600 text-xs uppercase font-medium mb-1">{{ __('Total Sales') }}</div>
                 <div class="text-lg md:text-2xl font-bold text-blue-900 mb-0.5 md:mb-1 truncate">{{ formatCurrency(closingData.grand_total) }}</div>
-                <div class="text-blue-600 text-xs">{{ invoiceCount }} invoices</div>
+                <div class="text-blue-600 text-xs">{{ __('{0} invoices', [invoiceCount]) }}</div>
               </div>
 
               <!-- Net Amount -->
               <div class="bg-gray-50 border border-gray-200 rounded-lg p-3 md:p-4">
-                <div class="text-gray-600 text-xs uppercase font-medium mb-1">Net Amount</div>
+                <div class="text-gray-600 text-xs uppercase font-medium mb-1">{{ __('Net Amount') }}</div>
                 <div class="text-lg md:text-2xl font-bold text-gray-900 mb-0.5 md:mb-1 truncate">{{ formatCurrency(closingData.net_total) }}</div>
-                <div class="text-gray-600 text-xs">Before tax</div>
+                <div class="text-gray-600 text-xs">{{ __('Before tax') }}</div>
               </div>
 
               <!-- Items Sold -->
               <div class="bg-gray-50 border border-gray-200 rounded-lg p-3 md:p-4">
-                <div class="text-gray-600 text-xs uppercase font-medium mb-1">Items Sold</div>
+                <div class="text-gray-600 text-xs uppercase font-medium mb-1">{{ __('Items Sold') }}</div>
                 <div class="text-lg md:text-2xl font-bold text-gray-900 mb-0.5 md:mb-1">{{ formatQuantity(closingData.total_quantity) }}</div>
-                <div class="text-gray-600 text-xs">Total items</div>
+                <div class="text-gray-600 text-xs">{{ __('Total items') }}</div>
               </div>
 
               <!-- Tax Collected -->
               <div class="bg-gray-50 border border-gray-200 rounded-lg p-3 md:p-4">
-                <div class="text-gray-600 text-xs uppercase font-medium mb-1">Tax Collected</div>
+                <div class="text-gray-600 text-xs uppercase font-medium mb-1">{{ __('Tax Collected') }}</div>
                 <div class="text-lg md:text-2xl font-bold text-gray-900 mb-0.5 md:mb-1 truncate">{{ formatCurrency(totalTax) }}</div>
-                <div class="text-gray-600 text-xs">Total tax</div>
+                <div class="text-gray-600 text-xs">{{ __('Total tax') }}</div>
               </div>
             </div>
           </div>
@@ -63,9 +63,9 @@
                 </svg>
               </div>
               <div>
-                <h3 class="text-xs md:text-sm font-medium text-yellow-900">No Sales During This Shift</h3>
+                <h3 class="text-xs md:text-sm font-medium text-yellow-900">{{ __('No Sales During This Shift') }}</h3>
                 <p class="text-xs md:text-sm text-yellow-700 mt-1 md:mt-2">
-                  No invoices were created. Closing amounts should match opening amounts.
+                  {{ __('No invoices were created. Closing amounts should match opening amounts.') }}
                 </p>
               </div>
             </div>
@@ -80,8 +80,11 @@
               class="w-full px-3 py-3 md:px-6 md:py-4 flex items-center justify-between hover:bg-gray-50 transition-colors"
             >
               <div class="text-left">
-                <h3 class="text-sm md:text-lg font-medium text-gray-900">Invoice Details</h3>
-                <p class="text-xs md:text-sm text-gray-500">{{ invoiceCount }} transactions • {{ formatCurrency(closingData.grand_total) }}</p>
+                <h3 class="text-sm md:text-lg font-medium text-gray-900">{{ __('Invoice Details') }}</h3>
+                <p class="text-xs md:text-sm text-gray-500">{{ __('{0} transactions • {1}', [
+                  invoiceCount,
+                  formatCurrency(closingData.grand_total)
+                ]) }}</p>
               </div>
               <svg
                 :class="['h-4 w-4 md:h-5 md:w-5 text-gray-400 transition-transform', showInvoiceDetails ? 'transform rotate-180' : '']"
@@ -99,7 +102,7 @@
                 <div v-for="(invoice, idx) in closingData.pos_transactions" :key="idx" class="p-3 hover:bg-gray-50">
                   <div class="flex justify-between items-start mb-2">
                     <span class="text-xs font-medium text-gray-900">
-                      {{ invoice.pos_invoice || invoice.sales_invoice || 'N/A' }}
+                      {{ invoice.pos_invoice || invoice.sales_invoice || __('N/A') }}
                     </span>
                     <span class="text-sm font-semibold text-gray-900">
                       {{ formatCurrency(invoice.grand_total) }}
@@ -112,7 +115,7 @@
                 </div>
                 <div class="bg-gray-50 p-3">
                   <div class="flex justify-between items-center">
-                    <span class="text-xs font-semibold text-gray-700">Total:</span>
+                    <span class="text-xs font-semibold text-gray-700">{{ __('Total:') }}</span>
                     <span class="text-sm font-bold text-gray-900">
                       {{ formatCurrency(closingData.grand_total) }}
                     </span>
@@ -125,17 +128,17 @@
                 <table class="min-w-full divide-y divide-gray-200">
                   <thead class="bg-gray-50">
                     <tr>
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Invoice</th>
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Customer</th>
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Time</th>
-                      <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Amount</th>
+                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">{{ __('Invoice') }}</th>
+                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">{{ __('Customer') }}</th>
+                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">{{ __('Time') }}</th>
+                      <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">{{ __('Amount') }}</th>
                     </tr>
                   </thead>
                   <tbody class="bg-white divide-y divide-gray-200">
                     <tr v-for="(invoice, idx) in closingData.pos_transactions" :key="idx" class="hover:bg-gray-50">
                       <td class="px-6 py-4 whitespace-nowrap">
                         <span class="text-sm font-medium text-gray-900">
-                          {{ invoice.pos_invoice || invoice.sales_invoice || 'N/A' }}
+                          {{ invoice.pos_invoice || invoice.sales_invoice || __('N/A') }}
                         </span>
                       </td>
                       <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
@@ -154,7 +157,7 @@
                   <tfoot class="bg-gray-50">
                     <tr>
                       <td colspan="3" class="px-6 py-4 text-right text-sm font-semibold text-gray-700">
-                        Total:
+                        {{ __('Total:') }}
                       </td>
                       <td class="px-6 py-4 whitespace-nowrap text-right">
                         <span class="text-base font-bold text-gray-900">
@@ -177,9 +180,9 @@
               <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
                 <div>
                   <div class="flex items-center gap-2">
-                    <h3 class="text-sm md:text-lg font-semibold text-gray-900">Payment Reconciliation</h3>
+                    <h3 class="text-sm md:text-lg font-semibold text-gray-900">{{ __('Payment Reconciliation') }}</h3>
                     <span v-if="hideExpectedAmount && showSuccessReport" class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                      ✓ Shift Closed
+                      {{ __('✓ Shift Closed') }}
                     </span>
                   </div>
                   <p class="text-xs md:text-sm text-gray-600">
@@ -187,7 +190,7 @@
                   </p>
                 </div>
                 <div v-if="shouldShowSummary && getTotalDifference !== 0" class="text-left sm:text-right">
-                  <div class="text-xs text-gray-500 uppercase">Total Variance</div>
+                  <div class="text-xs text-gray-500 uppercase">{{ __('Total Variance') }}</div>
                   <div :class="[
                     'text-lg md:text-xl font-bold',
                     getTotalDifference > 0 ? 'text-blue-600' : 'text-red-600'
@@ -228,7 +231,7 @@
                         min="0"
                         placeholder="0.00"
                         :disabled="submitResource.loading"
-                        :aria-label="`Enter actual amount for ${payment.mode_of_payment}`"
+                        :aria-label="__('Enter actual amount for {0}', [payment.mode_of_payment])"
                         class="text-base md:text-lg text-center font-semibold"
                       />
                     </div>
@@ -256,22 +259,24 @@
                       </div>
                       <div>
                         <h4 class="text-sm md:text-base font-semibold text-gray-900">{{ payment.mode_of_payment }}</h4>
-                        <p class="text-xs md:text-sm text-gray-600">
-                          Expected: <span class="font-medium">{{ formatCurrency(payment.expected_amount) }}</span>
-                        </p>
+                        <TranslatedHTML
+                          :tag="'p'"
+                          class="text-xs md:text-sm text-gray-600"
+                          :inner="__('Expected: &lt;span class=&quot;font-medium&quot;&gt;{0}&lt;/span&gt;', [formatCurrency(payment.expected_amount)])"
+                        />
                       </div>
                     </div>
 
                     <!-- Status Badge -->
                     <div v-if="payment.closing_amount !== null && payment.closing_amount !== undefined" class="flex-shrink-0">
                       <span v-if="payment.difference === 0" class="inline-flex items-center px-2 md:px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                        ✓ Balanced
+                        {{ __('✓ Balanced') }}
                       </span>
                       <span v-else-if="payment.difference > 0" class="inline-flex items-center px-2 md:px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                        Over {{ formatCurrency(payment.difference) }}
+                        {{ __('Over {0}', [formatCurrency(payment.difference)]) }}
                       </span>
                       <span v-else class="inline-flex items-center px-2 md:px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
-                        Short {{ formatCurrency(Math.abs(payment.difference)) }}
+                        {{ __('Short {0}', [formatCurrency(Math.abs(payment.difference))]) }}
                       </span>
                     </div>
                   </div>
@@ -280,16 +285,16 @@
                   <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 md:gap-3">
                     <!-- Opening Amount -->
                     <div class="bg-white rounded-lg p-2 md:p-3 border border-gray-200">
-                      <label class="block text-xs font-medium text-gray-500 uppercase mb-0.5 md:mb-1">Opening</label>
+                      <label class="block text-xs font-medium text-gray-500 uppercase mb-0.5 md:mb-1">{{ __('Opening') }}</label>
                       <div class="text-base md:text-lg font-semibold text-gray-900">
                         {{ formatCurrency(payment.opening_amount) }}
                       </div>
-                      <div class="text-xs text-gray-500 mt-0.5 md:mt-1 hidden sm:block">Shift start</div>
+                      <div class="text-xs text-gray-500 mt-0.5 md:mt-1 hidden sm:block">{{ __('Shift start') }}</div>
                     </div>
 
                     <!-- Expected Amount -->
                     <div class="bg-white rounded-lg p-2 md:p-3 border border-gray-200">
-                      <label class="block text-xs font-medium text-gray-500 uppercase mb-0.5 md:mb-1">Expected</label>
+                      <label class="block text-xs font-medium text-gray-500 uppercase mb-0.5 md:mb-1">{{ __('Expected') }}</label>
                       <div class="text-base md:text-lg font-semibold text-gray-900">
                         {{ formatCurrency(payment.expected_amount) }}
                       </div>
@@ -297,14 +302,14 @@
                         <span v-if="getSalesForPayment(payment) > 0">
                           +{{ formatCurrency(getSalesForPayment(payment)) }}
                         </span>
-                        <span v-else>No sales</span>
+                        <span v-else>{{ __('No sales') }}</span>
                       </div>
                     </div>
 
                     <!-- Actual/Closing Amount -->
                     <div class="bg-white rounded-lg p-2 md:p-3 border border-gray-300">
                       <label class="block text-xs font-medium text-gray-700 uppercase mb-0.5 md:mb-1">
-                        Actual Amount *
+                        {{ __('Actual Amount *') }}
                       </label>
                       <Input
                         :modelValue="payment.closing_amount"
@@ -318,7 +323,7 @@
                         class="text-base md:text-lg"
                       />
                       <div class="text-xs text-gray-500 mt-0.5 md:mt-1 hidden sm:block">
-                        {{ showSuccessReport ? 'Final Amount' : 'Count & enter' }}
+                        {{ showSuccessReport ? __('Final Amount') : __('Count & enter') }}
                       </div>
                     </div>
                   </div>
@@ -331,12 +336,12 @@
                     <div class="flex items-center justify-between gap-2">
                       <div class="flex-1">
                         <p :class="['text-xs md:text-sm font-medium', payment.difference > 0 ? 'text-blue-900' : 'text-red-900']">
-                          {{ payment.difference > 0 ? 'Cash Over' : 'Cash Short' }}
+                          {{ payment.difference > 0 ? __('Cash Over') : __('Cash Short') }}
                         </p>
                         <p :class="['text-xs', payment.difference > 0 ? 'text-blue-700' : 'text-red-700']">
                           {{ payment.difference > 0
-                            ? 'You have more than expected.'
-                            : 'You have less than expected.'
+                            ? __('You have more than expected.')
+                            : __('You have less than expected.')
                           }}
                         </p>
                       </div>
@@ -353,15 +358,15 @@
             <div v-if="shouldShowSummary" class="bg-gray-50 px-3 py-3 md:px-6 md:py-4 border-t border-gray-200">
               <div class="grid grid-cols-3 gap-2 md:gap-4">
                 <div>
-                  <p class="text-xs md:text-sm text-gray-600">Total Expected</p>
+                  <p class="text-xs md:text-sm text-gray-600">{{ __('Total Expected') }}</p>
                   <p class="text-base md:text-xl font-semibold text-gray-900">{{ formatCurrency(getTotalExpected) }}</p>
                 </div>
                 <div class="text-center md:text-right">
-                  <p class="text-xs md:text-sm text-gray-600">Total Actual</p>
+                  <p class="text-xs md:text-sm text-gray-600">{{ __('Total Actual') }}</p>
                   <p class="text-base md:text-xl font-semibold text-gray-900">{{ formatCurrency(getTotalActual) }}</p>
                 </div>
                 <div class="text-right">
-                  <p class="text-xs md:text-sm text-gray-600">Net Variance</p>
+                  <p class="text-xs md:text-sm text-gray-600">{{ __('Net Variance') }}</p>
                   <p :class="[
                     'text-base md:text-xl font-bold',
                     getTotalDifference === 0 ? 'text-green-600' :
@@ -377,7 +382,7 @@
           <!-- Tax Summary (hidden in entry mode when hideExpectedAmount is enabled) -->
           <div v-if="shouldShowSummary && closingData.taxes && closingData.taxes.length > 0" class="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm">
             <div class="px-3 py-3 md:px-6 md:py-4 bg-gray-50 border-b border-gray-200">
-              <h3 class="text-sm md:text-lg font-medium text-gray-900">Tax Summary</h3>
+              <h3 class="text-sm md:text-lg font-medium text-gray-900">{{ __('Tax Summary') }}</h3>
             </div>
             <div class="p-3 md:p-6">
               <div class="space-y-2 md:space-y-3">
@@ -393,7 +398,7 @@
               </div>
               <div class="mt-3 md:mt-4 pt-3 md:pt-4 border-t border-gray-200">
                 <div class="flex items-center justify-between">
-                  <span class="text-xs md:text-sm font-medium text-gray-700">Total Tax Collected</span>
+                  <span class="text-xs md:text-sm font-medium text-gray-700">{{ __('Total Tax Collected') }}</span>
                   <span class="text-base md:text-lg font-bold text-gray-900">{{ formatCurrency(totalTax) }}</span>
                 </div>
               </div>
@@ -407,14 +412,14 @@
                 <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
               </svg>
               <div class="flex-1">
-                <h4 class="text-xs md:text-sm font-medium text-red-800">Error Closing Shift</h4>
+                <h4 class="text-xs md:text-sm font-medium text-red-800">{{ __('Error Closing Shift') }}</h4>
                 <p class="text-xs md:text-sm text-red-700 mt-1">{{ errorMessage || submitResource.error }}</p>
                 <button
                   v-if="errorMessage"
                   @click="errorMessage = ''"
                   class="mt-2 text-xs text-red-600 hover:text-red-800 underline"
                 >
-                  Dismiss
+                  {{ __('Dismiss') }}
                 </button>
               </div>
             </div>
@@ -428,7 +433,7 @@
               <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
             </svg>
             <div>
-              <h3 class="text-xs md:text-sm font-medium text-red-800">Failed to Load Shift Data</h3>
+              <h3 class="text-xs md:text-sm font-medium text-red-800">{{ __('Failed to Load Shift Data') }}</h3>
               <p class="text-xs md:text-sm text-red-700 mt-1">{{ errorMessage || closingDataResource.error }}</p>
             </div>
           </div>
@@ -445,18 +450,18 @@
           :disabled="submitResource.loading"
           class="order-2 sm:order-1"
         >
-          {{ showSuccessReport ? 'Close' : 'Cancel' }}
+          {{ showSuccessReport ? __('Close') : __('Cancel') }}
         </Button>
 
         <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3 order-1 sm:order-2">
           <!-- Validation Warning (only in entry mode) -->
           <div v-if="!canSubmit && closingData && !showSuccessReport" class="text-xs md:text-sm text-yellow-600 font-medium text-center sm:text-right">
-            Please enter all closing amounts
+            {{ __('Please enter all closing amounts') }}
           </div>
 
           <!-- Success message (shown in report view) -->
           <div v-if="showSuccessReport" class="text-xs md:text-sm text-green-600 font-medium text-center sm:text-right">
-            ✓ Shift closed successfully
+            {{ __('✓ Shift closed successfully') }}
           </div>
 
           <!-- Submit/Close button (only shown in entry mode) -->
@@ -468,7 +473,7 @@
             :loading="submitResource.loading"
             :disabled="!canSubmit"
           >
-            {{ submitResource.loading ? 'Closing Shift...' : 'Close Shift' }}
+            {{ submitResource.loading ? __('Closing Shift...') : __('Close Shift') }}
           </Button>
         </div>
       </div>
@@ -483,6 +488,7 @@ import { storeToRefs } from "pinia"
 import { useShift } from "../composables/useShift"
 import { useFormatters } from "../composables/useFormatters"
 import { usePOSSettingsStore } from "../stores/posSettings"
+import TranslatedHTML from "./common/TranslatedHTML.vue"
 
 const props = defineProps({
 	modelValue: {
@@ -694,7 +700,7 @@ function getSalesForPayment(payment) {
 }
 
 function getShiftDuration() {
-	if (!closingData.value || !closingData.value.period_start_date) return "N/A"
+	if (!closingData.value || !closingData.value.period_start_date) return __("N/A")
 
 	const start = new Date(closingData.value.period_start_date)
 	const end = new Date()
@@ -704,9 +710,9 @@ function getShiftDuration() {
 	const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60))
 
 	if (hours > 0) {
-		return `${hours}h ${minutes}m`
+    return __('{0}h {1}m', [hours, minutes])
 	}
-	return `${minutes}m`
+	return __('{0}m', [minutes])
 }
 
 function getPaymentIcon(method) {

--- a/POS/src/components/ShiftOpeningDialog.vue
+++ b/POS/src/components/ShiftOpeningDialog.vue
@@ -1,12 +1,12 @@
 <template>
-  <Dialog v-model="open" :options="{ title: 'Open POS Shift', size: 'xl' }">
+  <Dialog v-model="open" :options="{ title: __('Open POS Shift'), size: 'xl' }">
     <template #body-content>
       <div class="space-y-6">
         <!-- Step 1: Select POS Profile -->
         <div v-if="step === 1" class="space-y-4">
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-2">
-              Select POS Profile
+              {{ __('Select POS Profile') }}
             </label>
             <div v-if="profilesResource.loading" class="text-center py-4">
               <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
@@ -35,7 +35,7 @@
               </div>
             </div>
             <div v-else class="text-center py-8 text-gray-500">
-              <p>No POS Profiles available. Please contact your administrator.</p>
+              <p>{{ __('No POS Profiles available. Please contact your administrator.') }}</p>
             </div>
           </div>
 
@@ -52,13 +52,13 @@
                 <h3 class="font-medium text-gray-900">{{ selectedProfile?.name }}</h3>
                 <p class="text-sm text-gray-500">{{ selectedProfile?.company }}</p>
               </div>
-              <Button variant="subtle" @click="step = 1">Change Profile</Button>
+              <Button variant="subtle" @click="step = 1">{{ __('Change Profile') }}</Button>
             </div>
           </div>
 
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-3">
-              Opening Balance (Optional)
+              {{ __('Opening Balance (Optional)') }}
             </label>
 
             <div v-if="dialogDataResource.loading" class="text-center py-4">
@@ -89,7 +89,7 @@
             </div>
 
             <div v-else class="text-center py-4 text-gray-500">
-              <p class="text-sm">No payment methods configured for this POS Profile</p>
+              <p class="text-sm">{{ __('No payment methods configured for this POS Profile') }}</p>
             </div>
           </div>
 
@@ -110,21 +110,27 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </div>
-            <h3 class="text-lg font-medium text-gray-900 mb-2">Existing Shift Found</h3>
+            <h3 class="text-lg font-medium text-gray-900 mb-2">{{ __('Existing Shift Found') }}</h3>
             <p class="text-sm text-gray-500 mb-6">
-              You have an open shift. Would you like to resume it or close it and open a new one?
+              {{ __('You have an open shift. Would you like to resume it or close it and open a new one?') }}
             </p>
 
             <div v-if="existingShift" class="bg-gray-50 rounded-lg p-4 mb-6">
               <div class="text-sm text-gray-600">
-                <p><strong>POS Profile:</strong> {{ existingShift.pos_profile?.name }}</p>
-                <p><strong>Opened:</strong> {{ formatDateTime(existingShift.pos_opening_shift?.period_start_date) }}</p>
+                  <TranslatedHTML
+                    :tag="'p'"
+                    :inner="__('&lt;strong&gt;POS Profile:&lt;/strong&gt; {0}', [existingShift.pos_profile?.name])"
+                  />  
+                  <TranslatedHTML
+                    :tag="'p'"
+                    :inner="__('&lt;strong&gt;Opened:&lt;/strong&gt; {0}', [formatDateTime(existingShift.pos_opening_shift?.period_start_date)])"
+                  />
               </div>
             </div>
 
             <div class="flex space-x-3 justify-center">
               <Button variant="solid" theme="blue" @click="resumeShift">
-                Resume Shift
+                {{ __('Resume Shift') }}
               </Button>
               <Button
                 variant="subtle"
@@ -132,7 +138,7 @@
                 @click="closeAndOpenNew"
                 :disabled="closingExistingShift"
               >
-                Close & Open New
+                {{ __('Close & Open New') }}
               </Button>
             </div>
           </div>
@@ -143,13 +149,13 @@
     <template #actions>
       <div class="flex justify-between w-full">
         <Button v-if="step > 1 && step !== 3" variant="subtle" @click="step--">
-          Back
+          {{ __('Back') }}
         </Button>
         <div v-else></div>
 
         <div class="flex space-x-2">
           <Button variant="subtle" @click="closeDialog('cancelled')" :disabled="createShiftResource.loading">
-            Cancel
+            {{ __('Cancel') }}
           </Button>
           <Button
             v-if="step === 1"
@@ -158,7 +164,7 @@
             @click="nextStep"
             :disabled="!selectedProfile"
           >
-            Next
+            {{ __('Next') }}
           </Button>
           <Button
             v-if="step === 2"
@@ -167,7 +173,7 @@
             @click="openShift"
             :loading="createShiftResource.loading"
           >
-            Open Shift
+            {{ __('Open Shift') }}
           </Button>
         </div>
       </div>
@@ -189,6 +195,7 @@ import { computed, ref, watch } from "vue"
 import { useShift } from "../composables/useShift"
 import { useFormatters } from "../composables/useFormatters"
 import ShiftClosingDialog from "./ShiftClosingDialog.vue"
+import TranslatedHTML from "./common/TranslatedHTML.vue"
 
 const props = defineProps({
 	modelValue: Boolean,

--- a/POS/src/components/common/AutocompleteSelect.vue
+++ b/POS/src/components/common/AutocompleteSelect.vue
@@ -44,7 +44,7 @@
 				<!-- Loading State -->
 				<div v-if="loading" class="dropdown-loading">
 					<div class="loading-spinner"></div>
-					<span>Searching...</span>
+					<span>{{ __('Searching...') }}</span>
 				</div>
 
 				<!-- No Results -->
@@ -52,7 +52,7 @@
 					<svg class="empty-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
 					</svg>
-					<span>{{ searchQuery ? 'No results found' : 'No options available' }}</span>
+					<span>{{ searchQuery ? __('No results found') : __('No options available') }}</span>
 				</div>
 
 				<!-- Options List -->
@@ -67,7 +67,7 @@
 						<svg class="item-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
 						</svg>
-						<span>Clear selection</span>
+						<span>{{ __('Clear selection') }}</span>
 					</button>
 
 					<!-- Options -->
@@ -100,7 +100,7 @@
 						<svg class="item-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
 						</svg>
-						<span>Load more ({{ filteredOptions.length - displayLimit }} remaining)</span>
+						<span>{{ __('Load more ({0} remaining)', [(filteredOptions.length - displayLimit)]) }}</span>
 					</button>
 				</div>
 			</div>
@@ -122,7 +122,7 @@ const props = defineProps({
 	},
 	placeholder: {
 		type: String,
-		default: "Search...",
+		default: __("Search..."),
 	},
 	icon: {
 		type: String,

--- a/POS/src/components/common/ClearCacheOverlay.vue
+++ b/POS/src/components/common/ClearCacheOverlay.vue
@@ -37,10 +37,10 @@
 
 							<!-- Title & Message -->
 							<h3 class="text-2xl font-bold text-gray-900 text-center mb-3">
-								Clear Cache?
+								{{ __('Clear Cache?') }}
 							</h3>
 							<p class="text-gray-600 text-center mb-8 leading-relaxed">
-								This will clear all cached items, customers, and stock data. Invoices and drafts will be preserved.
+								{{ __('This will clear all cached items, customers, and stock data. Invoices and drafts will be preserved.') }}
 							</p>
 
 							<!-- Buttons -->
@@ -49,13 +49,13 @@
 									@click="$emit('cancel')"
 									class="flex-1 px-6 py-3 bg-gray-100 hover:bg-gray-200 text-gray-700 font-semibold rounded-xl transition-all active:scale-95"
 								>
-									Cancel
+									{{ __('Cancel') }}
 								</button>
 								<button
 									@click="handleConfirm"
 									class="flex-1 px-6 py-3 bg-red-600 hover:bg-red-700 text-white font-semibold rounded-xl transition-all active:scale-95 shadow-lg shadow-red-500/30"
 								>
-									Clear Cache
+									{{ __('Clear Cache') }}
 								</button>
 							</div>
 						</div>
@@ -86,10 +86,10 @@
 
 								<!-- Text -->
 								<h3 class="text-xl font-bold text-gray-900 mb-2">
-									Clearing Cache...
+									{{ __('Clearing Cache...') }}
 								</h3>
 								<p class="text-gray-500 text-center">
-									Please wait while we clear your cached data
+									{{ __('Please wait while we clear your cached data') }}
 								</p>
 
 								<!-- Progress dots animation -->

--- a/POS/src/components/common/CountryCodeSelector.vue
+++ b/POS/src/components/common/CountryCodeSelector.vue
@@ -67,7 +67,7 @@
 							ref="searchInputRef"
 							v-model="searchQuery"
 							type="text"
-							placeholder="Search countries..."
+							:placeholder="__('Search countries...')"
 							class="w-full pl-9 pr-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
 							@keydown.escape="closeDropdown"
 							@keydown.enter.prevent="selectFirstFiltered"
@@ -95,7 +95,7 @@
 					</div>
 
 					<div v-else-if="filteredCountries.length === 0" class="px-4 py-8 text-center text-sm text-gray-500">
-						No countries found
+						{{ __('No countries found') }}
 					</div>
 
 					<button

--- a/POS/src/components/common/InstallAppBadge.vue
+++ b/POS/src/components/common/InstallAppBadge.vue
@@ -28,17 +28,17 @@
 					<!-- Text Content -->
 					<div class="flex-1 min-w-0 mr-2">
 						<h3 id="install-banner-title" class="text-xs font-semibold mb-0.5 leading-tight" style="color: #111827;">
-							Install POSNext
+							{{ __('Install POSNext') }}
 						</h3>
 						<p class="text-[10px] leading-tight mb-1" style="color: #4B5563;">
-							Faster access and offline support
+							{{ __('Faster access and offline support') }}
 						</p>
 						<button
 							@click="handleSnooze"
 							class="text-[10px] underline hover:no-underline transition-all"
 							style="color: #6B7280;"
 						>
-							Snooze for 7 days
+							{{ __('Snooze for 7 days') }}
 						</button>
 					</div>
 
@@ -49,14 +49,14 @@
 							class="px-3 py-1.5 text-xs font-medium rounded hover:opacity-90 active:opacity-80 transition-opacity touch-manipulation shadow-sm whitespace-nowrap"
 							style="background-color: #4F46E5; color: #ffffff;"
 						>
-							Install
+							{{  __('Install') }}
 						</button>
 						<button
 							@click="handleDismiss"
 							class="p-1.5 hover:bg-gray-100 rounded transition-colors touch-manipulation flex-shrink-0"
 							style="color: #6B7280;"
-							aria-label="Close"
-							title="Close (shows again next session)"
+							:aria-label="__('Close')"
+							:title="__('Close (shows again next session)')"
 						>
 							<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>

--- a/POS/src/components/common/LoadingSpinner.vue
+++ b/POS/src/components/common/LoadingSpinner.vue
@@ -11,7 +11,7 @@
 defineProps({
 	text: {
 		type: String,
-		default: "Loading...",
+		default: __("Loading..."),
 	},
 })
 </script>

--- a/POS/src/components/common/TranslatedHTML.vue
+++ b/POS/src/components/common/TranslatedHTML.vue
@@ -1,0 +1,28 @@
+<template>
+    <component :is="tag" :="$attrs" ref="containerRef">
+    </component>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import DOMPurify from 'dompurify'
+
+const props = defineProps({
+    tag: {
+        type: String,
+        required: false,
+        default: 'span'
+    },
+    inner: {
+        type: String,
+        required: true
+    }
+})
+
+const containerRef = ref(null)
+
+onMounted(() => {
+    const sanitized = DOMPurify.sanitize(props.inner)
+    containerRef.value.innerHTML = sanitized
+})
+</script>

--- a/POS/src/components/common/UserMenu.vue
+++ b/POS/src/components/common/UserMenu.vue
@@ -67,7 +67,7 @@
 				<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
 				</svg>
-				<span>Logout</span>
+				<span>{{ __('Logout') }}</span>
 			</button>
 		</div>
 	</div>

--- a/POS/src/components/invoices/InvoiceDetailDialog.vue
+++ b/POS/src/components/invoices/InvoiceDetailDialog.vue
@@ -6,7 +6,7 @@
 		<template #body-content>
 			<div v-if="loading" class="text-center py-12">
 				<div class="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-500 mx-auto"></div>
-				<p class="mt-3 text-sm text-gray-500">Loading invoice details...</p>
+				<p class="mt-3 text-sm text-gray-500">{{ __('Loading invoice details...') }}</p>
 			</div>
 
 			<div v-else-if="invoiceData" class="space-y-6">
@@ -20,7 +20,7 @@
 									v-if="invoiceData.is_return"
 									class="px-3 py-1 text-xs font-semibold rounded-full bg-red-100 text-red-800"
 								>
-									Return Invoice
+									{{ __('Return Invoice') }}
 								</span>
 								<span
 									v-else
@@ -34,21 +34,21 @@
 							</div>
 							<div class="grid grid-cols-2 gap-3 text-sm">
 								<div>
-									<span class="text-gray-600">Customer:</span>
+									<span class="text-gray-600">{{ __('Customer:') }}</span>
 									<span class="ml-2 font-semibold text-gray-900">{{ invoiceData.customer_name || invoiceData.customer }}</span>
 								</div>
 								<div>
-									<span class="text-gray-600">Date:</span>
+									<span class="text-gray-600">{{ __('Date:') }}</span>
 									<span class="ml-2 font-medium text-gray-900">{{ formatDate(invoiceData.posting_date) }} {{ formatTime(invoiceData.posting_time) }}</span>
 								</div>
 								<div v-if="invoiceData.return_against">
-									<span class="text-gray-600">Return Against:</span>
+									<span class="text-gray-600">{{ __('Return Against:') }}</span>
 									<span class="ml-2 font-medium text-gray-900">{{ invoiceData.return_against }}</span>
 								</div>
 							</div>
 						</div>
 						<div class="text-right ml-4">
-							<div class="text-xs text-gray-500 mb-1">Grand Total</div>
+							<div class="text-xs text-gray-500 mb-1">{{ __('Grand Total') }}</div>
 							<div class="text-2xl font-bold text-indigo-600">
 								{{ formatCurrency(invoiceData.grand_total) }}
 							</div>
@@ -62,17 +62,17 @@
 						<svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
 						</svg>
-						Items
+						{{ __('Items') }}
 					</h4>
 					<div class="border border-gray-200 rounded-lg overflow-hidden">
 						<table class="min-w-full divide-y divide-gray-200">
 							<thead class="bg-gray-50">
 								<tr>
-									<th class="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Item</th>
-									<th class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">Qty</th>
-									<th class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">Rate</th>
-									<th class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">Discount</th>
-									<th class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">Amount</th>
+									<th class="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">{{ __('Item') }}</th>
+									<th class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">{{ __('Qty') }}</th>
+									<th class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">{{ __('Rate') }}</th>
+									<th class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">{{ __('Discount') }}</th>
+									<th class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">{{ __('Amount') }}</th>
 								</tr>
 							</thead>
 							<tbody class="bg-white divide-y divide-gray-200">
@@ -101,7 +101,7 @@
 							<svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/>
 							</svg>
-							Payments
+							{{ __('Payments') }}
 						</h4>
 						<div class="space-y-2">
 							<div
@@ -120,30 +120,30 @@
 
 					<!-- Summary -->
 					<div>
-						<h4 class="text-sm font-semibold text-gray-700 mb-3">Summary</h4>
+						<h4 class="text-sm font-semibold text-gray-700 mb-3">{{ __('Summary') }}</h4>
 						<div class="space-y-2 bg-gray-50 p-4 rounded-lg border border-gray-200">
 							<div class="flex justify-between text-sm">
-								<span class="text-gray-600">Net Total:</span>
+								<span class="text-gray-600">{{ __('Net Total:') }}</span>
 								<span class="font-medium text-gray-900">{{ formatCurrency(invoiceData.net_total || invoiceData.total) }}</span>
 							</div>
 							<div v-if="invoiceData.total_taxes_and_charges" class="flex justify-between text-sm">
-								<span class="text-gray-600">Taxes:</span>
+								<span class="text-gray-600">{{ __('Taxes:') }}</span>
 								<span class="font-medium text-gray-900">{{ formatCurrency(invoiceData.total_taxes_and_charges) }}</span>
 							</div>
 							<div v-if="invoiceData.discount_amount" class="flex justify-between text-sm">
-								<span class="text-gray-600">Discount:</span>
+								<span class="text-gray-600">{{ __('Discount:') }}</span>
 								<span class="font-medium text-red-600">-{{ formatCurrency(invoiceData.discount_amount) }}</span>
 							</div>
 							<div class="pt-2 border-t border-gray-300 flex justify-between">
-								<span class="font-semibold text-gray-900">Grand Total:</span>
+								<span class="font-semibold text-gray-900">{{ __('Grand Total:') }}</span>
 								<span class="font-bold text-lg text-indigo-600">{{ formatCurrency(invoiceData.grand_total) }}</span>
 							</div>
 							<div v-if="invoiceData.paid_amount" class="flex justify-between text-sm">
-								<span class="text-gray-600">Paid Amount:</span>
+								<span class="text-gray-600">{{ __('Paid Amount:') }}</span>
 								<span class="font-semibold text-green-600">{{ formatCurrency(invoiceData.paid_amount) }}</span>
 							</div>
 							<div v-if="invoiceData.outstanding_amount" class="flex justify-between text-sm">
-								<span class="text-gray-600">Outstanding:</span>
+								<span class="text-gray-600">{{ __('Outstanding:') }}</span>
 								<span class="font-semibold text-orange-600">{{ formatCurrency(invoiceData.outstanding_amount) }}</span>
 							</div>
 						</div>
@@ -152,7 +152,7 @@
 
 				<!-- Additional Info -->
 				<div v-if="invoiceData.remarks" class="bg-gray-50 p-4 rounded-lg border border-gray-200">
-					<h4 class="text-sm font-semibold text-gray-700 mb-2">Remarks</h4>
+					<h4 class="text-sm font-semibold text-gray-700 mb-2">{{ __('Remarks') }}</h4>
 					<p class="text-sm text-gray-600">{{ invoiceData.remarks }}</p>
 				</div>
 			</div>
@@ -161,13 +161,13 @@
 				<svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
 				</svg>
-				<p class="mt-2 text-sm text-gray-500">Failed to load invoice details</p>
+				<p class="mt-2 text-sm text-gray-500">{{ __('Failed to load invoice details') }}</p>
 			</div>
 		</template>
 		<template #actions>
 			<div class="flex justify-between items-center w-full">
 				<Button variant="subtle" @click="show = false">
-					Close
+					{{ __('Close') }}
 				</Button>
 				<Button @click="handlePrint">
 					<template #prefix>
@@ -175,7 +175,7 @@
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
 						</svg>
 					</template>
-					Print
+					{{ __('Print') }}
 				</Button>
 			</div>
 		</template>

--- a/POS/src/components/invoices/InvoiceFilters.vue
+++ b/POS/src/components/invoices/InvoiceFilters.vue
@@ -10,7 +10,7 @@
 					v-model="store.searchTerm"
 					type="text"
 					class="search-input"
-					placeholder="Search invoices..."
+					:placeholder="__('Search invoices...')"
 				/>
 				<button
 					v-if="store.searchTerm"
@@ -68,7 +68,7 @@
 					<svg class="chip-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>
 					</svg>
-					More
+					{{ __('More') }}
 					<span v-if="hasAdvancedFilters" class="count-badge">{{ advancedFiltersCount }}</span>
 				</button>
 			</div>
@@ -78,9 +78,11 @@
 		<Transition name="fade">
 			<div v-if="store.hasActiveFilters" class="active-summary">
 				<div class="summary-content">
-					<span class="summary-text">
-						<strong>{{ filterStats?.filtered || 0 }}</strong> of <strong>{{ filterStats?.total || 0 }}</strong> invoices
-					</span>
+					<TranslatedHTML 
+						class="summary-text"
+						:inner="__('&lt;strong&gt;{0}&lt;/strong&gt; of &lt;strong&gt;{1}&lt;/strong&gt; invoice(s)', 
+							[(filterStats?.filtered || 0), (filterStats?.total || 0)]) "
+					/>
 					<div class="active-pills">
 						<button
 							v-for="filter in store.filterSummary"
@@ -96,7 +98,7 @@
 					</div>
 				</div>
 				<button @click="store.clearAllFilters()" class="clear-all">
-					Clear all
+					{{ __('Clear all') }}
 				</button>
 			</div>
 		</Transition>
@@ -111,12 +113,12 @@
 							<svg class="label-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
 							</svg>
-							Customer
+							{{ __('Customer') }}
 						</label>
 						<AutocompleteSelect
 							v-model="store.customer"
 							:options="props.uniqueCustomers"
-							placeholder="Search customers..."
+							:placeholder="__('Search customers...')"
 							icon="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
 						/>
 					</div>
@@ -126,12 +128,12 @@
 							<svg class="label-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
 							</svg>
-							Product
+							{{ __('Product') }}
 						</label>
 						<AutocompleteSelect
 							v-model="store.product"
 							:options="props.uniqueProducts"
-							placeholder="Search products..."
+							:placeholder="__('Search products...')"
 							icon="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
 						/>
 					</div>
@@ -144,7 +146,7 @@
 							<svg class="label-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
 							</svg>
-							From Date
+							{{ __('From Date') }}
 						</label>
 						<input
 							v-model="store.dateFrom"
@@ -158,7 +160,7 @@
 							<svg class="label-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
 							</svg>
-							To Date
+							{{ __('To Date') }}
 						</label>
 						<input
 							v-model="store.dateTo"
@@ -174,20 +176,20 @@
 						v-model="saveFilterName"
 						type="text"
 						class="save-input"
-						placeholder="Save these filters as..."
+						:placeholder="__('Save these filters as...')"
 						@keyup.enter="saveFilters"
 					/>
 					<button @click="saveFilters" :disabled="!saveFilterName" class="save-btn">
 						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
 						</svg>
-						Save
+						{{ __('Save') }}
 					</button>
 				</div>
 
 				<!-- Saved Filters -->
 				<div v-if="store.savedFilters.length > 0" class="saved-filters">
-					<div class="saved-header">Saved Filters</div>
+					<div class="saved-header">{{ __('Saved Filters') }}</div>
 					<div class="saved-list">
 						<button
 							v-for="preset in store.savedFilters"
@@ -219,6 +221,7 @@
 import AutocompleteSelect from "@/components/common/AutocompleteSelect.vue"
 import { useInvoiceFiltersStore } from "@/stores/invoiceFilters"
 import { computed, ref } from "vue"
+import TranslatedHTML from "../common/TranslatedHTML.vue"
 
 const props = defineProps({
 	uniqueCustomers: {
@@ -241,22 +244,22 @@ const saveFilterName = ref("")
 
 // Quick date presets (simplified)
 const quickDates = [
-	{ label: "Today", value: "today", action: () => store.setToday() },
+	{ label: __("Today"), value: "today", action: () => store.setToday() },
 	{
-		label: "Yesterday",
+		label: __("Yesterday"),
 		value: "yesterday",
 		action: () => store.setYesterday(),
 	},
-	{ label: "This Week", value: "week", action: () => store.setThisWeek() },
-	{ label: "This Month", value: "month", action: () => store.setThisMonth() },
+	{ label: __("This Week"), value: "week", action: () => store.setThisWeek() },
+	{ label: __("This Month"), value: "month", action: () => store.setThisMonth() },
 ]
 
 // Status options (only show meaningful ones)
 const statusOptions = [
-	{ label: "Paid", value: "Paid" },
-	{ label: "Unpaid", value: "Unpaid" },
-	{ label: "Partial", value: "Partly Paid" },
-	{ label: "Overdue", value: "Overdue" },
+	{ label: __("Paid"), value: "Paid" },
+	{ label: __("Unpaid"), value: "Unpaid" },
+	{ label: __("Partial"), value: "Partly Paid" },
+	{ label: __("Overdue"), value: "Overdue" },
 ]
 
 // Advanced filters (customer, product, custom date)
@@ -334,7 +337,7 @@ function loadSavedFilter(name) {
 }
 
 function deleteSavedFilter(name) {
-	if (confirm(`Delete "${name}"?`)) {
+	if (confirm(__('Delete "{0}"?', [name]))) {
 		store.deleteFilterPreset(name)
 	}
 }

--- a/POS/src/components/invoices/InvoiceManagement.vue
+++ b/POS/src/components/invoices/InvoiceManagement.vue
@@ -18,9 +18,9 @@
 								</svg>
 							</div>
 							<div>
-								<h2 class="text-xl font-bold text-gray-900">Invoice Management</h2>
+								<h2 class="text-xl font-bold text-gray-900">{{ __('Invoice Management') }}</h2>
 								<p class="text-sm text-gray-600 flex items-center mt-0.5">
-									Manage all your invoices in one place
+									{{ __('Manage all your invoices in one place') }}
 								</p>
 							</div>
 						</div>
@@ -36,7 +36,7 @@
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
 									</svg>
 								</template>
-								Refresh
+								{{ __('Refresh') }}
 							</Button>
 							<button
 								@click="handleClose"
@@ -51,7 +51,7 @@
 
 					<!-- Tabs Navigation -->
 					<div class="border-b border-gray-200 bg-gray-50">
-						<nav class="flex space-x-2 px-6" aria-label="Tabs">
+						<nav class="flex space-x-2 px-6" :aria-label="__('Tabs')">
 							<button
 								v-for="tab in tabs"
 								:key="tab.id"
@@ -87,7 +87,7 @@
 						<!-- Loading State -->
 						<div v-if="loading && activeTab === 'partial'" class="flex flex-col items-center justify-center py-16">
 							<div class="animate-spin rounded-full h-12 w-12 border-b-3 border-indigo-500 mb-4"></div>
-							<p class="text-sm font-medium text-gray-600">Loading {{ currentTabLabel }}...</p>
+							<p class="text-sm font-medium text-gray-600">{{ __('Loading {0}...', [currentTabLabel]) }}</p>
 						</div>
 
 						<!-- Tab Content -->
@@ -105,7 +105,7 @@
 												: 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
 										]"
 									>
-										All ({{ unpaidInvoices.length }})
+										{{ __('All ({0})', [unpaidInvoices.length]) }}
 									</button>
 									<button
 										@click="unpaidFilter = 'partial'"
@@ -116,7 +116,7 @@
 												: 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
 										]"
 									>
-										Partially Paid ({{ unpaidInvoices.filter(inv => inv.status === 'Partly Paid').length }})
+										{{ __('Partially Paid ({0})', [unpaidInvoices.filter(inv => inv.status === 'Partly Paid').length]) }}
 									</button>
 									<button
 										@click="unpaidFilter = 'unpaid'"
@@ -127,7 +127,7 @@
 												: 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
 										]"
 									>
-										Unpaid ({{ unpaidInvoices.filter(inv => inv.status === 'Unpaid').length }})
+										{{ __('Unpaid ({0})', [unpaidInvoices.filter(inv => inv.status === 'Unpaid').length]) }}
 									</button>
 									<button
 										@click="unpaidFilter = 'overdue'"
@@ -138,7 +138,7 @@
 												: 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
 										]"
 									>
-										Overdue ({{ unpaidInvoices.filter(inv => inv.status === 'Overdue').length }})
+										{{ __('Overdue ({0})', [unpaidInvoices.filter(inv => inv.status === 'Overdue').length]) }}
 									</button>
 								</div>
 
@@ -146,12 +146,12 @@
 								<div v-if="filteredUnpaidSummary.count > 0" class="bg-gradient-to-r from-orange-50 to-amber-50 border border-orange-200 rounded-lg p-4">
 									<div class="flex items-center justify-between">
 										<div>
-											<div class="text-sm text-orange-600 font-medium">Outstanding Payments</div>
+											<div class="text-sm text-orange-600 font-medium">{{ __('Outstanding Payments') }}</div>
 											<div class="text-2xl font-bold text-gray-900 mt-1">{{ formatCurrency(filteredUnpaidSummary.total_outstanding) }}</div>
 										</div>
 										<div class="text-right">
 											<div class="text-xs text-gray-600">{{ filteredUnpaidSummary.count }} invoices</div>
-											<div class="text-sm text-gray-800 font-semibold mt-1">{{ formatCurrency(filteredUnpaidSummary.total_paid) }} paid</div>
+											<div class="text-sm text-gray-800 font-semibold mt-1">{{ __('{0} paid', [formatCurrency(filteredUnpaidSummary.total_paid)]) }}</div>
 										</div>
 									</div>
 								</div>
@@ -161,8 +161,8 @@
 									<svg class="w-16 h-16 text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
 									</svg>
-									<p class="text-gray-600 font-medium">No Unpaid Invoices</p>
-									<p class="text-gray-500 text-sm mt-1">All invoices are fully paid</p>
+									<p class="text-gray-600 font-medium">{{ __('No Unpaid Invoices') }}</p>
+									<p class="text-gray-500 text-sm mt-1">{{ __('All invoices are fully paid') }}</p>
 								</div>
 
 								<!-- Invoices List -->
@@ -206,7 +206,7 @@
 													@click="selectInvoiceForPayment(invoice)"
 													class="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors text-sm font-semibold"
 												>
-													Add Payment
+													{{ __('Add Payment') }}
 												</button>
 											</div>
 										</div>
@@ -215,15 +215,15 @@
 										<div class="p-4">
 											<div class="grid grid-cols-3 gap-4 mb-4">
 												<div class="text-center p-3 bg-blue-50 rounded-lg border border-blue-100">
-													<div class="text-xs text-gray-600 mb-1">Total Amount</div>
+													<div class="text-xs text-gray-600 mb-1">{{ __('Total Amount') }}</div>
 													<div class="text-lg font-bold text-gray-900">{{ formatCurrency(invoice.grand_total) }}</div>
 												</div>
 												<div class="text-center p-3 bg-green-50 rounded-lg border border-green-100">
-													<div class="text-xs text-gray-600 mb-1">Paid</div>
+													<div class="text-xs text-gray-600 mb-1">{{ __('Paid') }}</div>
 													<div class="text-lg font-bold text-green-600">{{ formatCurrency(invoice.paid_amount) }}</div>
 												</div>
 												<div class="text-center p-3 bg-orange-50 rounded-lg border border-orange-100">
-													<div class="text-xs text-gray-600 mb-1">Outstanding</div>
+													<div class="text-xs text-gray-600 mb-1">{{ __('Outstanding') }}</div>
 													<div class="text-lg font-bold text-orange-600">{{ formatCurrency(invoice.outstanding_amount) }}</div>
 												</div>
 											</div>
@@ -238,7 +238,7 @@
 
 											<!-- Payment Methods -->
 											<div v-if="invoice.payments && invoice.payments.length > 0" class="mt-3">
-												<div class="text-xs font-medium text-gray-600 mb-2">Payment History</div>
+												<div class="text-xs font-medium text-gray-600 mb-2">{{ __('Payment History') }}</div>
 												<div class="grid grid-cols-2 md:grid-cols-3 gap-2">
 													<div
 														v-for="(payment, idx) in invoice.payments"
@@ -251,7 +251,7 @@
 														]"
 													>
 														<div class="flex items-center justify-between mb-1">
-															<span class="text-gray-700 font-medium">{{ payment.mode_of_payment || 'N/A' }}</span>
+															<span class="text-gray-700 font-medium">{{ payment.mode_of_payment || __('N/A') }}</span>
 															<span class="font-semibold text-gray-900">{{ formatCurrency(payment.amount) }}</span>
 														</div>
 														<div class="flex items-center justify-between">
@@ -294,7 +294,7 @@
 									<svg class="w-16 h-16 text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
 									</svg>
-									<p class="text-gray-600 font-medium">No invoices found</p>
+									<p class="text-gray-600 font-medium">{{ __('No invoices found') }}</p>
 								</div>
 
 								<!-- Invoices Grid - 2 columns on large screens -->
@@ -321,7 +321,7 @@
 													</div>
 												</div>
 												<div class="text-right ml-3">
-													<div class="text-xs text-gray-500 mb-1">Total</div>
+													<div class="text-xs text-gray-500 mb-1">{{ __('Total') }}</div>
 													<div class="text-lg font-bold text-indigo-600">
 														{{ formatCurrency(invoice.grand_total) }}
 													</div>
@@ -337,7 +337,7 @@
 													<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
 												</svg>
 												<div class="flex-1">
-													<div class="text-xs text-gray-500">Customer</div>
+													<div class="text-xs text-gray-500">{{ __('Customer') }}</div>
 													<div class="text-sm font-semibold text-gray-900">{{ invoice.customer_name || invoice.customer }}</div>
 												</div>
 											</div>
@@ -348,7 +348,7 @@
 													<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
 												</svg>
 												<div class="flex-1">
-													<div class="text-xs text-gray-500">Date & Time</div>
+													<div class="text-xs text-gray-500">{{ __('Date & Time') }}</div>
 													<div class="text-sm font-medium text-gray-900">{{ formatDate(invoice.posting_date) }} {{ formatTime(invoice.posting_time) }}</div>
 												</div>
 											</div>
@@ -356,11 +356,11 @@
 											<!-- Payment Details -->
 											<div class="grid grid-cols-2 gap-3 pt-2 border-t border-gray-100">
 												<div>
-													<div class="text-xs text-gray-500 mb-1">Paid Amount</div>
+													<div class="text-xs text-gray-500 mb-1">{{ __('Paid Amount') }}</div>
 													<div class="text-sm font-semibold text-green-600">{{ formatCurrency(invoice.paid_amount || 0) }}</div>
 												</div>
 												<div>
-													<div class="text-xs text-gray-500 mb-1">Outstanding</div>
+													<div class="text-xs text-gray-500 mb-1">{{ __('Outstanding') }}</div>
 													<div class="text-sm font-semibold text-orange-600">{{ formatCurrency(invoice.outstanding_amount || 0) }}</div>
 												</div>
 											</div>
@@ -371,23 +371,23 @@
 											<button
 												@click="$emit('view-invoice', invoice)"
 												class="px-3 py-2 text-xs font-semibold text-blue-600 bg-blue-50 hover:bg-blue-100 rounded-lg transition-colors flex items-center space-x-1"
-												title="View Details"
+												:title="__('View Details')"
 											>
 												<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 													<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
 													<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
 												</svg>
-												<span>View</span>
+												<span>{{ __('View') }}</span>
 											</button>
 											<button
 												@click="$emit('print-invoice', invoice)"
 												class="px-3 py-2 text-xs font-semibold text-green-600 bg-green-50 hover:bg-green-100 rounded-lg transition-colors flex items-center space-x-1"
-												title="Print"
+												:title="__('Print')"
 											>
 												<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 													<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
 												</svg>
-												<span>Print</span>
+												<span>{{ __('Print') }}</span>
 											</button>
 										</div>
 									</div>
@@ -401,8 +401,8 @@
 									<svg class="w-16 h-16 text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
 									</svg>
-									<p class="text-gray-600 font-medium">No draft invoices</p>
-									<p class="text-gray-500 text-sm mt-1">Save invoices as drafts to continue later</p>
+									<p class="text-gray-600 font-medium">{{ __('No draft invoices') }}</p>
+									<p class="text-gray-500 text-sm mt-1">{{ __('Save invoices as drafts to continue later') }}</p>
 								</div>
 
 								<!-- Drafts Grid -->
@@ -417,14 +417,14 @@
 											<div class="flex-1">
 												<h4 class="text-sm font-semibold text-gray-900">{{ draft.draft_id }}</h4>
 												<p v-if="draft.customer" class="text-xs text-gray-500 mt-0.5">
-													Customer: {{ draft.customer?.customer_name || draft.customer?.name || draft.customer }}
+													{{ __('Customer: {0}', [(draft.customer?.customer_name || draft.customer?.name || draft.customer)]) }}
 												</p>
 												<p class="text-xs text-gray-400 mt-0.5">{{ formatDateTime(draft.created_at) }}</p>
 											</div>
 											<button
 												@click.stop="$emit('delete-draft', draft.draft_id)"
 												class="text-gray-400 hover:text-red-600 transition-colors p-1"
-												title="Delete draft"
+												:title="__('Delete draft')"
 											>
 												<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 													<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
@@ -433,7 +433,7 @@
 										</div>
 
 										<div class="flex items-center justify-between text-xs">
-											<span class="text-gray-600">{{ draft.items?.length || 0 }} item(s)</span>
+											<span class="text-gray-600">{{ __('{0} item(s)', [draft.items?.length || 0]) }}</span>
 											<span class="font-bold text-purple-600">{{ formatCurrency(calculateDraftTotal(draft.items)) }}</span>
 										</div>
 
@@ -448,7 +448,7 @@
 													{{ item.item_name }} ({{ item.quantity || item.qty }})
 												</span>
 												<span v-if="draft.items.length > 3" class="text-[10px] text-gray-500 px-1.5 py-0.5">
-													+{{ draft.items.length - 3 }} more
+													{{ __('+{0} more', [draft.items.length - 3]) }}
 												</span>
 											</div>
 										</div>
@@ -463,8 +463,8 @@
 									<svg class="w-16 h-16 text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/>
 									</svg>
-									<p class="text-gray-600 font-medium">No return invoices</p>
-									<p class="text-gray-500 text-sm mt-1">Return invoices will appear here</p>
+									<p class="text-gray-600 font-medium">{{ __('No return invoices') }}</p>
+									<p class="text-gray-500 text-sm mt-1">{{ __('Return invoices will appear here') }}</p>
 								</div>
 
 								<!-- Returns Grid -->
@@ -479,13 +479,13 @@
 												<div class="flex items-center space-x-2 mb-1">
 													<h4 class="text-sm font-semibold text-gray-900">{{ invoice.name }}</h4>
 													<span class="text-xs px-2 py-0.5 rounded-full font-medium bg-red-100 text-red-800">
-														Return
+														{{ __('Return') }}
 													</span>
 												</div>
 												<div class="flex items-center space-x-4 text-xs text-gray-600">
 													<span>{{ invoice.customer_name }}</span>
 													<span>{{ formatDate(invoice.posting_date) }}</span>
-													<span v-if="invoice.return_against">Against: {{ invoice.return_against }}</span>
+													<span v-if="invoice.return_against">{{ __('Against: {0}', [invoice.return_against]) }}</span>
 												</div>
 											</div>
 
@@ -497,7 +497,7 @@
 													<button
 														@click="$emit('view-invoice', invoice)"
 														class="p-1.5 hover:bg-blue-50 rounded transition-colors"
-														title="View Details"
+														:title="__('View Details')"
 													>
 														<svg class="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 															<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
@@ -507,7 +507,7 @@
 													<button
 														@click="$emit('print-invoice', invoice)"
 														class="p-1.5 hover:bg-green-50 rounded transition-colors"
-														title="Print"
+														:title="__('Print')"
 													>
 														<svg class="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 															<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
@@ -659,7 +659,7 @@ const filteredHistoryInvoices = computed(() => {
 const tabs = computed(() => [
 	{
 		id: "partial",
-		label: "Unpaid",
+		label: __("Unpaid"),
 		icon: "M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z",
 		color: "orange",
 		activeClass: "text-orange-600",
@@ -667,7 +667,7 @@ const tabs = computed(() => [
 	},
 	{
 		id: "history",
-		label: "Invoice History",
+		label: __("Invoice History"),
 		icon: "M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z",
 		color: "indigo",
 		activeClass: "text-indigo-600",
@@ -675,7 +675,7 @@ const tabs = computed(() => [
 	},
 	{
 		id: "drafts",
-		label: "Drafts",
+		label: __("Drafts"),
 		icon: "M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z",
 		color: "purple",
 		activeClass: "text-purple-600",
@@ -683,7 +683,7 @@ const tabs = computed(() => [
 	},
 	{
 		id: "returns",
-		label: "Returns",
+		label: __("Returns"),
 		icon: "M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6",
 		color: "red",
 		activeClass: "text-red-600",
@@ -812,7 +812,7 @@ async function loadUnpaidInvoices() {
 		unpaidInvoices.value = result || []
 	} catch (error) {
 		console.error("Error loading unpaid invoices:", error)
-		showError(error.message || "Failed to load unpaid invoices")
+		showError(error.message || __("Failed to load unpaid invoices"))
 	} finally {
 		loading.value = false
 	}
@@ -853,7 +853,7 @@ async function handlePaymentCompleted(paymentData) {
 			payments: paymentData.payments,
 		})
 
-		showSuccess("Payment added successfully")
+		showSuccess(__("Payment added successfully"))
 
 		// Reload invoices and summary for partial tab
 		await loadUnpaidInvoices()
@@ -865,7 +865,7 @@ async function handlePaymentCompleted(paymentData) {
 		selectedInvoice.value = null
 	} catch (error) {
 		console.error("Error adding payment:", error)
-		showError(error.message || "Failed to add payment")
+		showError(error.message || __("Failed to add payment"))
 	}
 }
 

--- a/POS/src/components/partials/PartialPayments.vue
+++ b/POS/src/components/partials/PartialPayments.vue
@@ -18,9 +18,9 @@
 								</svg>
 							</div>
 							<div>
-								<h2 class="text-xl font-bold text-gray-900">Partial Payments</h2>
+								<h2 class="text-xl font-bold text-gray-900">{{ __('Partial Payments') }}</h2>
 								<p class="text-sm text-gray-600 flex items-center mt-0.5">
-									Manage invoices with pending payments
+									{{ __('Manage invoices with pending payments') }}
 								</p>
 							</div>
 						</div>
@@ -28,7 +28,9 @@
 							<!-- Summary Badge -->
 							<div v-if="summary.count > 0" class="px-4 py-2 bg-orange-100 rounded-lg border border-orange-200">
 								<div class="text-xs text-orange-600 font-medium">
-									{{ summary.count }} invoice{{ summary.count !== 1 ? 's' : '' }} - {{ formatCurrency(summary.total_outstanding) }} outstanding
+									{{ summary.count === 1 
+									? __('{0} invoice - {1} outstanding', [summary.count, formatCurrency(summary.total_outstanding)])
+									: __('{0} invoices - {1} outstanding', [summary.count, formatCurrency(summary.total_outstanding)]) }}
 								</div>
 							</div>
 							<Button
@@ -42,7 +44,7 @@
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
 									</svg>
 								</template>
-								Refresh
+								{{ __('Refresh') }}
 							</Button>
 							<button
 								@click="handleClose"
@@ -60,7 +62,7 @@
 						<!-- Loading State -->
 						<div v-if="loading" class="flex flex-col items-center justify-center py-16">
 							<div class="animate-spin rounded-full h-12 w-12 border-b-3 border-orange-500 mb-4"></div>
-							<p class="text-sm font-medium text-gray-600">Loading invoices...</p>
+							<p class="text-sm font-medium text-gray-600">{{ __('Loading invoices...') }}</p>
 						</div>
 
 						<!-- Empty State -->
@@ -68,8 +70,8 @@
 							<svg class="w-16 h-16 text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
 							</svg>
-							<p class="text-gray-600 font-medium">No Partial Payments</p>
-							<p class="text-gray-500 text-sm mt-1">All invoices are either fully paid or unpaid</p>
+							<p class="text-gray-600 font-medium">{{ __('No Partial Payments') }}</p>
+							<p class="text-gray-500 text-sm mt-1">{{ __('All invoices are either fully paid or unpaid') }}</p>
 						</div>
 
 						<!-- Invoices List -->
@@ -113,7 +115,7 @@
 											@click="selectInvoice(invoice)"
 											class="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors text-sm font-semibold"
 										>
-											Add Payment
+											{{ __('Add Payment') }}
 										</button>
 									</div>
 								</div>
@@ -122,15 +124,15 @@
 								<div class="p-4">
 									<div class="grid grid-cols-3 gap-4 mb-4">
 										<div class="text-center p-3 bg-blue-50 rounded-lg border border-blue-100">
-											<div class="text-xs text-gray-600 mb-1">Total Amount</div>
+											<div class="text-xs text-gray-600 mb-1">{{ __('Total Amount') }}</div>
 											<div class="text-lg font-bold text-gray-900">{{ formatCurrency(invoice.grand_total) }}</div>
 										</div>
 										<div class="text-center p-3 bg-green-50 rounded-lg border border-green-100">
-											<div class="text-xs text-gray-600 mb-1">Paid</div>
+											<div class="text-xs text-gray-600 mb-1">{{ __('Paid') }}</div>
 											<div class="text-lg font-bold text-green-600">{{ formatCurrency(invoice.paid_amount) }}</div>
 										</div>
 										<div class="text-center p-3 bg-orange-50 rounded-lg border border-orange-100">
-											<div class="text-xs text-gray-600 mb-1">Outstanding</div>
+											<div class="text-xs text-gray-600 mb-1">{{ __('Outstanding') }}</div>
 											<div class="text-lg font-bold text-orange-600">{{ formatCurrency(invoice.outstanding_amount) }}</div>
 										</div>
 									</div>
@@ -145,7 +147,7 @@
 
 									<!-- Payment Methods -->
 									<div v-if="invoice.payments && invoice.payments.length > 0" class="mt-3">
-										<div class="text-xs font-medium text-gray-600 mb-2">Payment History</div>
+										<div class="text-xs font-medium text-gray-600 mb-2">{{ __('Payment History') }}</div>
 										<div class="grid grid-cols-2 md:grid-cols-3 gap-2">
 											<div
 												v-for="(payment, idx) in invoice.payments"
@@ -274,7 +276,7 @@ async function loadInvoices() {
 		invoices.value = result || []
 	} catch (error) {
 		console.error("Error loading partial payments:", error)
-		showError(error.message || "Failed to load partial payments")
+		showError(error.message || __("Failed to load partial payments"))
 	} finally {
 		loading.value = false
 	}
@@ -324,7 +326,7 @@ async function handlePaymentCompleted(paymentData) {
 
 		console.log('[PartialPayments] API response:', result)
 
-		showSuccess("Payment added successfully")
+		showSuccess(__("Payment added successfully"))
 
 		// Reload invoices and summary
 		console.log('[PartialPayments] Reloading invoices and summary...')
@@ -334,7 +336,7 @@ async function handlePaymentCompleted(paymentData) {
 		selectedInvoice.value = null
 	} catch (error) {
 		console.error("[PartialPayments] Error adding payment:", error)
-		showError(error.message || "Failed to add payment")
+		showError(error.message || __("Failed to add payment"))
 	}
 }
 
@@ -360,19 +362,19 @@ function getStatusLabel(status) {
 	// Convert ERPNext status to user-friendly labels
 	switch (status) {
 		case 'Partly Paid':
-			return 'Partially Paid'
+			return __('Partially Paid')
 		case 'Overdue':
-			return 'Overdue'
+			return __('Overdue')
 		case 'Unpaid':
-			return 'Unpaid'
+			return __('Unpaid')
 		case 'Paid':
-			return 'Paid'
+			return __('Paid')
 		case 'Draft':
-			return 'Draft'
+			return __('Draft')
 		case 'Cancelled':
-			return 'Cancelled'
+			return __('Cancelled')
 		case 'Return':
-			return 'Return'
+			return __('Return')
 		default:
 			return status
 	}

--- a/POS/src/components/pos/ManagementSlider.vue
+++ b/POS/src/components/pos/ManagementSlider.vue
@@ -10,11 +10,11 @@
 					? 'bg-blue-100 text-blue-600'
 					: 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
 			]"
-			:title="'Dashboard'"
+			:title="__('Dashboard')"
 		>
 			<FeatherIcon name="layout" class="w-5 h-5" />
 			<div class="absolute left-full ml-2 px-2 py-1 bg-gray-900 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
-				Dashboard
+				{{ __('Dashboard') }}
 			</div>
 		</button>
 
@@ -27,11 +27,11 @@
 					? 'bg-green-100 text-green-600'
 					: 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
 			]"
-			:title="'Promotions'"
+			:title="__('Promotions')"
 		>
 			<FeatherIcon name="tag" class="w-5 h-5" />
 			<div class="absolute left-full ml-2 px-2 py-1 bg-gray-900 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
-				Promotions
+				{{ __('Promotions') }}
 			</div>
 		</button>
 
@@ -44,11 +44,11 @@
 					? 'bg-purple-100 text-purple-600'
 					: 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
 			]"
-			:title="'Products'"
+			:title="__('Products')"
 		>
 			<FeatherIcon name="package" class="w-5 h-5" />
 			<div class="absolute left-full ml-2 px-2 py-1 bg-gray-900 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
-				Products
+				{{ __('Products') }}
 			</div>
 		</button>
 
@@ -61,11 +61,11 @@
 					? 'bg-orange-100 text-orange-600'
 					: 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
 			]"
-			:title="'Reports'"
+			:title="__('Reports')"
 		>
 			<FeatherIcon name="bar-chart-2" class="w-5 h-5" />
 			<div class="absolute left-full ml-2 px-2 py-1 bg-gray-900 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
-				Reports
+				{{ __('Reports') }}
 			</div>
 		</button>
 
@@ -78,11 +78,11 @@
 					? 'bg-indigo-100 text-indigo-600'
 					: 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
 			]"
-			:title="'Invoice Management'"
+			:title="__('Invoice Management')"
 		>
 			<FeatherIcon name="file-text" class="w-5 h-5" />
 			<div class="absolute left-full ml-2 px-2 py-1 bg-gray-900 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
-				Invoice Management
+				{{ __('Invoice Management') }}
 			</div>
 		</button>
 
@@ -98,11 +98,11 @@
 					? 'bg-gray-100 text-gray-900'
 					: 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
 			]"
-			:title="'Settings'"
+			:title="__('Settings')"
 		>
 			<FeatherIcon name="settings" class="w-5 h-5" />
 			<div class="absolute left-full ml-2 px-2 py-1 bg-gray-900 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
-				Settings
+				{{ __('Settings') }}
 			</div>
 		</button>
 	</div>

--- a/POS/src/components/pos/POSHeader.vue
+++ b/POS/src/components/pos/POSHeader.vue
@@ -8,7 +8,7 @@
 				<button
 					class="w-10 h-10 bg-gradient-to-br from-blue-500 to-blue-600 rounded-lg flex items-center justify-center shadow-md flex-shrink-0 hover:from-blue-600 hover:to-blue-700 active:scale-95 transition-all"
 					:aria-label="'POS Next'"
-					title="POS Next"
+					:title="__('POS Next')"
 				>
 					<svg class="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
 						<path d="M20 7h-4V4c0-1.1-.9-2-2-2h-4c-1.1 0-2 .9-2 2v3H4c-1.1 0-2 .9-2 2v11c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V9c0-1.1-.9-2-2-2zM10 4h4v3h-4V4zm10 16H4V9h16v11z"/>
@@ -22,7 +22,7 @@
 				<div class="flex items-center space-x-1 sm:space-x-4 min-w-0 flex-1 overflow-hidden">
 					<div class="min-w-0 flex-shrink overflow-hidden">
 						<div class="flex items-center gap-1 sm:gap-2">
-							<h1 class="text-xs sm:text-base font-bold text-gray-900 truncate flex-shrink">POS Next</h1>
+							<h1 class="text-xs sm:text-base font-bold text-gray-900 truncate flex-shrink">{{ __('POS Next') }}</h1>
 							<span class="hidden sm:inline-flex relative items-center px-1 sm:px-2 py-0.5 text-[8px] sm:text-[10px] font-bold bg-gradient-to-r from-blue-500 to-blue-600 text-white rounded-md shadow-sm hover:shadow-md transition-shadow flex-shrink-0">
 								<span class="absolute inset-0 bg-white/20 rounded-md animate-pulse"></span>
 								<span class="relative">v{{ appVersion }}</span>
@@ -47,7 +47,7 @@
 							variant="green"
 							size="xs"
 							:icon="shiftIcon"
-							label="Shift Open:"
+							:label="__('Shift Open:')"
 							:value="shiftDuration"
 						/>
 					</div>
@@ -67,8 +67,8 @@
 							'p-2 sm:p-2 hover:bg-gray-100 active:bg-gray-200 rounded-lg transition-colors relative group touch-manipulation',
 							isSyncing ? 'animate-pulse' : ''
 						]"
-						:title="isOffline ? `Offline (${pendingInvoicesCount} pending)` : 'Online - Click to sync'"
-						:aria-label="isOffline ? 'Offline mode active' : 'Online mode active'"
+						:title="isOffline ? __('Offline ({0} pending)', [pendingInvoicesCount]) : __('Online - Click to sync')"
+						:aria-label="isOffline ? __('Offline mode active') : __('Online mode active')"
 					>
 						<svg
 							v-if="!isOffline"
@@ -138,7 +138,7 @@
 
 								<!-- Header -->
 								<div class="flex items-center justify-between mb-1.5 sm:mb-2 pb-1.5 sm:pb-2 border-b border-gray-700">
-									<span class="font-semibold text-[11px] sm:text-xs">Cache</span>
+									<span class="font-semibold text-[11px] sm:text-xs">{{ __('Cache') }}</span>
 									<span class="px-1.5 sm:px-2 py-0.5 rounded text-[9px] sm:text-[10px] font-bold uppercase" :class="getCacheStatusBadgeClass()">
 										{{ getCacheStatus() }}
 									</span>
@@ -147,28 +147,28 @@
 								<!-- Stats -->
 								<div class="space-y-1 sm:space-y-1.5 text-[10px] sm:text-xs">
 									<div class="flex items-center justify-between">
-										<span class="text-gray-400">Items:</span>
+										<span class="text-gray-400">{{ __('Items:') }}</span>
 										<span class="font-semibold">{{ cacheStats?.items || 0 }}</span>
 									</div>
 									<div v-if="cacheStats?.lastSync" class="flex items-center justify-between">
-										<span class="text-gray-400">Last Sync:</span>
+										<span class="text-gray-400">{{ __('Last Sync:') }}</span>
 										<span class="font-semibold text-[9px] sm:text-[10px]">{{ formatLastSync() }}</span>
 									</div>
 									<div v-if="cacheSyncing" class="flex items-center justify-between">
-										<span class="text-gray-400">Status:</span>
+										<span class="text-gray-400">{{ __('Status:') }}</span>
 										<span class="text-orange-400 font-semibold flex items-center gap-1">
 											<svg class="w-2.5 h-2.5 sm:w-3 sm:h-3 animate-spin" fill="none" viewBox="0 0 24 24">
 												<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
 												<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
 											</svg>
-											Syncing...
+											{{ __('Syncing...') }}
 										</span>
 									</div>
 									<div v-if="stockSyncActive" class="flex items-center justify-between">
-										<span class="text-gray-400">Auto-Sync:</span>
+										<span class="text-gray-400">{{ __('Auto-Sync:') }}</span>
 										<span class="text-green-400 font-semibold flex items-center gap-1">
 											<div class="w-1.5 h-1.5 bg-green-500 rounded-full animate-pulse"></div>
-											Active
+											{{ __('Active') }}
 										</span>
 									</div>
 								</div>
@@ -182,7 +182,7 @@
 										<svg class="w-2.5 h-2.5 sm:w-3 sm:h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
 										</svg>
-										Clear Cache
+										{{ __('Clear Cache') }}
 									</button>
 								</div>
 							</div>
@@ -193,7 +193,7 @@
 					<div class="hidden md:block">
 						<ActionButton
 							:icon="printerIcon"
-							title="Print Invoice"
+							:title="__('Print Invoice')"
 							@click="$emit('printer-click')"
 						/>
 					</div>
@@ -201,13 +201,13 @@
 					<!-- Refresh -->
 					<ActionButton
 						:icon="refreshIcon"
-						:title="isRefreshing ? 'Refreshing...' : 'Refresh Items'"
+						:title="isRefreshing ? __('Refreshing...') : __('Refresh Items')"
 						@click="$emit('refresh-click')"
 						:class="[
 							'touch-manipulation p-1 sm:p-2',
 							isRefreshing ? 'animate-spin' : ''
 						]"
-						:aria-label="isRefreshing ? 'Refreshing items...' : 'Refresh items list'"
+						:aria-label="isRefreshing ? __('Refreshing items...') : __('Refresh items list')"
 					/>
 
 					<div class="w-px h-4 sm:h-6 bg-gray-200 mx-0.5 sm:mx-2"></div>
@@ -341,12 +341,12 @@ function getCacheIconColor() {
 
 function getCacheStatus() {
 	if (!props.cacheStats || props.cacheStats.items === 0) {
-		return "Empty"
+		return __("Empty")
 	}
 	if (props.cacheSyncing) {
-		return "Syncing"
+		return __("Syncing")
 	}
-	return "Ready"
+	return __("Ready")
 }
 
 function getCacheStatusBadgeClass() {
@@ -361,7 +361,7 @@ function getCacheStatusBadgeClass() {
 
 function formatLastSync() {
 	if (!props.cacheStats?.lastSync) {
-		return "Never"
+		return __("Never")
 	}
 	const date = new Date(props.cacheStats.lastSync)
 	return date.toLocaleTimeString("en-US", {
@@ -373,12 +373,12 @@ function formatLastSync() {
 
 function getCacheAriaLabel() {
 	if (!props.cacheStats || props.cacheStats.items === 0) {
-		return "Cache empty"
+		return __("Cache empty")
 	}
 	if (props.cacheSyncing) {
-		return "Cache syncing"
+		return __("Cache syncing")
 	}
-	return "Cache ready"
+	return __("Cache ready")
 }
 
 // SVG Path Icons

--- a/POS/src/components/sale/BatchSerialDialog.vue
+++ b/POS/src/components/sale/BatchSerialDialog.vue
@@ -1,7 +1,7 @@
 <template>
 	<Dialog
 		v-model="show"
-		:options="{ title: `Select ${item?.has_batch_no ? 'Batch' : 'Serial'} Numbers`, size: 'lg' }"
+		:options="{ title: item?.has_batch_no ? __('Select Batch Numbers') : __('Select Serial Numbers'), size: 'lg' }"
 	>
 		<template #body-content>
 			<div class="space-y-4">
@@ -33,7 +33,7 @@
 				<!-- Batch Selection -->
 				<div v-if="item?.has_batch_no">
 					<label class="block text-sm font-medium text-gray-700 mb-2">
-						Select Batch Number
+						{{ __('Select Batch Number') }}
 					</label>
 					<div class="space-y-2 max-h-80 overflow-y-auto">
 						<div
@@ -52,10 +52,10 @@
 									<h4 class="text-sm font-semibold text-gray-900">{{ batch.batch_no }}</h4>
 									<div class="flex items-center space-x-3 mt-1">
 										<span class="text-xs text-gray-600">
-											Qty: {{ batch.qty }}
+											{{ __('Qty: {0}', [batch.qty]) }}
 										</span>
 										<span v-if="batch.expiry_date" class="text-xs text-gray-600">
-											Exp: {{ formatDate(batch.expiry_date) }}
+											{{ __('Exp: {0}', [formatDate(batch.expiry_date)]) }}
 										</span>
 									</div>
 								</div>
@@ -72,7 +72,7 @@
 				<!-- Serial Number Selection -->
 				<div v-if="item?.has_serial_no">
 					<label class="block text-sm font-medium text-gray-700 mb-2">
-						Select Serial Numbers ({{ selectedSerials.length }}/{{ quantity }})
+						{{ __('Select Serial Numbers ({0}/{1})', [selectedSerials.length, quantity]) }}
 					</label>
 					<div class="space-y-2 max-h-80 overflow-y-auto">
 						<div
@@ -90,7 +90,7 @@
 								<div class="flex-1">
 									<h4 class="text-sm font-semibold text-gray-900">{{ serial.serial_no }}</h4>
 									<p v-if="serial.warehouse" class="text-xs text-gray-600 mt-1">
-										Warehouse: {{ serial.warehouse }}
+										{{ __('Warehouse: {0}', [serial.warehouse]) }}
 									</p>
 								</div>
 								<div v-if="isSerialSelected(serial.serial_no)" class="flex-shrink-0">
@@ -105,12 +105,12 @@
 					<!-- Manual Serial Entry -->
 					<div class="mt-3 p-3 bg-gray-50 rounded-lg">
 						<label class="block text-xs font-medium text-gray-700 mb-2">
-							Or enter serial numbers manually (one per line)
+							{{ __('Or enter serial numbers manually (one per line)') }}
 						</label>
 						<textarea
 							v-model="manualSerials"
 							rows="3"
-							placeholder="Enter serial numbers..."
+							:placeholder="__('Enter serial numbers...')"
 							class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
 						></textarea>
 					</div>
@@ -120,14 +120,14 @@
 		<template #actions>
 			<div class="flex space-x-2">
 				<Button variant="subtle" @click="show = false">
-					Cancel
+					{{ __('Cancel') }}
 				</Button>
 				<Button
 					variant="solid"
 					@click="handleConfirm"
 					:disabled="!isValid"
 				>
-					Confirm
+					{{ __('Confirm') }}
 				</Button>
 			</div>
 		</template>

--- a/POS/src/components/sale/CouponDialog.vue
+++ b/POS/src/components/sale/CouponDialog.vue
@@ -1,5 +1,5 @@
 <template>
-	<Dialog v-model="show" :options="{ title: 'Apply', size: 'md' }">
+	<Dialog v-model="show" :options="{ title: __('Apply'), size: 'md' }">
 		<template #body-content>
 			<div class="space-y-4">
 				<!-- Info Banner -->
@@ -11,8 +11,8 @@
 								clip-rule="evenodd" />
 						</svg>
 						<div class="flex-1">
-							<p class="text-xs font-medium text-blue-900">Have a coupon code?</p>
-							<p class="text-xs text-blue-700 mt-0.5">Enter your promotional or gift card code below</p>
+							<p class="text-xs font-medium text-blue-900">{{ __('Have a coupon code?') }}</p>
+							<p class="text-xs text-blue-700 mt-0.5">{{ __('Enter your promotional or gift card code below') }}</p>
 						</div>
 					</div>
 				</div>
@@ -20,10 +20,10 @@
 				<!-- Coupon Code Input -->
 				<div v-if="!appliedDiscount">
 					<label class="block text-sm font-medium text-gray-700 mb-2">
-						Coupon Code
+						{{ __('Coupon Code') }}
 					</label>
 					<div class="flex space-x-2">
-						<Input v-model="couponCode" type="text" placeholder="ENTER-CODE-HERE" class="flex-1 uppercase"
+						<Input v-model="couponCode" type="text" :placeholder="__('ENTER-CODE-HERE')" class="flex-1 uppercase"
 							@keyup.enter="applyCoupon" :disabled="applying" />
 						<Button @click="applyCoupon" :loading="applying" theme="blue" variant="solid" class="flex-shrink-0">
 							<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -32,7 +32,7 @@
 							</svg>
 						</Button>
 					</div>
-					<p class="text-xs text-gray-500 mt-1">Code is case-insensitive</p>
+					<p class="text-xs text-gray-500 mt-1">{{ __('Code is case-insensitive') }}</p>
 				</div>
 
 				<!-- My Gift Cards -->
@@ -45,7 +45,7 @@
 									d="M18 9H2v5a2 2 0 002 2h12a2 2 0 002-2V9zM4 13a1 1 0 011-1h1a1 1 0 110 2H5a1 1 0 01-1-1zm5-1a1 1 0 100 2h1a1 1 0 100-2H9z"
 									clip-rule="evenodd" />
 							</svg>
-							<span>My Gift Cards ({{ giftCards.length }})</span>
+							<span>{{ __('My Gift Cards ({0})', [giftCards.length]) }}</span>
 						</div>
 					</label>
 					<div class="space-y-2 max-h-60 overflow-y-auto pr-1">
@@ -93,16 +93,16 @@
 							</svg>
 						</div>
 						<h4 class="text-sm font-bold text-green-900">
-							Coupon Applied Successfully!
+							{{ __('Coupon Applied Successfully!') }}
 						</h4>
 					</div>
 					<div class="bg-white rounded-lg p-3">
 						<div class="flex justify-between items-center mb-2">
-							<span class="text-xs text-gray-600">Coupon Code</span>
+							<span class="text-xs text-gray-600">{{ __('Coupon Code') }}</span>
 							<span class="text-sm font-bold text-gray-900">{{ appliedDiscount.code }}</span>
 						</div>
 						<div class="flex justify-between items-center">
-							<span class="text-xs text-gray-600">Discount Amount</span>
+							<span class="text-xs text-gray-600">{{ __('Discount Amount') }}</span>
 							<span class="text-lg font-bold text-green-600">
 								-{{ formatCurrency(appliedDiscount.amount) }}
 							</span>
@@ -132,11 +132,11 @@
 								d="M6 18L18 6M6 6l12 12" />
 						</svg>
 					</template>
-					Remove
+					{{ __('Remove') }}
 				</Button>
 				<div class="flex space-x-2 ml-auto">
 					<Button variant="subtle" @click="show = false">
-						Close
+						{{ __('Close') }}
 					</Button>
 				</div>
 			</div>
@@ -160,7 +160,7 @@ const props = defineProps({
 	subtotal: {
 		type: Number,
 		required: true,
-		note: "Cart subtotal BEFORE tax - used for discount calculations",
+		note: __("Cart subtotal BEFORE tax - used for discount calculations"),
 	},
 	items: Array,
 	posProfile: String,
@@ -259,7 +259,7 @@ function applyGiftCard(card) {
 
 async function applyCoupon() {
 	if (!couponCode.value.trim()) {
-		errorMessage.value = "Please enter a coupon code"
+		errorMessage.value = __("Please enter a coupon code")
 		return
 	}
 
@@ -276,7 +276,7 @@ async function applyCoupon() {
 
 		if (!validationData || !validationData.valid) {
 			errorMessage.value =
-				validationData?.message || "The coupon code you entered is not valid"
+				validationData?.message || __("The coupon code you entered is not valid")
 			showError(errorMessage.value)
 			return
 		}
@@ -285,7 +285,7 @@ async function applyCoupon() {
 
 		// Check minimum amount (on subtotal before tax)
 		if (coupon.min_amount && props.subtotal < coupon.min_amount) {
-			errorMessage.value = `This coupon requires a minimum purchase of ${formatCurrency(coupon.min_amount)}`
+			errorMessage.value = __('This coupon requires a minimum purchase of ', [formatCurrency(coupon.min_amount)])
 			showWarning(errorMessage.value)
 			return
 		}
@@ -319,12 +319,12 @@ async function applyCoupon() {
 
 		emit("discount-applied", appliedDiscount.value)
 
-		showSuccess(`${couponCode.value.toUpperCase()} applied successfully`)
+		showSuccess(__('{0} applied successfully', [couponCode.value.toUpperCase()]))
 
 		errorMessage.value = ""
 	} catch (error) {
 		console.error("Error applying coupon:", error)
-		errorMessage.value = "Failed to apply coupon. Please try again."
+		errorMessage.value = __("Failed to apply coupon. Please try again.")
 		showError(errorMessage.value)
 	} finally {
 		applying.value = false
@@ -334,7 +334,7 @@ async function applyCoupon() {
 function removeDiscount() {
 	appliedDiscount.value = null
 	emit("discount-removed")
-	showSuccess("Discount has been removed")
+	showSuccess(__("Discount has been removed"))
 }
 
 function formatCurrency(amount) {

--- a/POS/src/components/sale/CouponManagement.vue
+++ b/POS/src/components/sale/CouponManagement.vue
@@ -8,7 +8,7 @@
 				<FormControl
 					type="text"
 					v-model="searchQuery"
-					placeholder="Search coupons..."
+					:placeholder="__('Search coupons...')"
 				>
 					<template #prefix>
 						<FeatherIcon name="search" class="w-4 h-4 text-gray-500" />
@@ -20,21 +20,21 @@
 						type="select"
 						v-model="filterStatus"
 						:options="[
-							{ label: 'All Status', value: 'all' },
-							{ label: 'Active Only', value: 'active' },
-							{ label: 'Expired', value: 'expired' },
-							{ label: 'Not Started', value: 'not_started' },
-							{ label: 'Exhausted', value: 'exhausted' },
-							{ label: 'Disabled', value: 'disabled' }
+							{ label: __('All Status'), value: 'all' },
+							{ label: __('Active Only'), value: 'active' },
+							{ label: __('Expired'), value: 'expired' },
+							{ label: __('Not Started'), value: 'not_started' },
+							{ label: __('Exhausted'), value: 'exhausted' },
+							{ label: __('Disabled'), value: 'disabled' }
 						]"
 					/>
 					<FormControl
 						type="select"
 						v-model="filterType"
 						:options="[
-							{ label: 'All Types', value: 'all' },
-							{ label: 'Promotional', value: 'Promotional' },
-							{ label: 'Gift Card', value: 'Gift Card' }
+							{ label: __('All Types'), value: 'all' },
+							{ label: __('Promotional'), value: 'Promotional' },
+							{ label: __('Gift Card'), value: 'Gift Card' }
 						]"
 					/>
 				</div>
@@ -51,7 +51,7 @@
 					<template #prefix>
 						<FeatherIcon name="plus-circle" class="w-4 h-4" />
 					</template>
-					Create New Coupon
+					{{ __('Create New Coupon') }}
 				</Button>
 				<Button
 					@click="loadCoupons"
@@ -62,7 +62,7 @@
 					<template #prefix>
 						<FeatherIcon name="refresh-cw" class="w-4 h-4" />
 					</template>
-					Refresh
+					{{ __('Refresh') }}
 				</Button>
 			</div>
 
@@ -72,7 +72,7 @@
 				<div v-if="loading && coupons.length === 0" class="flex items-center justify-center py-12">
 					<div class="text-center">
 						<LoadingIndicator class="w-6 h-6 mx-auto mb-2" />
-						<p class="text-sm text-gray-600">Loading...</p>
+						<p class="text-sm text-gray-600">{{ __('Loading...') }}</p>
 					</div>
 				</div>
 
@@ -81,7 +81,7 @@
 					<div class="text-gray-400 mb-3">
 						<FeatherIcon name="gift" class="w-12 h-12 mx-auto" />
 					</div>
-					<p class="text-sm text-gray-600">No coupons found</p>
+					<p class="text-sm text-gray-600">{{ __('No coupons found') }}</p>
 				</div>
 
 				<!-- Coupon Items -->
@@ -112,7 +112,7 @@
 										theme="purple"
 										size="sm"
 									>
-										Gift
+										{{ __('Gift') }}
 									</Badge>
 								</div>
 								<p class="text-xs text-gray-500 mt-0.5 truncate">{{ coupon.coupon_name }}</p>
@@ -122,15 +122,17 @@
 								:theme="getStatusTheme(coupon.status)"
 								size="sm"
 							>
-								{{ coupon.status || 'Active' }}
+								{{ coupon.status || __('Active') }}
 							</Badge>
 						</div>
 						<div class="flex items-center justify-between text-xs">
 							<span class="text-gray-500">
-								Used: {{ coupon.used }}{{ coupon.maximum_use ? `/${coupon.maximum_use}` : '' }}
+								{{ coupon.maximum_use 
+									? __('Used: {0}/{1}', [coupon.used, coupon.maximum_use])
+									: __('Used: {0}', [coupon.used]) }}
 							</span>
 							<span class="text-gray-500">
-								{{ coupon.valid_upto ? formatDate(coupon.valid_upto) : 'No expiry' }}
+								{{ coupon.valid_upto ? formatDate(coupon.valid_upto) : __('No expiry') }}
 							</span>
 						</div>
 					</button>
@@ -146,8 +148,8 @@
 					<div class="text-gray-300 mb-4">
 						<FeatherIcon name="gift" class="w-16 h-16 mx-auto" />
 					</div>
-					<h3 class="text-xl font-semibold text-gray-900 mb-2">Select a Coupon</h3>
-					<p class="text-sm text-gray-600 mb-6">Choose a coupon from the list to view and edit, or create a new one to get started</p>
+					<h3 class="text-xl font-semibold text-gray-900 mb-2">{{ __('Select a Coupon') }}</h3>
+					<p class="text-sm text-gray-600 mb-6">{{ __('Choose a coupon from the list to view and edit, or create a new one to get started') }}</p>
 					<Button
 						v-if="permissions.create"
 						@click="handleCreateNew"
@@ -156,10 +158,10 @@
 						<template #prefix>
 							<FeatherIcon name="plus" class="w-4 h-4" />
 						</template>
-						Create New Coupon
+						{{ __('Create New Coupon') }}
 					</Button>
 					<p v-else class="text-sm text-amber-600">
-						You don't have permission to create coupons
+						{{ __("You don't have permission to create coupons") }}
 					</p>
 				</div>
 			</div>
@@ -172,7 +174,7 @@
 						<div>
 							<div class="flex items-center space-x-3">
 								<h3 class="text-xl font-semibold text-gray-900">
-									{{ isCreating ? 'Create New Coupon' : 'Coupon Details' }}
+									{{ isCreating ? __('Create New Coupon') : __('Coupon Details') }}
 								</h3>
 								<Badge
 									v-if="!isCreating && selectedCoupon?.coupon_type"
@@ -184,7 +186,7 @@
 								</Badge>
 							</div>
 							<p class="text-sm text-gray-600 mt-1">
-								{{ isCreating ? 'Fill in the details to create a new coupon' : 'View and update coupon information' }}
+								{{ isCreating ? __('Fill in the details to create a new coupon') : __('View and update coupon information') }}
 							</p>
 						</div>
 						<div class="flex items-center space-x-2">
@@ -197,7 +199,7 @@
 								<template #prefix>
 									<FeatherIcon :name="couponDetails.disabled ? 'check-circle' : 'x-circle'" class="w-4 h-4" />
 								</template>
-								{{ couponDetails.disabled ? 'Enable' : 'Disable' }}
+								{{ couponDetails.disabled ? __('Enable') : __('Disable') }}
 							</Button>
 							<Button
 								v-if="!isCreating && permissions.delete && selectedCoupon.used === 0"
@@ -208,14 +210,14 @@
 								<template #prefix>
 									<FeatherIcon name="trash-2" class="w-4 h-4" />
 								</template>
-								Delete
+								{{ __('Delete') }}
 							</Button>
 							<div v-if="!isCreating && (permissions.write || permissions.delete)" class="w-px h-6 bg-gray-200"></div>
 							<Button
 								@click="handleCancel"
 								variant="ghost"
 							>
-								Cancel
+								{{ __('Cancel') }}
 							</Button>
 							<Button
 								v-if="isCreating ? permissions.create : permissions.write"
@@ -226,7 +228,7 @@
 								<template #prefix>
 									<FeatherIcon :name="isCreating ? 'plus' : 'save'" class="w-4 h-4" />
 								</template>
-								{{ isCreating ? 'Create' : 'Update' }}
+								{{ isCreating ? __('Create') : __('Update') }}
 							</Button>
 						</div>
 					</div>
@@ -238,38 +240,38 @@
 							<div class="p-5">
 								<div class="flex items-center space-x-2 mb-4">
 									<FeatherIcon name="info" class="w-4 h-4 text-blue-600" />
-									<h4 class="text-sm font-semibold text-gray-900">Basic Information</h4>
+									<h4 class="text-sm font-semibold text-gray-900">{{ __('Basic Information') }}</h4>
 								</div>
 								<div class="grid grid-cols-2 gap-4">
 									<div class="col-span-2">
 										<FormControl
 											type="text"
-											label="Coupon Name"
+											:label="__('Coupon Name')"
 											v-model="form.coupon_name"
 											:disabled="!isCreating"
-											placeholder="e.g., Summer Sale Coupon 2025"
+											:placeholder="__('e.g., Summer Sale Coupon 2025')"
 											required
 										/>
 									</div>
 
 									<FormControl
 										type="select"
-										label="Coupon Type"
+										:label="__('Coupon Type')"
 										v-model="form.coupon_type"
 										:disabled="!isCreating"
 										:options="[
-											{ label: 'Promotional', value: 'Promotional' },
-											{ label: 'Gift Card', value: 'Gift Card' }
+											{ label: __('Promotional'), value: 'Promotional' },
+											{ label: __('Gift Card'), value: 'Gift Card' }
 										]"
 										required
 									/>
 
 									<FormControl
 										type="text"
-										label="Coupon Code"
+										:label="__('Coupon Code')"
 										v-model="form.coupon_code"
 										:disabled="!isCreating"
-										placeholder="Auto-generated if empty"
+										:placeholder="__('Auto-generated if empty')"
 									>
 										<template #suffix v-if="isCreating">
 											<Button
@@ -277,7 +279,7 @@
 												variant="ghost"
 												@click="generateCouponCode"
 											>
-												Generate
+												{{ __('Generate') }}
 											</Button>
 										</template>
 									</FormControl>
@@ -287,13 +289,13 @@
 										<FormControl
 											v-if="isCreating"
 											type="text"
-											label="Customer"
+											:label="__('Customer')"
 											v-model="form.customer"
-											placeholder="Customer ID or Name"
+											:placeholder="__('Customer ID or Name')"
 											required
 										/>
 										<div v-else>
-											<label class="block text-sm font-medium text-gray-700 mb-2">Customer</label>
+											<label class="block text-sm font-medium text-gray-700 mb-2">{{ __('Customer') }}</label>
 											<div class="px-3 py-2 bg-gray-50 rounded-lg">
 												<p class="text-sm font-medium text-gray-900">{{ couponDetails.customer_name || couponDetails.customer }}</p>
 												<p class="text-xs text-gray-500">{{ couponDetails.customer }}</p>
@@ -304,7 +306,7 @@
 									<FormControl
 										v-if="campaigns.length > 0"
 										type="select"
-										label="Campaign"
+										:label="__('Campaign')"
 										v-model="form.campaign"
 										:disabled="!isCreating"
 										:options="campaignOptions"
@@ -312,7 +314,7 @@
 
 									<!-- Company field -->
 									<div>
-										<label class="block text-sm font-medium text-gray-700 mb-2">Company</label>
+										<label class="block text-sm font-medium text-gray-700 mb-2">{{ __('Company') }}</label>
 										<div class="px-3 py-2 bg-gray-50 rounded-lg">
 											<p class="text-sm text-gray-900">{{ isCreating ? props.company : couponDetails.company }}</p>
 										</div>
@@ -320,7 +322,7 @@
 
 									<!-- Referral Code (view only when editing) -->
 									<div v-if="!isCreating && couponDetails.referral_code">
-										<label class="block text-sm font-medium text-gray-700 mb-2">Referral Code</label>
+										<label class="block text-sm font-medium text-gray-700 mb-2">{{ __('Referral Code') }}</label>
 										<div class="px-3 py-2 bg-blue-50 rounded-lg border border-blue-200">
 											<p class="text-sm font-medium text-blue-900">{{ couponDetails.referral_code }}</p>
 										</div>
@@ -334,27 +336,27 @@
 							<div class="p-5">
 								<div class="flex items-center space-x-2 mb-4">
 									<FeatherIcon name="percent" class="w-4 h-4 text-purple-600" />
-									<h4 class="text-sm font-semibold text-gray-900">Discount Configuration</h4>
+									<h4 class="text-sm font-semibold text-gray-900">{{ __('Discount Configuration') }}</h4>
 								</div>
 								<div class="grid grid-cols-2 gap-4">
 									<FormControl
 										type="select"
-										label="Discount Type"
+										:label="__('Discount Type')"
 										v-model="form.discount_type"
 										:options="[
-											{ label: 'Percentage', value: 'Percentage' },
-											{ label: 'Amount', value: 'Amount' }
+											{ label: __('Percentage'), value: 'Percentage' },
+											{ label: __('Amount'), value: 'Amount' }
 										]"
 										required
 									/>
 
 									<FormControl
 										type="select"
-										label="Apply Discount On"
+										:label="__('Apply Discount On')"
 										v-model="form.apply_on"
 										:options="[
-											{ label: 'Grand Total', value: 'Grand Total' },
-											{ label: 'Net Total', value: 'Net Total' }
+											{ label: __('Grand Total'), value: 'Grand Total' },
+											{ label: __('Net Total'), value: 'Net Total' }
 										]"
 										required
 									/>
@@ -362,9 +364,9 @@
 									<FormControl
 										v-if="form.discount_type === 'Percentage'"
 										type="number"
-										label="Discount Percentage (%)"
+										:label="__('Discount Percentage (%)')"
 										v-model="form.discount_percentage"
-										placeholder="e.g., 20"
+										:placeholder="__('e.g., 20')"
 										:min="0"
 										:max="100"
 										required
@@ -373,43 +375,43 @@
 									<FormControl
 										v-if="form.discount_type === 'Amount'"
 										type="number"
-										label="Discount Amount"
+										:label="__('Discount Amount')"
 										v-model="form.discount_amount"
-										:placeholder="`Amount in ${currency}`"
+										:placeholder="__('Amount in {0}', [currency])"
 										:min="0"
 										required
 									/>
 
 									<FormControl
 										type="number"
-										label="Minimum Cart Amount"
+										:label="__('Minimum Cart Amount')"
 										v-model="form.min_amount"
-										:placeholder="`Optional minimum in ${currency}`"
+										:placeholder="__('Optional minimum in {0}', [currency])"
 										:min="0"
 									/>
 
 									<FormControl
 										type="number"
-										label="Maximum Discount Amount"
+										:label="__('Maximum Discount Amount')"
 										v-model="form.max_amount"
-										:placeholder="`Optional cap in ${currency}`"
+										:placeholder="__('Optional cap in {0}', [currency])"
 										:min="0"
 									/>
 								</div>
 								<div v-if="!isCreating && couponDetails.discount_type" class="mt-4 p-3 bg-purple-50 rounded-lg">
 									<p class="text-sm text-gray-700">
-										<strong>Current Discount:</strong>
+										<strong>{{ __('Current Discount:') }}</strong>
 										<span v-if="couponDetails.discount_type === 'Percentage'">
-											{{ Number(couponDetails.discount_percentage).toFixed(2) }}% off {{ couponDetails.apply_on }}
+											{{ __('{0}% off {1}', [Number(couponDetails.discount_percentage).toFixed(2), couponDetails.apply_on]) }}
 										</span>
 										<span v-else>
-											{{ formatCurrency(couponDetails.discount_amount) }} off {{ couponDetails.apply_on }}
+											{{ __('{0} off {1}', [formatCurrency(couponDetails.discount_amount), couponDetails.apply_on]) }}
 										</span>
 										<span v-if="couponDetails.min_amount" class="ml-2">
-											(Min: {{ formatCurrency(couponDetails.min_amount) }})
+											{{ __('(Min: {0})', [formatCurrency(couponDetails.min_amount)]) }}
 										</span>
 										<span v-if="couponDetails.max_amount" class="ml-2">
-											(Max Discount: {{ formatCurrency(couponDetails.max_amount) }})
+											{{ __('(Max Discount: {0})', [formatCurrency(couponDetails.max_amount)]) }}
 										</span>
 									</p>
 								</div>
@@ -421,28 +423,28 @@
 							<div class="p-5">
 								<div class="flex items-center space-x-2 mb-4">
 									<FeatherIcon name="calendar" class="w-4 h-4 text-green-600" />
-									<h4 class="text-sm font-semibold text-gray-900">Validity & Usage</h4>
+									<h4 class="text-sm font-semibold text-gray-900">{{ __('Validity & Usage') }}</h4>
 								</div>
 								<div class="grid grid-cols-3 gap-4">
 									<FormControl
 										type="date"
-										label="Valid From"
+										:label="__('Valid From')"
 										v-model="form.valid_from"
 									/>
 									<FormControl
 										type="date"
-										label="Valid Until"
+										:label="__('Valid Until')"
 										v-model="form.valid_upto"
 									/>
 									<FormControl
 										v-if="form.coupon_type === 'Promotional'"
 										type="number"
-										label="Maximum Use"
+										:label="__('Maximum Use')"
 										v-model="form.maximum_use"
-										placeholder="Unlimited"
+										:placeholder="__('Unlimited')"
 									/>
 									<div v-if="!isCreating">
-										<label class="block text-sm font-medium text-gray-700 mb-2">Times Used</label>
+										<label class="block text-sm font-medium text-gray-700 mb-2">{{ __('Times Used') }}</label>
 										<div class="px-3 py-2 bg-gray-50 rounded-lg">
 											<p class="text-lg font-bold text-gray-900">{{ couponDetails.used || 0 }}</p>
 										</div>
@@ -455,7 +457,7 @@
 											v-model="form.one_use"
 											class="rounded border-gray-300"
 										/>
-										<span class="text-sm text-gray-700">Only One Use Per Customer</span>
+										<span class="text-sm text-gray-700">{{ __('Only One Use Per Customer') }}</span>
 									</label>
 								</div>
 							</div>
@@ -466,29 +468,29 @@
 							<div class="p-5">
 								<div class="flex items-center space-x-2 mb-4">
 									<FeatherIcon name="activity" class="w-4 h-4 text-orange-600" />
-									<h4 class="text-sm font-semibold text-gray-900">Coupon Status & Info</h4>
+									<h4 class="text-sm font-semibold text-gray-900">{{ __('Coupon Status & Info') }}</h4>
 								</div>
 								<div class="grid grid-cols-3 gap-4">
 									<div>
-										<label class="block text-xs font-medium text-gray-500 mb-1">Current Status</label>
+										<label class="block text-xs font-medium text-gray-500 mb-1">{{ __('Current Status') }}</label>
 										<Badge :theme="getStatusTheme(selectedCoupon.status)" variant="subtle" size="md">
 											{{ selectedCoupon.status }}
 										</Badge>
 									</div>
 									<div>
-										<label class="block text-xs font-medium text-gray-500 mb-1">Created On</label>
+										<label class="block text-xs font-medium text-gray-500 mb-1">{{ __('Created On') }}</label>
 										<p class="text-sm text-gray-900">{{ formatDate(couponDetails.creation) }}</p>
 									</div>
 									<div>
-										<label class="block text-xs font-medium text-gray-500 mb-1">Last Modified</label>
+										<label class="block text-xs font-medium text-gray-500 mb-1">{{ __('Last Modified') }}</label>
 										<p class="text-sm text-gray-900">{{ formatDate(couponDetails.modified) }}</p>
 									</div>
 									<div v-if="couponDetails.email_id">
-										<label class="block text-xs font-medium text-gray-500 mb-1">Email</label>
+										<label class="block text-xs font-medium text-gray-500 mb-1">{{ __('Email') }}</label>
 										<p class="text-sm text-gray-900">{{ couponDetails.email_id }}</p>
 									</div>
 									<div v-if="couponDetails.mobile_no">
-										<label class="block text-xs font-medium text-gray-500 mb-1">Mobile</label>
+										<label class="block text-xs font-medium text-gray-500 mb-1">{{ __('Mobile') }}</label>
 										<p class="text-sm text-gray-900">{{ couponDetails.mobile_no }}</p>
 									</div>
 								</div>
@@ -515,12 +517,14 @@
 						</div>
 					</div>
 					<div class="flex-1">
-						<h3 class="text-lg font-semibold text-gray-900 mb-2">Delete Coupon</h3>
-						<p class="text-sm text-gray-600 mb-1">
-							Are you sure you want to delete <strong>"{{ selectedCoupon?.coupon_code }}"</strong>?
-						</p>
+						<h3 class="text-lg font-semibold text-gray-900 mb-2">{{ __('Delete Coupon') }}</h3>
+							<TranslatedHTML 
+								:tag="'p'"
+								class="text-sm text-gray-600 mb-1"
+								:inner="__('Are you sure you want to delete &lt;strong&gt;&quot;{0}&quot;&lt;strong&gt;?', [selectedCoupon?.coupon_code])"
+							/>
 						<p class="text-sm text-gray-500">
-							This action cannot be undone.
+							{{ __('This action cannot be undone.') }}
 						</p>
 					</div>
 				</div>
@@ -529,7 +533,7 @@
 						@click="showDeleteConfirm = false"
 						variant="ghost"
 					>
-						Cancel
+						{{ __('Cancel') }}
 					</Button>
 					<Button
 						@click="confirmDelete"
@@ -540,7 +544,7 @@
 						<template #prefix>
 							<FeatherIcon name="trash-2" class="w-4 h-4" />
 						</template>
-						Delete Coupon
+						{{ __('Delete Coupon') }}
 					</Button>
 				</div>
 			</div>
@@ -553,6 +557,7 @@ import { useToast } from "@/composables/useToast"
 import { Badge, Button, Card, FormControl, LoadingIndicator, createResource } from "frappe-ui"
 import { FeatherIcon } from "frappe-ui"
 import { computed, onMounted, ref, watch } from "vue"
+import TranslatedHTML from "../common/TranslatedHTML.vue"
 
 const { showSuccess, showError, showWarning } = useToast()
 
@@ -641,7 +646,7 @@ const filteredCoupons = computed(() => {
 
 const campaignOptions = computed(() => {
 	return [
-		{ label: "-- No Campaign --", value: "" },
+		{ label: __("-- No Campaign --"), value: "" },
 		...campaigns.value.map(c => ({ label: c.name, value: c.name }))
 	]
 })
@@ -662,7 +667,7 @@ const couponsResource = createResource({
 	},
 	onError(error) {
 		loading.value = false
-		handleError(error, "Failed to load coupons")
+		handleError(error, __('Failed to load coupons'))
 	},
 })
 
@@ -679,7 +684,7 @@ const couponDetailsResource = createResource({
 	},
 	onError(error) {
 		loading.value = false
-		handleError(error, "Failed to load coupon details")
+		handleError(error, __('Failed to load coupon details'))
 	},
 })
 
@@ -708,14 +713,14 @@ const createCouponResource = createResource({
 	onSuccess(data) {
 		loading.value = false
 		const responseData = data?.message || data
-		showSuccess(responseData?.message || "Coupon created successfully")
+		showSuccess(responseData?.message || __("Coupon created successfully"))
 		loadCoupons()
 		handleCancel()
 		emit("coupon-saved", responseData)
 	},
 	onError(error) {
 		loading.value = false
-		handleError(error, "Failed to create coupon")
+		handleError(error, __("Failed to create coupon"))
 	},
 })
 
@@ -742,14 +747,14 @@ const updateCouponResource = createResource({
 	onSuccess(data) {
 		loading.value = false
 		const responseData = data?.message || data
-		showSuccess(responseData?.message || "Coupon updated successfully")
+		showSuccess(responseData?.message || __("Coupon updated successfully"))
 		loadCoupons()
 		// Reload details to show updated info
 		couponDetailsResource.reload()
 	},
 	onError(error) {
 		loading.value = false
-		handleError(error, "Failed to update coupon")
+		handleError(error, __("Failed to update coupon"))
 	},
 })
 
@@ -762,7 +767,7 @@ const toggleCouponResource = createResource({
 	onSuccess(data) {
 		loading.value = false
 		const responseData = data?.message || data
-		showSuccess(responseData?.message || "Coupon status updated successfully")
+		showSuccess(responseData?.message || __("Coupon status updated successfully"))
 		loadCoupons()
 		// Reload details to get updated disabled status
 		if (selectedCoupon.value) {
@@ -771,7 +776,7 @@ const toggleCouponResource = createResource({
 	},
 	onError(error) {
 		loading.value = false
-		handleError(error, "Failed to toggle coupon status")
+		handleError(error, __("Failed to toggle coupon status"))
 	},
 })
 
@@ -785,14 +790,14 @@ const deleteCouponResource = createResource({
 		loading.value = false
 		showDeleteConfirm.value = false
 		const responseData = data?.message || data
-		showSuccess(responseData?.message || "Coupon deleted successfully")
+		showSuccess(responseData?.message || __("Coupon deleted successfully"))
 		loadCoupons()
 		handleCancel()
 	},
 	onError(error) {
 		loading.value = false
 		showDeleteConfirm.value = false
-		handleError(error, "Failed to delete coupon")
+		handleError(error, __("Failed to delete coupon"))
 	},
 })
 
@@ -839,26 +844,26 @@ function handleCancel() {
 function handleSubmit() {
 	// Validate
 	if (!form.value.coupon_name) {
-		showWarning("Please enter a coupon name")
+		showWarning(__("Please enter a coupon name"))
 		return
 	}
 	if (!form.value.discount_type) {
-		showWarning("Please select a discount type")
+		showWarning(__("Please select a discount type"))
 		return
 	}
 	if (form.value.discount_type === "Percentage") {
 		if (!form.value.discount_percentage || form.value.discount_percentage <= 0 || form.value.discount_percentage > 100) {
-			showWarning("Please enter a valid discount percentage (1-100)")
+			showWarning(__("Please enter a valid discount percentage (1-100)"))
 			return
 		}
 	} else if (form.value.discount_type === "Amount") {
 		if (!form.value.discount_amount || form.value.discount_amount <= 0) {
-			showWarning("Please enter a valid discount amount")
+			showWarning(__("Please enter a valid discount amount"))
 			return
 		}
 	}
 	if (form.value.coupon_type === "Gift Card" && !form.value.customer) {
-		showWarning("Please select a customer for gift card")
+		showWarning(__("Please select a customer for gift card"))
 		return
 	}
 
@@ -878,7 +883,7 @@ function handleToggle() {
 
 function handleDelete() {
 	if (selectedCoupon.value.used > 0) {
-		showWarning(`Cannot delete coupon as it has been used ${selectedCoupon.value.used} times`)
+		showWarning(__('Cannot delete coupon as it has been used {0} times', [selectedCoupon.value.used]))
 		return
 	}
 	showDeleteConfirm.value = true
@@ -922,14 +927,14 @@ function resetForm() {
 function populateFormFromCoupon(coupon) {
 	form.value = {
 		coupon_name: coupon.coupon_name || "",
-		coupon_type: coupon.coupon_type || "Promotional",
+		coupon_type: coupon.coupon_type || __('Promotional'),
 		coupon_code: coupon.coupon_code || "",
-		discount_type: coupon.discount_type || "Percentage",
+		discount_type: coupon.discount_type || __('Percentage'),
 		discount_percentage: coupon.discount_percentage || null,
 		discount_amount: coupon.discount_amount || null,
 		min_amount: coupon.min_amount || null,
 		max_amount: coupon.max_amount || null,
-		apply_on: coupon.apply_on || "Grand Total",
+		apply_on: coupon.apply_on || __('Grand Total'),
 		customer: coupon.customer || "",
 		campaign: coupon.campaign || "",
 		valid_from: coupon.valid_from || "",
@@ -980,16 +985,16 @@ function parseErrorMessage(error) {
 			const messages = JSON.parse(error._server_messages)
 			if (Array.isArray(messages) && messages.length > 0) {
 				const firstMessage = typeof messages[0] === "string" ? JSON.parse(messages[0]) : messages[0]
-				return firstMessage.message || error.message || "An error occurred"
+				return firstMessage.message || error.message || __("An error occurred")
 			}
 		}
-		return error.message || "An error occurred"
+		return error.message || __("An error occurred")
 	} catch (e) {
-		return error.message || "An error occurred"
+		return error.message || __("An error occurred")
 	}
 }
 
-function handleError(error, defaultMessage = "An error occurred") {
+function handleError(error, defaultMessage = __("An error occurred")) {
 	const errorMessage = parseErrorMessage(error)
 	showError(errorMessage || defaultMessage)
 }

--- a/POS/src/components/sale/CreateCustomerDialog.vue
+++ b/POS/src/components/sale/CreateCustomerDialog.vue
@@ -1,16 +1,16 @@
 <template>
-	<Dialog v-model="show" :options="{ title: 'Create New Customer', size: 'md' }">
+	<Dialog v-model="show" :options="{ title: __('Create New Customer'), size: 'md' }">
 		<template #body-content>
 			<div class="space-y-4">
 				<!-- Customer Name -->
 				<div>
 					<label class="block text-sm font-medium text-gray-700 mb-2">
-						Customer Name <span class="text-red-500">*</span>
+						{{ __('Customer Name') }} <span class="text-red-500">*</span>
 					</label>
 					<Input
 						v-model="customerData.customer_name"
 						type="text"
-						placeholder="Enter customer name"
+						:placeholder="__('Enter customer name')"
 						required
 					/>
 				</div>
@@ -18,7 +18,7 @@
 				<!-- Mobile Number with Country Code -->
 				<div>
 					<label class="block text-sm font-medium text-gray-700 mb-2">
-						Mobile Number
+						{{ __('Mobile Number') }}
 					</label>
 					<div class="flex gap-2">
 						<!-- Country Code Searchable Dropdown -->
@@ -51,7 +51,7 @@
 										ref="countrySearchRef"
 										v-model="countrySearchQuery"
 										type="text"
-										placeholder="Search country or code..."
+										:placeholder="__('Search country or code...')"
 										class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
 										@keydown.escape="showCountryDropdown = false"
 									/>
@@ -77,7 +77,7 @@
 										<span class="text-sm text-gray-500">{{ country.isd }}</span>
 									</button>
 									<div v-if="filteredCountries.length === 0" class="px-4 py-8 text-center text-sm text-gray-500">
-										No countries found
+										{{ __('No countries found') }}
 									</div>
 								</div>
 							</div>
@@ -87,7 +87,7 @@
 						<input
 							v-model="phoneNumber"
 							type="tel"
-							placeholder="Enter phone number"
+							:placeholder="__('Enter phone number')"
 							class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
 							@input="updateMobileNumber"
 						/>
@@ -97,25 +97,25 @@
 				<!-- Email -->
 				<div>
 					<label class="block text-sm font-medium text-gray-700 mb-2">
-						Email
+						{{ __('Email') }}
 					</label>
 					<Input
 						v-model="customerData.email_id"
 						type="email"
-						placeholder="Enter email address"
+						:placeholder="__('Enter email address')"
 					/>
 				</div>
 
 				<!-- Customer Group -->
 				<div>
 					<label class="block text-sm font-medium text-gray-700 mb-2">
-						Customer Group
+						{{ __('Customer Group') }}
 					</label>
 					<select
 						v-model="customerData.customer_group"
 						class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
 					>
-						<option value="">Select Customer Group</option>
+						<option value="">{{ __('Select Customer Group') }}</option>
 						<option v-for="group in customerGroups" :key="group" :value="group">
 							{{ group }}
 						</option>
@@ -125,13 +125,13 @@
 				<!-- Territory -->
 				<div>
 					<label class="block text-sm font-medium text-gray-700 mb-2">
-						Territory
+						{{ __('Territory') }}
 					</label>
 					<select
 						v-model="customerData.territory"
 						class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
 					>
-						<option value="">Select Territory</option>
+						<option value="">{{ __('Select Territory') }}</option>
 						<option v-for="territory in territories" :key="territory" :value="territory">
 							{{ territory }}
 						</option>
@@ -149,15 +149,15 @@
 							<path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
 						</svg>
 						<div class="flex-1">
-							<p class="text-sm font-medium text-amber-900">Permission Required</p>
-							<p class="text-xs text-amber-700 mt-0.5">You don't have permission to create customers. Contact your administrator.</p>
+							<p class="text-sm font-medium text-amber-900">{{ __('Permission Required') }}</p>
+							<p class="text-xs text-amber-700 mt-0.5">{{ __("You don't have permission to create customers. Contact your administrator.") }}</p>
 						</div>
 					</div>
 				</div>
 
 				<div class="flex space-x-2">
 					<Button variant="subtle" @click="show = false">
-						Cancel
+						{{ __('Cancel') }}
 					</Button>
 					<Button
 						variant="solid"
@@ -165,7 +165,7 @@
 						:loading="createCustomerResource.loading || checkingPermission"
 						:disabled="!customerData.customer_name || !hasPermission"
 					>
-						Create Customer
+						{{ __('Create Customer') }}
 					</Button>
 				</div>
 			</div>
@@ -367,22 +367,22 @@ const createCustomerResource = createResource({
 				doctype: "Customer",
 				customer_name: customerData.value.customer_name,
 				customer_type: "Individual",
-				customer_group: customerData.value.customer_group || "Individual",
-				territory: customerData.value.territory || "All Territories",
+				customer_group: customerData.value.customer_group || __('Individual'),
+				territory: customerData.value.territory || __('All Territories'),
 				mobile_no: customerData.value.mobile_no || "",
 				email_id: customerData.value.email_id || "",
 			},
 		}
 	},
 	onSuccess(data) {
-		showSuccess(`Customer ${data.customer_name} created successfully`)
+		showSuccess(__('Customer {0} created successfully', [data.customer_name]))
 
 		emit("customer-created", data)
 		show.value = false
 	},
 	onError(error) {
 		log.error("Error creating customer", error)
-		showError(error.message || "Failed to create customer")
+		showError(error.message || __("Failed to create customer"))
 	},
 })
 
@@ -470,7 +470,7 @@ const checkPermissions = async () => {
 }
 
 const handleCreate = async () => {
-	if (!customerData.value.customer_name) return showError("Customer Name is required")
+	if (!customerData.value.customer_name) return showError(__("Customer Name is required"))
 	await createCustomerResource.submit()
 }
 

--- a/POS/src/components/sale/CustomerDialog.vue
+++ b/POS/src/components/sale/CustomerDialog.vue
@@ -1,7 +1,7 @@
 <template>
-	<Dialog v-model="show" :options="{ title: 'Select Customer', size: 'md' }">
+	<Dialog v-model="show" :options="{ title: __('Select Customer'), size: 'md' }">
 		<template #body-title>
-			<span class="sr-only">Search and select a customer for the transaction</span>
+			<span class="sr-only">{{ __('Search and select a customer for the transaction') }}</span>
 		</template>
 		<template #body-content>
 			<div class="space-y-4">
@@ -30,11 +30,11 @@
 						:value="searchTerm"
 						@input="handleSearchInput"
 						type="text"
-						placeholder="Search customers by name, mobile, or email..."
+						:placeholder="__('Search customers by name, mobile, or email...')"
 						class="w-full border border-gray-300 rounded-md px-3 py-2 pl-10 pr-10 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
 						@keydown="handleKeydown"
 						autofocus
-						aria-label="Search customers"
+						:aria-label="__('Search customers')"
 					/>
 					<!-- Clear Button -->
 					<div v-if="searchTerm" class="absolute inset-y-0 right-0 pr-3 flex items-center">
@@ -45,9 +45,9 @@
 						</button>
 					</div>
 					<p v-if="!loading && allCustomers.length > 0" class="text-xs text-gray-500 mt-1">
-						<span v-if="showingRecent" class="text-blue-600 font-medium">⭐ Recent & Frequent</span>
-						<span v-else>{{ customers.length }} of {{ allCustomers.length }} customers</span>
-						<span v-if="customers.length > 0" class="text-gray-400 ml-1">• Use ↑↓ to navigate, Enter to select</span>
+						<span v-if="showingRecent" class="text-blue-600 font-medium">{{ __('⭐ Recent & Frequent') }}</span>
+						<span v-else>{{ __('{0} of {1} customers', [customers.length, allCustomers.length]) }}</span>
+						<span v-if="customers.length > 0" class="text-gray-400 ml-1">{{ __('• Use ↑↓ to navigate, Enter to select') }}</span>
 					</p>
 				</div>
 
@@ -69,7 +69,7 @@
 						<div
 							class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"
 						></div>
-						<p class="mt-2 text-sm text-gray-500">Loading customers...</p>
+						<p class="mt-2 text-sm text-gray-500">{{ __('Loading customers...') }}</p>
 					</div>
 
 					<div
@@ -89,9 +89,9 @@
 								d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
 							/>
 						</svg>
-						<p class="mt-2 text-sm text-gray-500">No customers available</p>
+						<p class="mt-2 text-sm text-gray-500">{{ __('No customers available') }}</p>
 						<p class="text-xs text-gray-400 mt-1">
-							Create your first customer to get started
+							{{ __('Create your first customer to get started') }}
 						</p>
 					</div>
 
@@ -112,9 +112,9 @@
 								d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
 							/>
 						</svg>
-						<p class="mt-2 text-sm font-medium text-gray-700">No results for "{{ searchTerm }}"</p>
+						<p class="mt-2 text-sm font-medium text-gray-700">{{ __('No results for "{0}"', [searchTerm]) }}</p>
 						<p class="text-xs text-gray-500 mt-1">
-							Try a different search term or create a new customer
+							{{ __('Try a different search term or create a new customer') }}
 						</p>
 					</div>
 
@@ -161,14 +161,14 @@
 						@click="createNewCustomer"
 						class="w-full py-2 px-4 text-sm font-medium text-blue-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-colors"
 					>
-						+ Create New Customer
+						{{ __('+ Create New Customer') }}
 					</button>
 				</div>
 			</div>
 		</template>
 
 		<template #actions>
-			<Button variant="subtle" @click="show = false">Cancel</Button>
+			<Button variant="subtle" @click="show = false">{{ __('Cancel') }}</Button>
 		</template>
 	</Dialog>
 

--- a/POS/src/components/sale/DraftInvoicesDialog.vue
+++ b/POS/src/components/sale/DraftInvoicesDialog.vue
@@ -2,7 +2,7 @@
 	<!-- Main Dialog -->
 	<Dialog
 		v-model="show"
-		:options="{ title: 'Draft Invoices', size: 'lg' }"
+		:options="{ title: __('Draft Invoices'), size: 'lg' }"
 	>
 		<template #body-content>
 			<div class="space-y-3">
@@ -13,8 +13,8 @@
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
 						</svg>
 					</div>
-					<p class="text-sm font-medium text-gray-900">No draft invoices</p>
-					<p class="text-xs text-gray-500 mt-1">Save invoices as drafts to continue later</p>
+					<p class="text-sm font-medium text-gray-900">{{ __('No draft invoices') }}</p>
+					<p class="text-xs text-gray-500 mt-1">{{ __('Save invoices as drafts to continue later') }}</p>
 				</div>
 
 				<!-- Drafts List -->
@@ -31,7 +31,7 @@
 									{{ draft.draft_id }}
 								</h4>
 								<p v-if="draft.customer" class="text-xs text-gray-500 mt-0.5">
-									Customer: {{ draft.customer?.customer_name || draft.customer?.name || draft.customer }}
+									{{ __('Customer: {0}', [(draft.customer?.customer_name || draft.customer?.name || draft.customer)]) }}
 								</p>
 								<p class="text-xs text-gray-400 mt-0.5">
 									{{ formatDateTime(draft.created_at) }}
@@ -40,7 +40,7 @@
 							<button
 								@click.stop="handleDeleteDraft(draft.draft_id)"
 								class="text-gray-400 hover:text-red-600 transition-colors p-1"
-								title="Delete draft"
+								:title="__('Delete draft')"
 							>
 								<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
@@ -51,7 +51,7 @@
 						<!-- Items Preview -->
 						<div class="flex items-center justify-between text-xs">
 							<span class="text-gray-600">
-								{{ draft.items?.length || 0 }} item(s)
+								{{ __('{0} item(s)', [draft.items?.length || 0]) }}
 							</span>
 							<span class="font-bold text-blue-600">
 								{{ formatCurrency(calculateTotal(draft.items)) }}
@@ -72,7 +72,7 @@
 									v-if="draft.items.length > 3"
 									class="text-[10px] text-gray-500 px-1.5 py-0.5"
 								>
-									+{{ draft.items.length - 3 }} more
+									{{ __('+{0} more', [draft.items.length - 3]) }}
 								</span>
 							</div>
 						</div>
@@ -88,10 +88,10 @@
 					theme="red"
 					@click="showClearAllDialog = true"
 				>
-					Clear All
+					{{ __('Clear All') }}
 				</Button>
 				<Button variant="subtle" @click="show = false">
-					Close
+					{{ __('Close') }}
 				</Button>
 			</div>
 		</template>
@@ -100,22 +100,22 @@
 	<!-- Delete Single Draft Confirmation -->
 	<Dialog
 		v-model="showDeleteDialog"
-		:options="{ title: 'Delete Draft?', size: 'xs' }"
+		:options="{ title: __('Delete Draft?'), size: 'xs' }"
 	>
 		<template #body-content>
 			<div class="py-3">
 				<p class="text-sm text-gray-600">
-					Permanently delete this draft invoice?
+					{{ __('Permanently delete this draft invoice?') }}
 				</p>
 			</div>
 		</template>
 		<template #actions>
 			<div class="flex space-x-2 w-full">
 				<Button class="flex-1" variant="subtle" @click="showDeleteDialog = false">
-					Cancel
+					{{ __('Cancel') }}
 				</Button>
 				<Button class="flex-1" variant="solid" theme="red" @click="confirmDeleteDraft">
-					Delete
+					{{ __('Delete') }}
 				</Button>
 			</div>
 		</template>
@@ -124,22 +124,22 @@
 	<!-- Clear All Drafts Confirmation -->
 	<Dialog
 		v-model="showClearAllDialog"
-		:options="{ title: 'Clear All Drafts?', size: 'xs' }"
+		:options="{ title: __('Clear All Drafts?'), size: 'xs' }"
 	>
 		<template #body-content>
 			<div class="py-3">
 				<p class="text-sm text-gray-600">
-					Permanently delete all {{ drafts.length }} draft invoices?
+					{{ __('Permanently delete all {0} draft invoices?', [drafts.length]) }}
 				</p>
 			</div>
 		</template>
 		<template #actions>
 			<div class="flex space-x-2 w-full">
 				<Button class="flex-1" variant="subtle" @click="showClearAllDialog = false">
-					Cancel
+					{{ __('Cancel') }}
 				</Button>
 				<Button class="flex-1" variant="solid" theme="red" @click="confirmClearAll">
-					Clear All
+					{{ __('Clear All') }}
 				</Button>
 			</div>
 		</template>
@@ -194,7 +194,7 @@ async function loadDrafts() {
 		drafts.value = await getAllDrafts()
 	} catch (error) {
 		console.error("Error loading drafts:", error)
-		showError("Failed to load draft invoices")
+		showError(__("Failed to load draft invoices"))
 	}
 }
 
@@ -213,10 +213,10 @@ async function confirmDeleteDraft() {
 		// Notify parent to update count
 		emit("drafts-updated")
 
-		showSuccess("Draft invoice deleted")
+		showSuccess(__("Draft invoice deleted"))
 	} catch (error) {
 		console.error("Error deleting draft:", error)
-		showError("Failed to delete draft")
+		showError(__("Failed to delete draft"))
 	}
 }
 
@@ -229,10 +229,10 @@ async function confirmClearAll() {
 		// Notify parent to update count
 		emit("drafts-updated")
 
-		showSuccess("All draft invoices deleted")
+		showSuccess(__("All draft invoices deleted"))
 	} catch (error) {
 		console.error("Error clearing drafts:", error)
-		showError("Failed to clear drafts")
+		showError(__("Failed to clear drafts"))
 	}
 }
 

--- a/POS/src/components/sale/EditItemDialog.vue
+++ b/POS/src/components/sale/EditItemDialog.vue
@@ -1,7 +1,7 @@
 <template>
-	<Dialog v-model="show" :options="{ title: 'Edit Item Details', size: 'md' }">
+	<Dialog v-model="show" :options="{ title: __('Edit Item Details'), size: 'md' }">
 		<template #body-title>
-			<span class="sr-only">Edit item quantity, UOM, warehouse, and discount</span>
+			<span class="sr-only">{{ __('Edit item quantity, UOM, warehouse, and discount') }}</span>
 		</template>
 		<template #body-content>
 			<div v-if="localItem" class="space-y-4">
@@ -36,7 +36,7 @@
 							{{ localItem.item_name }}
 						</h3>
 						<p class="text-sm text-gray-500 truncate">
-							{{ formatCurrency(localItem.price_list_rate || localItem.rate) }} / {{ localItem.stock_uom || 'Nos' }}
+							{{ formatCurrency(localItem.price_list_rate || localItem.rate) }} / {{ localItem.stock_uom || __('Nos', null, 'UOM') }}
 						</p>
 					</div>
 				</div>
@@ -47,7 +47,7 @@
 					<div class="space-y-4">
 						<!-- Quantity Control -->
 						<div>
-							<label class="block text-sm font-medium text-gray-700 mb-2">Quantity</label>
+							<label class="block text-sm font-medium text-gray-700 mb-2">{{ __('Quantity') }}</label>
 							<div class="w-full h-10 border border-gray-300 rounded-lg bg-white flex items-center overflow-hidden">
 								<button
 									type="button"
@@ -83,7 +83,7 @@
 
 						<!-- Rate -->
 						<div>
-							<label class="block text-sm font-medium text-gray-700 mb-2">Rate</label>
+							<label class="block text-sm font-medium text-gray-700 mb-2">{{ __('Rate') }}</label>
 							<div class="relative h-10">
 								<span class="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-500 text-sm font-medium">
 									{{ currencySymbol }}
@@ -104,7 +104,7 @@
 					<div class="space-y-4">
 						<!-- UOM Selector -->
 						<div>
-							<label class="block text-sm font-medium text-gray-700 mb-2">UOM</label>
+							<label class="block text-sm font-medium text-gray-700 mb-2">{{ __('UOM') }}</label>
 							<select
 								v-model="localUom"
 								@change="handleUomChange"
@@ -124,7 +124,7 @@
 
 						<!-- Warehouse Selector -->
 						<div>
-							<label class="block text-sm font-medium text-gray-700 mb-2">Warehouse</label>
+							<label class="block text-sm font-medium text-gray-700 mb-2">{{ __('Warehouse') }}</label>
 							<select
 								v-model="localWarehouse"
 								@change="handleWarehouseChange"
@@ -139,7 +139,7 @@
 									{{ warehouse.warehouse || warehouse.name }}
 								</option>
 								<option v-else :value="localWarehouse">
-									{{ localWarehouse || 'Default' }}
+									{{ localWarehouse || __('Default') }}
 								</option>
 							</select>
 						</div>
@@ -148,23 +148,23 @@
 
 				<!-- Item Discount Section (only if allowed by POS Profile) -->
 				<div v-if="settingsStore.allowItemDiscount" class="border-t border-gray-200 pt-4">
-					<label class="block text-sm font-medium text-gray-700 mb-3">Item Discount</label>
+					<label class="block text-sm font-medium text-gray-700 mb-3">{{ __('Item Discount') }}</label>
 					<div class="grid grid-cols-2 gap-3">
 						<!-- Discount Type -->
 						<div>
-							<label class="block text-xs text-gray-600 mb-1">Discount Type</label>
+							<label class="block text-xs text-gray-600 mb-1">{{ __('Discount Type') }}</label>
 							<select
 								v-model="discountType"
 								@change="handleDiscountTypeChange"
 								class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
 							>
-								<option value="percentage">Percentage (%)</option>
-								<option value="amount">Amount</option>
+								<option value="percentage">{{ __('Percentage (%)') }}</option>
+								<option value="amount">{{ __('Amount') }}</option>
 							</select>
 						</div>
 						<!-- Discount Value -->
 						<div>
-							<label class="block text-xs text-gray-600 mb-1">{{ discountType === 'percentage' ? 'Percentage' : 'Amount' }}</label>
+							<label class="block text-xs text-gray-600 mb-1">{{ discountType === 'percentage' ? __('Percentage') : __('Amount') }}</label>
 							<div class="relative">
 								<input
 									v-model.number="discountValue"
@@ -186,15 +186,15 @@
 				<!-- Totals -->
 				<div class="bg-gray-50 rounded-lg p-4 space-y-2">
 					<div class="flex items-center justify-between text-sm">
-						<span class="text-gray-600">Subtotal:</span>
+						<span class="text-gray-600">{{ __('Subtotal:') }}</span>
 						<span class="font-semibold text-gray-900">{{ formatCurrency(calculatedSubtotal) }}</span>
 					</div>
 					<div v-if="calculatedDiscount > 0" class="flex items-center justify-between text-sm text-red-600">
-						<span>Discount:</span>
+						<span>{{ __('Discount:') }}</span>
 						<span class="font-semibold">-{{ formatCurrency(calculatedDiscount) }}</span>
 					</div>
 					<div class="flex items-center justify-between pt-2 border-t border-gray-200">
-						<span class="text-base font-bold text-gray-900">Total:</span>
+						<span class="text-base font-bold text-gray-900">{{ __('Total:') }}</span>
 						<span class="text-lg font-bold text-blue-600">{{ formatCurrency(calculatedTotal) }}</span>
 					</div>
 				</div>
@@ -203,15 +203,15 @@
 
 		<template #actions>
 			<div class="flex items-center justify-end space-x-2">
-				<Button variant="subtle" @click="cancel">Cancel</Button>
+				<Button variant="subtle" @click="cancel">{{ __('Cancel') }}</Button>
 				<Button
 					variant="solid"
 					@click="updateItem"
 					:disabled="!hasStock || isCheckingStock"
 				>
-					<span v-if="isCheckingStock">Checking Stock...</span>
-					<span v-else-if="!hasStock">No Stock Available</span>
-					<span v-else>Update Item</span>
+					<span v-if="isCheckingStock">{{ __('Checking Stock...') }}</span>
+					<span v-else-if="!hasStock">{{ __('No Stock Available') }}</span>
+					<span v-else>{{ __('Update Item') }}</span>
 				</Button>
 			</div>
 		</template>
@@ -279,7 +279,7 @@ watch(
 		if (newItem) {
 			localItem.value = { ...newItem }
 			localQuantity.value = newItem.quantity || 1
-			localUom.value = newItem.uom || newItem.stock_uom || "Nos"
+			localUom.value = newItem.uom || newItem.stock_uom || __("Nos")
 			localRate.value = newItem.rate || 0
 			localWarehouse.value =
 				newItem.warehouse || props.warehouses[0]?.name || ""
@@ -398,17 +398,23 @@ async function handleWarehouseChange() {
 		if (availableStock === 0) {
 			hasStock.value = false
 			showError(
-				`"${localItem.value.item_name}" is not available in warehouse "${localWarehouse.value}". Please select another warehouse.`,
+				__('"{0}" is not available in warehouse "{1}". Please select another warehouse.', 
+				[localItem.value.item_name, localWarehouse.value])
 			)
 		} else if (availableStock < localQuantity.value) {
 			hasStock.value = false
 			showWarning(
-				`Only ${availableStock} units of "${localItem.value.item_name}" available in "${localWarehouse.value}". Current quantity: ${localQuantity.value}`,
+				__('Only {0} units of "{1}" available in "{2}". Current quantity: {3}', [
+					availableStock,
+					localItem.value.item_name,
+					localWarehouse.value,
+					localQuantity.value
+				])
 			)
 		} else {
 			hasStock.value = true
 			showSuccess(
-				`${availableStock} units available in "${localWarehouse.value}"`,
+				__('{0} units available in "{1}"', [availableStock, localWarehouse.value])
 			)
 		}
 	} catch (error) {

--- a/POS/src/components/sale/InvoiceCart.vue
+++ b/POS/src/components/sale/InvoiceCart.vue
@@ -26,7 +26,7 @@
 							type="button"
 							@click="$emit('create-customer', '')"
 							class="flex items-center justify-center w-10 h-10 bg-green-500 hover:bg-green-600 active:bg-green-700 rounded-xl text-white transition-colors shadow-sm hover:shadow touch-manipulation flex-shrink-0"
-							title="Create new customer"
+							:title="__('Create new customer')"
 						>
 							<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"/>
@@ -37,7 +37,7 @@
 							type="button"
 							@click="clearCustomer"
 							class="flex items-center justify-center w-10 h-10 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-xl flex-shrink-0 transition-colors touch-manipulation"
-							title="Remove customer"
+							:title="__('Remove customer')"
 						>
 							<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
@@ -64,11 +64,11 @@
 								:value="customerSearch"
 								@input="handleSearchInput"
 								type="text"
-								placeholder="Search or add customer..."
+								:placeholder="__('Search or add customer...')"
 								class="w-full h-11 pl-11 pr-4 text-sm border border-gray-200 rounded-xl bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent shadow-sm transition-shadow"
 								:disabled="!customersLoaded"
 								@keydown="handleKeydown"
-								aria-label="Search customer in cart"
+								:aria-label="__('Search customer in cart')"
 							/>
 						</div>
 
@@ -77,8 +77,8 @@
 							type="button"
 							@click="createNewCustomer"
 							class="flex items-center justify-center w-11 h-11 bg-green-500 hover:bg-green-600 active:bg-green-700 rounded-xl text-white transition-colors shadow-sm hover:shadow touch-manipulation flex-shrink-0"
-							title="Create new customer"
-							aria-label="Create new customer"
+							:title="__('Create new customer')"
+							:aria-label="__('Create new customer')"
 						>
 							<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"/>
@@ -116,7 +116,7 @@
 						<!-- No Results + Create New Option -->
 						<div v-else-if="customerSearch.trim().length >= 2">
 							<div class="px-3 py-2 text-center text-xs font-medium text-gray-700 border-b border-gray-100">
-								No results for "{{ customerSearch }}"
+								{{ __('No results for "{0}"', [customerSearch]) }}
 							</div>
 						</div>
 
@@ -133,7 +133,7 @@
 								</svg>
 							</div>
 							<div class="flex-1">
-								<p class="text-xs font-medium text-green-700">Create New Customer</p>
+								<p class="text-xs font-medium text-green-700">{{  __('Create New Customer') }}</p>
 								<p class="text-[10px] text-green-600">"{{ customerSearch }}"</p>
 							</div>
 						</button>
@@ -145,17 +145,17 @@
                 <!-- Action Buttons Section -->
                 <div v-if="items.length > 0" class="px-3 py-3 border-b border-gray-200 bg-white">
                         <div class="flex items-center justify-between mb-2.5">
-                                <h2 class="text-sm font-bold text-gray-900">Cart Items</h2>
+                                <h2 class="text-sm font-bold text-gray-900">{{ __('Cart Items') }}</h2>
                                 <button
                                         @click="$emit('clear-cart')"
                                         class="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold text-red-600 hover:bg-red-50 transition-colors touch-manipulation"
                                         type="button"
-                                        title="Clear all items"
+                                        :title="__('Clear all items')"
                                 >
                                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V5a2 2 0 00-2-2h-2a2 2 0 00-2 2v2M4 7h16"/>
                                         </svg>
-                                        <span>Clear</span>
+                                        <span>{{ __('Clear') }}</span>
                                 </button>
                         </div>
 
@@ -166,13 +166,13 @@
                                         type="button"
                                         @click="$emit('show-offers')"
                                         class="relative flex-1 flex items-center justify-between px-3 py-2.5 rounded-xl bg-white border border-gray-200 hover:border-green-400 hover:bg-green-50 hover:shadow-sm transition-all min-w-0 touch-manipulation"
-                                        :aria-label="'View all available offers'"
+                                        :aria-label="__('View all available offers')"
                                 >
                                         <div class="flex items-center gap-2 min-w-0 flex-1">
                                                 <svg class="w-4 h-4 text-green-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
                                                         <path stroke-linecap="round" stroke-linejoin="round" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/>
                                                 </svg>
-                                                <span class="text-xs font-semibold text-gray-700 truncate">Offers</span>
+                                                <span class="text-xs font-semibold text-gray-700 truncate">{{ __('Offers') }}</span>
                                         </div>
                                         <span
                                                 v-if="appliedOfferCount > 0 || offersStore.autoEligibleCount > 0"
@@ -187,13 +187,13 @@
                                         type="button"
                                         @click="$emit('apply-coupon')"
                                         class="relative flex-1 flex items-center justify-between px-3 py-2.5 rounded-xl bg-white border border-gray-200 hover:border-purple-400 hover:bg-purple-50 hover:shadow-sm transition-all min-w-0 touch-manipulation"
-                                        :aria-label="'Apply coupon code'"
+                                        :aria-label="__('Apply coupon code')"
                                 >
                                         <div class="flex items-center gap-2 min-w-0 flex-1">
                                                 <svg class="w-4 h-4 text-purple-600 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                                                         <path fill-rule="evenodd" d="M4 2a2 2 0 00-2 2v11a3 3 0 106 0V4a2 2 0 00-2-2H4zm1 14a1 1 0 100-2 1 1 0 000 2zm5-1.757l4.9-4.9a2 2 0 000-2.828L13.485 5.1a2 2 0 00-2.828 0L10 5.757v8.486zM16 18H9.071l6-6H16a2 2 0 012 2v2a2 2 0 01-2 2z" clip-rule="evenodd"/>
                                                 </svg>
-                                                <span class="text-xs font-semibold text-gray-700 truncate">Coupon</span>
+                                                <span class="text-xs font-semibold text-gray-700 truncate">{{ __('Coupon') }}</span>
                                         </div>
                                         <span v-if="availableGiftCards.length > 0" class="bg-purple-600 text-white text-xs font-bold rounded-full px-2 py-0.5 flex-shrink-0 min-w-[20px] text-center">
                                                 {{ availableGiftCards.length }}
@@ -221,9 +221,9 @@
 						/>
 					</svg>
 				</div>
-				<p class="text-xs sm:text-sm font-semibold text-gray-900 mb-1">Your cart is empty</p>
+				<p class="text-xs sm:text-sm font-semibold text-gray-900 mb-1">{{ __('Your cart is empty') }}</p>
 				<p class="text-[10px] sm:text-xs text-gray-500 mb-5 sm:mb-6">
-					Select items to start or choose a quick action
+					{{ __('Select items to start or choose a quick action') }}
 				</p>
 
 				<!-- Quick Actions Grid -->
@@ -233,7 +233,7 @@
 						type="button"
 						@click="$emit('view-shift')"
 						class="flex flex-col items-center justify-center p-3 sm:p-4 bg-white border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 active:bg-blue-100 transition-colors shadow-sm hover:shadow touch-manipulation group"
-						title="View current shift details"
+						:title="__('View current shift details')"
 					>
 						<div class="w-9 h-9 sm:w-10 sm:h-10 bg-blue-50 rounded-full flex items-center justify-center mb-2 group-hover:bg-blue-100 transition-colors">
 							<svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -241,7 +241,7 @@
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
 							</svg>
 						</div>
-						<span class="text-[11px] sm:text-xs font-semibold text-gray-700">View Shift</span>
+						<span class="text-[11px] sm:text-xs font-semibold text-gray-700">{{ __('View Shift') }}</span>
 					</button>
 
 					<!-- Draft Invoices -->
@@ -249,14 +249,14 @@
 						type="button"
 						@click="$emit('show-drafts')"
 						class="flex flex-col items-center justify-center p-3 sm:p-4 bg-white border border-gray-200 rounded-lg hover:border-purple-300 hover:bg-purple-50 active:bg-purple-100 transition-colors shadow-sm hover:shadow touch-manipulation group"
-						title="View draft invoices"
+						:title="__('View draft invoices')"
 					>
 						<div class="w-9 h-9 sm:w-10 sm:h-10 bg-purple-50 rounded-full flex items-center justify-center mb-2 group-hover:bg-purple-100 transition-colors">
 							<svg class="w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
 							</svg>
 						</div>
-						<span class="text-[11px] sm:text-xs font-semibold text-gray-700">Draft Invoices</span>
+						<span class="text-[11px] sm:text-xs font-semibold text-gray-700">{{ __('Draft Invoices') }}</span>
 					</button>
 
 					<!-- Invoice History -->
@@ -264,14 +264,14 @@
 						type="button"
 						@click="$emit('show-history')"
 						class="flex flex-col items-center justify-center p-3 sm:p-4 bg-white border border-gray-200 rounded-lg hover:border-gray-300 hover:bg-gray-50 active:bg-gray-100 transition-colors shadow-sm hover:shadow touch-manipulation group"
-						title="View invoice history"
+						:title="__('View invoice history')"
 					>
 						<div class="w-9 h-9 sm:w-10 sm:h-10 bg-gray-50 rounded-full flex items-center justify-center mb-2 group-hover:bg-gray-100 transition-colors">
 							<svg class="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
 							</svg>
 						</div>
-						<span class="text-[11px] sm:text-xs font-semibold text-gray-700">Invoice History</span>
+						<span class="text-[11px] sm:text-xs font-semibold text-gray-700">{{ __('Invoice History') }}</span>
 					</button>
 
 					<!-- Return Invoice -->
@@ -279,14 +279,14 @@
 						type="button"
 						@click="$emit('show-return')"
 						class="flex flex-col items-center justify-center p-3 sm:p-4 bg-white border border-gray-200 rounded-lg hover:border-red-300 hover:bg-red-50 active:bg-red-100 transition-colors shadow-sm hover:shadow touch-manipulation group"
-						title="Process return invoice"
+						:title="__('Process return invoice')"
 					>
 						<div class="w-9 h-9 sm:w-10 sm:h-10 bg-red-50 rounded-full flex items-center justify-center mb-2 group-hover:bg-red-100 transition-colors">
 							<svg class="w-5 h-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/>
 							</svg>
 						</div>
-						<span class="text-[11px] sm:text-xs font-semibold text-gray-700">Return Invoice</span>
+						<span class="text-[11px] sm:text-xs font-semibold text-gray-700">{{ __('Return Invoice') }}</span>
 					</button>
 
 					<!-- Close Shift -->
@@ -294,14 +294,14 @@
 						type="button"
 						@click="$emit('close-shift')"
 						class="flex flex-col items-center justify-center p-3 sm:p-4 bg-white border border-gray-200 rounded-lg hover:border-orange-300 hover:bg-orange-50 active:bg-orange-100 transition-colors shadow-sm hover:shadow touch-manipulation group"
-						title="Close current shift"
+						:title="__('Close current shift')"
 					>
 						<div class="w-9 h-9 sm:w-10 sm:h-10 bg-orange-50 rounded-full flex items-center justify-center mb-2 group-hover:bg-orange-100 transition-colors">
 							<svg class="w-5 h-5 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
 							</svg>
 						</div>
-						<span class="text-[11px] sm:text-xs font-semibold text-gray-700">Close Shift</span>
+						<span class="text-[11px] sm:text-xs font-semibold text-gray-700">{{ __('Close Shift') }}</span>
 					</button>
 
 					<!-- Create Customer -->
@@ -309,14 +309,14 @@
 						type="button"
 						@click="$emit('create-customer', '')"
 						class="flex flex-col items-center justify-center p-3 sm:p-4 bg-white border border-gray-200 rounded-lg hover:border-green-300 hover:bg-green-50 active:bg-green-100 transition-colors shadow-sm hover:shadow touch-manipulation group"
-						title="Create new customer"
+						:title="__('Create new customer')"
 					>
 						<div class="w-9 h-9 sm:w-10 sm:h-10 bg-green-50 rounded-full flex items-center justify-center mb-2 group-hover:bg-green-100 transition-colors">
 							<svg class="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"/>
 							</svg>
 						</div>
-						<span class="text-[11px] sm:text-xs font-semibold text-gray-700">Create Customer</span>
+						<span class="text-[11px] sm:text-xs font-semibold text-gray-700">{{ __('Create Customer') }}</span>
 					</button>
 				</div>
 			</div>
@@ -369,20 +369,20 @@
 									<span
 										v-if="item.free_qty && item.free_qty > 0"
 										class="inline-flex items-center px-1.5 py-0.5 bg-green-600 text-white rounded-full text-[9px] font-bold flex-shrink-0"
-										:title="`${item.free_qty} free item(s) included`"
+										:title="__('{0} free item(s) included', [item.free_qty])"
 									>
 										<svg class="w-2.5 h-2.5 mr-0.5" fill="currentColor" viewBox="0 0 20 20">
 											<path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd"/>
 										</svg>
-										+{{ item.free_qty }} FREE
+										{{ __('+{0} FREE',  [item.free_qty]) }}
 									</span>
 								</div>
 								<button
 									type="button"
 									@click.stop="$emit('remove-item', item.item_code)"
 									class="text-gray-400 hover:text-red-600 active:text-red-700 transition-colors flex-shrink-0 p-0.5 -m-0.5 touch-manipulation active:scale-90"
-									:aria-label="'Remove ' + item.item_name"
-									title="Remove item"
+									:aria-label="__('Remove {0}', [item.item_name])"
+									:title="__('Remove item')"
 								>
 									<svg class="h-4 w-4 sm:h-4.5 sm:w-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
@@ -398,7 +398,7 @@
 									</span>
 									<span class="text-[10px] text-gray-500">/</span>
 									<span class="inline-flex items-center px-1.5 py-0.5 bg-gray-100 text-gray-700 rounded text-[10px] sm:text-xs font-semibold">
-										{{ item.uom || item.stock_uom || 'Nos' }}
+										{{ item.uom || item.stock_uom || __('Nos', null, 'UOM') }}
 									</span>
 								</div>
 
@@ -410,7 +410,7 @@
 									<svg class="w-2 h-2 mr-0.5" fill="currentColor" viewBox="0 0 20 20">
 										<path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 000 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
 									</svg>
-									{{ Number(item.discount_percentage).toFixed(2) }}% OFF
+									{{ __('{0}% OFF', [Number(item.discount_percentage).toFixed(2)]) }}
 								</div>
 							</div>
 
@@ -423,8 +423,8 @@
 											type="button"
 											@click="decrementQuantity(item)"
 											class="w-7 h-7 sm:w-8 sm:h-8 bg-white hover:bg-gray-100 active:bg-gray-200 flex items-center justify-center font-bold text-gray-700 transition-colors touch-manipulation border-r-2 border-gray-200"
-											:aria-label="'Decrease quantity'"
-											title="Decrease quantity"
+											:aria-label="__('Decrease quantity')"
+											:title="__('Decrease quantity')"
 										>
 											<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M20 12H4"/>
@@ -440,14 +440,14 @@
 											step="any"
 											inputmode="decimal"
 											class="w-16 sm:w-20 text-center bg-white border-0 text-sm sm:text-base font-bold text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-											:aria-label="'Quantity'"
+											:aria-label="__('Quantity')"
 										/>
 										<button
 											type="button"
 											@click="incrementQuantity(item)"
 											class="w-7 h-7 sm:w-8 sm:h-8 bg-white hover:bg-gray-100 active:bg-gray-200 flex items-center justify-center font-bold text-gray-700 transition-colors touch-manipulation border-l-2 border-gray-200"
-											:aria-label="'Increase quantity'"
-											title="Increase quantity"
+											:aria-label="__('Increase quantity')"
+											:title="__('Increase quantity')"
 										>
 											<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M12 4v16m8-8H4"/>
@@ -468,9 +468,9 @@
 													? 'bg-gradient-to-br from-blue-500 to-blue-600 text-white border-2 border-blue-400 hover:from-blue-600 hover:to-blue-700 hover:border-blue-500 hover:shadow-md active:scale-95 cursor-pointer'
 													: 'bg-gray-100 text-gray-500 border-2 border-gray-200 cursor-not-allowed opacity-60'
 											]"
-											:title="item.item_uoms && item.item_uoms.length > 0 ? 'Click to change unit' : 'Only one unit available'"
+											:title="item.item_uoms && item.item_uoms.length > 0 ? __('Click to change unit') : __('Only one unit available')"
 										>
-											{{ item.uom || item.stock_uom || 'Nos' }}
+											{{ item.uom || item.stock_uom || __('Nos', null, 'UOM') }}
 										</button>
 
 										<!-- Dropdown Arrow Icon -->
@@ -504,7 +504,7 @@
 												]"
 											>
 												<div class="flex items-center justify-between">
-													<span>{{ item.stock_uom || 'Nos' }}</span>
+													<span>{{ item.stock_uom || __('Nos', null, 'UOM') }}</span>
 													<svg
 														v-if="(item.uom || item.stock_uom) === item.stock_uom"
 														class="w-4 h-4 text-blue-600"
@@ -547,7 +547,7 @@
 
 								<!-- Item Total Price -->
 								<div class="text-right">
-									<div class="text-[9px] text-gray-500 leading-none mb-0.5">Total</div>
+									<div class="text-[9px] text-gray-500 leading-none mb-0.5">{{ __('Total') }}</div>
 									<div class="text-xs sm:text-sm font-bold text-blue-600 leading-none">
 										{{ formatCurrency(item.amount || item.rate * item.quantity) }}
 									</div>
@@ -564,11 +564,11 @@
 			<!-- Summary Details -->
 			<div v-if="items.length > 0" class="mb-2.5">
 				<div class="flex items-center justify-between text-[10px] text-gray-600 mb-1">
-					<span>Total Quantity</span>
+					<span>{{ __('Total Quantity') }}</span>
 					<span class="font-medium text-gray-900">{{ formatQuantity(totalQuantity) }}</span>
 				</div>
 				<div class="flex items-center justify-between text-[10px] text-gray-600 mb-2">
-					<span>Subtotal</span>
+					<span>{{ __('Subtotal') }}</span>
 					<span class="font-medium text-gray-900">{{ formatCurrency(subtotal) }}</span>
 				</div>
 			</div>
@@ -581,7 +581,7 @@
 						<svg class="w-3 h-3 text-red-600" fill="currentColor" viewBox="0 0 20 20">
 							<path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 000 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
 						</svg>
-						<span class="text-[10px] font-semibold text-red-700">Discount</span>
+						<span class="text-[10px] font-semibold text-red-700">{{ __('Discount') }}</span>
 					</div>
 					<span class="text-xs font-bold text-red-600">{{ formatCurrency(discountAmount) }}</span>
 				</div>
@@ -591,7 +591,7 @@
 						<svg class="w-3 h-3 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
 						</svg>
-						<span>Tax</span>
+						<span>{{ __('Tax') }}</span>
 					</div>
 					<span class="font-medium text-gray-900">{{ formatCurrency(taxAmount) }}</span>
 				</div>
@@ -600,7 +600,7 @@
 			<!-- Grand Total -->
 			<div class="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-lg p-2.5 mb-2.5">
 				<div class="flex items-center justify-between">
-					<span class="text-sm font-bold text-gray-900">Grand Total</span>
+					<span class="text-sm font-bold text-gray-900">{{ __('Grand Total') }}</span>
 					<span class="text-lg font-bold text-blue-600">
 						{{ formatCurrency(grandTotal) }}
 					</span>
@@ -620,12 +620,12 @@
 							? 'bg-gray-300 cursor-not-allowed'
 							: 'bg-blue-600 hover:bg-blue-700 active:bg-blue-800 shadow-lg hover:shadow-xl active:scale-[0.98]'
 					]"
-					:aria-label="'Proceed to payment'"
+					:aria-label="__('Proceed to payment')"
 				>
 					<svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/>
 					</svg>
-					<span>Checkout</span>
+					<span>{{ __('Checkout') }}</span>
 				</button>
 
 				<!-- Hold Order Button (Secondary - 50% width) -->
@@ -634,12 +634,12 @@
 					v-if="items.length > 0"
 					@click="$emit('save-draft')"
 					class="flex-1 py-3 px-3 rounded-xl font-semibold text-sm text-orange-700 bg-orange-50 hover:bg-orange-100 active:bg-orange-200 transition-all touch-manipulation active:scale-[0.98] flex items-center justify-center"
-					:aria-label="'Hold order as draft'"
+					:aria-label="__('Hold order as draft')"
 				>
 					<svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
 					</svg>
-					<span>Hold</span>
+					<span>{{ __('Hold', null, 'order') }}</span>
 				</button>
 			</div>
 		</div>

--- a/POS/src/components/sale/InvoiceHistoryDialog.vue
+++ b/POS/src/components/sale/InvoiceHistoryDialog.vue
@@ -1,7 +1,7 @@
 <template>
 	<Dialog
 		v-model="show"
-		:options="{ title: 'Invoice History', size: 'xl' }"
+		:options="{ title: __('Invoice History'), size: 'xl' }"
 	>
 		<template #body-content>
 			<div class="space-y-4">
@@ -11,7 +11,7 @@
 						<Input
 							v-model="searchTerm"
 							type="text"
-							placeholder="Search by invoice number or customer..."
+							:placeholder="__('Search by invoice number or customer...')"
 							@input="searchInvoices"
 						>
 							<template #prefix>
@@ -22,21 +22,21 @@
 						</Input>
 					</div>
 					<Button @click="loadInvoices" :loading="invoicesResource.loading">
-						Refresh
+						{{ __('Refresh') }}
 					</Button>
 				</div>
 
 				<!-- Invoices List -->
 				<div v-if="invoicesResource.loading" class="text-center py-8">
 					<div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"></div>
-					<p class="mt-3 text-xs text-gray-500">Loading invoices...</p>
+					<p class="mt-3 text-xs text-gray-500">{{ __('Loading invoices...') }}</p>
 				</div>
 
 				<div v-else-if="filteredInvoices.length === 0" class="text-center py-8">
 					<svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
 					</svg>
-					<p class="mt-2 text-sm text-gray-500">No invoices found</p>
+					<p class="mt-2 text-sm text-gray-500">{{ __('No invoices found') }}</p>
 				</div>
 
 				<div v-else class="space-y-2 max-h-96 overflow-y-auto">
@@ -56,7 +56,7 @@
 										v-if="invoice.is_return"
 										class="text-xs px-2 py-0.5 rounded-full font-medium bg-red-100 text-red-800"
 									>
-										Return
+										{{ __('Return') }}
 									</span>
 									<!-- Otherwise show regular status badge -->
 									<span
@@ -76,7 +76,7 @@
 								<div class="flex items-center space-x-4 text-xs text-gray-600">
 									<span>{{ invoice.customer_name }}</span>
 									<span>{{ formatDateTime(invoice.posting_date, invoice.posting_time) }}</span>
-									<span v-if="invoice.items_count">{{ invoice.items_count }} item(s)</span>
+									<span v-if="invoice.items_count">{{ __('{0} item(s)', [invoice.items_count]) }}</span>
 								</div>
 							</div>
 
@@ -88,7 +88,7 @@
 									<button
 										@click="viewInvoice(invoice)"
 										class="p-1.5 hover:bg-blue-50 rounded transition-colors"
-										title="View Details"
+										:title="__('View Details')"
 									>
 										<svg class="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
@@ -98,7 +98,7 @@
 									<button
 										@click="printInvoice(invoice)"
 										class="p-1.5 hover:bg-green-50 rounded transition-colors"
-										title="Print"
+										:title="__('Print')"
 									>
 										<svg class="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
@@ -108,7 +108,7 @@
 										v-if="invoice.docstatus === 1 && !invoice.is_return"
 										@click="createReturn(invoice)"
 										class="p-1.5 hover:bg-orange-50 rounded transition-colors"
-										title="Create Return"
+										:title="__('Create Return')"
 									>
 										<svg class="w-4 h-4 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/>
@@ -123,14 +123,14 @@
 				<!-- Load More -->
 				<div v-if="hasMore && !invoicesResource.loading" class="text-center">
 					<Button variant="subtle" @click="loadMore">
-						Load More
+						{{ __('Load More') }}
 					</Button>
 				</div>
 			</div>
 		</template>
 		<template #actions>
 			<Button variant="subtle" @click="show = false">
-				Close
+				{{ __('Close') }}
 			</Button>
 		</template>
 	</Dialog>
@@ -198,7 +198,7 @@ const invoicesResource = createResource({
 	},
 	onError(error) {
 		console.error("Error loading invoices:", error)
-		showError("Failed to load invoices")
+		showError(__("Failed to load invoices"))
 	},
 })
 

--- a/POS/src/components/sale/ItemSelectionDialog.vue
+++ b/POS/src/components/sale/ItemSelectionDialog.vue
@@ -21,7 +21,7 @@
 				<!-- Loading State -->
 				<div v-if="loading" class="flex items-center justify-center py-8">
 					<div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
-					<p class="ml-3 text-sm text-gray-500">Loading options...</p>
+					<p class="ml-3 text-sm text-gray-500">{{ __('Loading options...') }}</p>
 				</div>
 
 				<!-- Variant Options with Attribute Selection -->
@@ -67,7 +67,7 @@
 							<div class="text-right">
 								<p class="text-sm font-bold text-blue-600">{{ formatCurrency(matchedVariant.rate || 0) }}</p>
 								<p class="text-xs" :class="(matchedVariant.stock ?? matchedVariant.data?.actual_qty ?? 0) > 0 ? 'text-green-600' : 'text-red-600'">
-									Stock: {{ matchedVariant.stock ?? matchedVariant.data?.actual_qty ?? 0 }}
+									 {{ __('Stock: {0}', [(matchedVariant.stock ?? matchedVariant.data?.actual_qty ?? 0)]) }}
 								</p>
 							</div>
 						</div>
@@ -75,7 +75,7 @@
 
 					<!-- Warning if combination not found -->
 					<div v-else-if="allAttributesSelected" class="mt-4 p-3 bg-orange-50 border border-orange-200 rounded-lg">
-						<p class="text-xs text-orange-700">This combination is not available</p>
+						<p class="text-xs text-orange-700">{{ __('This combination is not available') }}</p>
 					</div>
 				</div>
 
@@ -114,20 +114,36 @@
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
 						</svg>
 					</div>
-					<p class="text-sm font-medium text-gray-900">No {{ mode === 'variant' ? 'Variants' : 'Options' }} Available</p>
+					<p class="text-sm font-medium text-gray-900">
+						{{ mode === 'variant'
+							? __('No Variants Available')
+							: __('No Options Available')
+						}}
+					</p>
 					<p v-if="mode === 'variant'" class="text-xs text-gray-500 mt-2">
-						This item template <strong>{{ item?.item_name }}</strong> has no variants created yet.
+						<TranslatedHTML 
+							:inner="__('This item template &lt;strong&gt;{0}&lt;strong&gt; has no variants created yet.', [item?.item_name])"
+						/>
 					</p>
 					<p v-else class="text-xs text-gray-500 mt-2">
-						No additional unit of measures configured for this item.
+						{{ __('No additional units of measurement configured for this item.') }}
 					</p>
 					<div v-if="mode === 'variant'" class="mt-4">
-						<p class="text-xs text-gray-600 mb-2">To create variants:</p>
+						<p class="text-xs text-gray-600 mb-2">{{ __('To create variants:') }}</p>
 						<ol class="text-xs text-gray-600 text-left max-w-xs mx-auto space-y-1">
-							<li>1. Go to <strong>Item Master</strong> → <strong>{{ item?.item_code }}</strong></li>
-							<li>2. Click <strong>"Make Variants"</strong> button</li>
-							<li>3. Select attribute combinations</li>
-							<li>4. Click <strong>"Create"</strong></li>
+							<TranslatedHTML 
+								:tag="'li'"
+								:inner="__('1. Go to &lt;strong&gt;Item Master&lt;strong&gt; → &lt;strong&gt;{0}&lt;strong&gt;', [item?.item_code])"
+							/>
+							<TranslatedHTML
+								:tag="'li'"
+								:inner="__('2. Click &lt;strong&gt;&quot;Make Variants&quot;&lt;strong&gt; button')"
+							/>
+							<li>{{ __('3. Select attribute combinations') }}</li>
+							<TranslatedHTML
+								:tag="'li'"
+								:inner="__('4. Click &lt;strong&gt;&quot;Create&quot;&lt;strong&gt;')"
+							/>
 						</ol>
 					</div>
 				</div>
@@ -137,7 +153,7 @@
 		<template #actions>
 			<div class="flex space-x-2 w-full">
 				<Button class="flex-1" variant="subtle" @click="cancel">
-					Cancel
+					{{ __('Cancel') }}
 				</Button>
 				<Button class="flex-1" variant="solid" theme="blue" @click="confirm" :disabled="!selectedOption">
 					{{ confirmButtonText }}
@@ -152,6 +168,7 @@ import { formatCurrency as formatCurrencyUtil } from "@/utils/currency"
 import { Button, Dialog } from "frappe-ui"
 import { createResource } from "frappe-ui"
 import { computed, ref, watch } from "vue"
+import TranslatedHTML from "../common/TranslatedHTML.vue"
 
 const props = defineProps({
 	modelValue: Boolean,
@@ -182,18 +199,18 @@ const selectedAttributes = ref({}) // For variant attribute selection
 // Computed properties for dialog customization
 const dialogTitle = computed(() => {
 	return props.mode === "variant"
-		? "Select Item Variant"
-		: "Select Unit of Measure"
+		? __("Select Item Variant")
+		: __("Select Unit of Measure")
 })
 
 const dialogDescription = computed(() => {
 	return props.mode === "variant"
-		? "Choose a variant of this item:"
-		: "Select the unit of measure for this item:"
+		? __("Choose a variant of this item:")
+		: __("Select the unit of measure for this item:")
 })
 
 const confirmButtonText = computed(() => {
-	return props.mode === "variant" ? "Add to Cart" : "Add to Cart"
+	return props.mode === "variant" ? __("Add to Cart") : __("Add to Cart")
 })
 
 // Computed: Build a map of all available attribute values
@@ -258,7 +275,7 @@ const variantsResource = createResource({
 			description: v.item_code,
 			attributes: v.attributes || {},
 			rate: v.rate || 0,
-			priceLabel: `per ${v.stock_uom}`,
+			priceLabel: __('per {0}', [v.stock_uom]),
 			stock: v.actual_qty ?? 0,
 			data: v, // Full variant data
 		}))
@@ -322,9 +339,9 @@ function buildUomOptions() {
 		uom: props.item.stock_uom,
 		conversion_factor: 1,
 		label: props.item.stock_uom,
-		description: "Stock unit",
+		description: __("Stock unit"),
 		rate: getUomPrice(props.item.stock_uom, 1),
-		priceLabel: `per ${props.item.stock_uom}`,
+		priceLabel: __('per {0}', [props.item.stock_uom]),
 	})
 
 	// Additional UOMs
@@ -337,7 +354,7 @@ function buildUomOptions() {
 				label: uomData.uom,
 				description: `1 ${uomData.uom} = ${uomData.conversion_factor} ${props.item.stock_uom}`,
 				rate: getUomPrice(uomData.uom, uomData.conversion_factor),
-				priceLabel: `per ${uomData.uom}`,
+				priceLabel: __('per {0}', [uomData.uom]),
 			})
 		})
 	}

--- a/POS/src/components/sale/ItemsSelector.vue
+++ b/POS/src/components/sale/ItemsSelector.vue
@@ -15,7 +15,7 @@
 					<svg class="w-3.5 h-3.5 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
 					</svg>
-					<span>All Items</span>
+					<span>{{ __('All Items') }}</span>
 				</button>
 				<button
 					v-for="group in itemGroups"
@@ -28,7 +28,7 @@
 							: 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50 active:bg-gray-100',
 					]"
 				>
-					<span>{{ group.item_group }}</span>
+					<span>{{ __(group.item_group) }}</span>
 				</button>
 			</div>
 		</div>
@@ -37,7 +37,7 @@
 		<div v-if="cacheSyncing" class="px-1.5 sm:px-3 py-1 bg-blue-50 border-b border-blue-200">
 			<div class="flex items-center justify-center space-x-2 text-[10px] sm:text-xs text-blue-700">
 				<div class="animate-spin rounded-full h-3 w-3 border-b-2 border-blue-600"></div>
-				<span>Syncing catalog in background... {{ cacheStats.items }} items cached</span>
+				<span>{{ __('Syncing catalog in background... {0} items cached', [cacheStats.items]) }}</span>
 			</div>
 		</div>
 
@@ -79,7 +79,7 @@
 								? 'border-green-400 bg-green-50 focus:ring-2 focus:ring-green-500 focus:border-transparent'
 								: 'border-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-transparent'
 						]"
-						aria-label="Search items"
+						:aria-label="__('Search items')"
 					/>
 					<!-- Barcode Scan Icon and Auto-Add Toggle -->
 					<div class="absolute inset-y-0 right-0 pr-1 sm:pr-2 flex items-center gap-0.5">
@@ -91,8 +91,8 @@
 									? 'bg-green-100 hover:bg-green-200 active:bg-green-300 text-green-700'
 									: 'hover:bg-gray-100 active:bg-gray-200 text-gray-600'
 							]"
-							:title="scannerEnabled ? 'Barcode Scanner: ON (Click to disable)' : 'Barcode Scanner: OFF (Click to enable)'"
-							:aria-label="scannerEnabled ? 'Disable barcode scanner' : 'Enable barcode scanner'"
+							:title="scannerEnabled ? __('Barcode Scanner: ON (Click to disable)') : __('Barcode Scanner: OFF (Click to enable)')"
+							:aria-label="scannerEnabled ? __('Disable barcode scanner') : __('Enable barcode scanner')"
 						>
 							<svg class="w-3.5 h-3.5 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"/>
@@ -106,13 +106,13 @@
 									? 'bg-blue-100 hover:bg-blue-200 active:bg-blue-300 text-blue-700'
 									: 'hover:bg-gray-100 active:bg-gray-200 text-gray-600'
 							]"
-							:title="autoAddEnabled ? 'Auto-Add: ON - Press Enter to add items to cart' : 'Auto-Add: OFF - Click to enable automatic cart addition on Enter'"
-							:aria-label="autoAddEnabled ? 'Disable auto-add' : 'Enable auto-add'"
+							:title="autoAddEnabled ? __('Auto-Add: ON - Press Enter to add items to cart') : __('Auto-Add: OFF - Click to enable automatic cart addition on Enter')"
+							:aria-label="autoAddEnabled ? __('Disable auto-add') : __('Enable auto-add')"
 						>
 							<svg class="w-3 h-3 sm:w-3.5 sm:h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
 							</svg>
-							<span class="hidden xs:inline">Auto</span>
+							<span class="hidden xs:inline">{{ __('Auto') }}</span>
 						</button>
 					</div>
 				</div>
@@ -123,8 +123,8 @@
 							'p-1.5 sm:p-2 rounded transition-[background-color,box-shadow] duration-75 touch-manipulation',
 							viewMode === 'grid' ? 'bg-white shadow-sm' : 'hover:bg-gray-200 active:bg-gray-300'
 						]"
-						title="Grid View"
-						:aria-label="'Switch to grid view'"
+						:title="__('Grid View')"
+						:aria-label="__('Switch to grid view')"
 					>
 						<svg class="w-4 h-4 sm:w-4.5 sm:h-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>
@@ -136,8 +136,8 @@
 							'p-1.5 sm:p-2 rounded transition-[background-color,box-shadow] duration-75 touch-manipulation',
 							viewMode === 'list' ? 'bg-white shadow-sm' : 'hover:bg-gray-200 active:bg-gray-300'
 						]"
-						title="List View"
-						:aria-label="'Switch to list view'"
+						:title="__('List View')"
+						:aria-label="__('Switch to list view')"
 					>
 						<svg class="w-4 h-4 sm:w-4.5 sm:h-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
@@ -155,8 +155,12 @@
 								? 'bg-blue-50 border-blue-400 text-blue-700 shadow-sm'
 								: 'bg-white border-gray-300 text-gray-600 hover:bg-gray-50 active:bg-gray-100'
 						]"
-						:title="sortBy ? `Sorted by ${getSortLabel(sortBy)} (${sortOrder === 'asc' ? 'A-Z' : 'Z-A'})` : 'Sort items'"
-						:aria-label="'Sort items'"
+						:title="sortBy 
+							? (sortOrder === 'asc'
+								? __('Sorted by {0} A-Z', [getSortLabel(sortBy)])
+								: __('Sorted by {0} Z-A', [getSortLabel(sortBy)])) 
+							: __('Sort items')"
+						:aria-label="__('Sort items')"
 					>
 						<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>
@@ -172,7 +176,7 @@
 					>
 						<div class="py-2">
 							<div class="px-3 py-2 text-xs font-semibold text-gray-500 uppercase border-b border-gray-100">
-								Sort Items
+								{{ __('Sort Items') }}
 							</div>
 							<div class="py-1">
 								<!-- Clear Sort -->
@@ -187,7 +191,7 @@
 										<svg class="w-4 h-4 text-gray-400 group-hover:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
 										</svg>
-										<span>No Sorting</span>
+										<span>{{ __('No Sorting') }}</span>
 									</span>
 								</button>
 
@@ -231,7 +235,7 @@
 		<div v-if="loading && !filteredItems" class="flex-1 flex items-center justify-center p-3">
 			<div class="text-center py-8">
 				<div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"></div>
-				<p class="mt-3 text-xs text-gray-500">Loading items...</p>
+				<p class="mt-3 text-xs text-gray-500">{{ __('Loading items...') }}</p>
 			</div>
 		</div>
 
@@ -255,9 +259,11 @@
 					/>
 				</svg>
 				<p v-if="searchTerm || selectedItemGroup" class="mt-2 text-xs font-medium text-gray-700">
-					No results for <span v-if="searchTerm">"{{ searchTerm }}"</span><span v-if="searchTerm && selectedItemGroup"> in </span><span v-if="selectedItemGroup">{{ selectedItemGroup }}</span>
+					<span v-if="searchTerm && selectedItemGroup">{{ __('No results for {0} in {1}', [searchTerm, selectedItemGroup]) }}</span>
+					<span v-else-if="selectedItemGroup">{{ __('No results in {0}', [selectedItemGroup]) }}</span>
+					<span v-else>{{ __('No results for {0}', [searchTerm]) }}</span>
 				</p>
-				<p v-else class="mt-2 text-xs text-gray-500">No items available</p>
+				<p v-else class="mt-2 text-xs text-gray-500">{{ __('No items available') }}</p>
 			</div>
 		</div>
 
@@ -292,7 +298,11 @@
 								getStockStatus(item.actual_qty ?? item.stock_qty ?? 0).color,
 								getStockStatus(item.actual_qty ?? item.stock_qty ?? 0).textColor
 							]"
-							:title="`${getStockStatus(item.actual_qty ?? item.stock_qty ?? 0).label}: ${Math.floor(item.actual_qty ?? item.stock_qty ?? 0)} ${item.is_bundle ? 'Bundles' : (item.uom || item.stock_uom || 'Nos')}`"
+							:title="__('{0}: {1} {2}', [
+								getStockStatus(item.actual_qty ?? item.stock_qty ?? 0).label,
+								Math.floor(item.actual_qty ?? item.stock_qty ?? 0),
+								(item.uom || item.stock_uom || __('Nos', null, 'UOM'))
+							], 'stock with uom')"
 						>
 							{{ Math.floor(item.actual_qty ?? item.stock_qty ?? 0) }}
 						</div>
@@ -350,8 +360,8 @@
 								v-if="(item.is_stock_item || item.is_bundle) && (item.actual_qty ?? item.stock_qty ?? 0) <= 0"
 								@click.stop="showWarehouseAvailability(item)"
 								class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-10"
-								title="Check availability in other warehouses"
-								aria-label="Check warehouse availability"
+								:title="__('Check availability in other warehouses')"
+								:aria-label="__('Check warehouse availability')"
 							>
 								<div class="p-2.5 bg-white/80 backdrop-blur-sm rounded-full">
 									<svg class="w-6 h-6 sm:w-7 sm:h-7 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
@@ -366,10 +376,10 @@
 							<h3 class="text-[10px] sm:text-xs font-semibold text-gray-900 truncate mb-0.5 leading-tight">
 								{{ item.item_name }}
 							</h3>
-                                                        <p class="text-[9px] sm:text-[10px] text-gray-500 leading-tight">
-                                                                <span class="font-semibold text-blue-600">{{ formatCurrency(item.rate || item.price_list_rate || 0) }}</span>
-                                                                <span class="text-gray-400">/ {{ item.uom || item.stock_uom || 'Nos' }}</span>
-                                                        </p>
+							<p class="text-[9px] sm:text-[10px] text-gray-500 leading-tight">
+									<span class="font-semibold text-blue-600">{{ formatCurrency(item.rate || item.price_list_rate || 0) }}</span>
+									<span class="text-gray-400">/ {{ item.uom || item.stock_uom || __('Nos', null, 'UOM') }}</span>
+							</p>
 						</div>
 					</div>
 				</div>
@@ -377,17 +387,17 @@
 				<!-- Loading More Indicator for Grid View -->
 				<div v-if="loadingMore" class="flex justify-center items-center py-4">
 					<div class="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
-					<p class="ml-2 text-xs text-gray-500">Loading more items...</p>
+					<p class="ml-2 text-xs text-gray-500">{{ __('Loading more items...') }}</p>
 				</div>
 
 				<!-- End of Results Indicator - Only show on last page or when all items fit in one page -->
 				<div v-else-if="!hasMore && filteredItems.length > 0 && !searchTerm && (currentPage === totalPages || totalPages === 1)" class="flex justify-center items-center py-3">
-					<p class="text-xs text-gray-400">All items loaded</p>
+					<p class="text-xs text-gray-400">{{ __('All items loaded') }}</p>
 				</div>
 
 				<!-- Search Results Count -->
 				<div v-else-if="searchTerm && filteredItems.length > 0" class="flex justify-center items-center py-3">
-					<p class="text-xs text-gray-500">{{ filteredItems.length }} items found</p>
+					<p class="text-xs text-gray-500">{{ __('{0} items found', [filteredItems.length]) }}</p>
 				</div>
 			</div>
 
@@ -395,7 +405,11 @@
 			<div v-if="totalPages > 1" class="px-2 sm:px-3 py-2 bg-white border-t border-gray-200">
 				<div class="flex flex-col sm:flex-row items-center justify-between gap-2">
 					<div class="text-[10px] sm:text-xs text-gray-600 order-2 sm:order-1">
-						{{ ((currentPage - 1) * itemsPerPage) + 1 }}-{{ Math.min(currentPage * itemsPerPage, filteredItems.length) }} of {{ filteredItems.length }}
+						{{ __('{0} - {1} of {2}', [
+							(((currentPage - 1) * itemsPerPage) + 1),
+							Math.min(currentPage * itemsPerPage, filteredItems.length),
+							filteredItems.length
+						]) }}
 					</div>
 					<div class="flex items-center space-x-1 order-1 sm:order-2">
 						<button
@@ -407,9 +421,9 @@
 									? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
 									: 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 active:bg-gray-100'
 							]"
-							:aria-label="'Go to first page'"
+							:aria-label="__('Go to first page')"
 						>
-							<span class="hidden xs:inline">First</span>
+							<span class="hidden xs:inline">{{ __('First') }}</span>
 							<span class="xs:hidden">«</span>
 						</button>
 						<button
@@ -421,9 +435,9 @@
 									? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
 									: 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 active:bg-gray-100'
 							]"
-							:aria-label="'Go to previous page'"
+							:aria-label="__('Go to previous page')"
 						>
-							<span class="hidden xs:inline">Previous</span>
+							<span class="hidden xs:inline">{{ __('Previous') }}</span>
 							<span class="xs:hidden">‹</span>
 						</button>
 						<div class="flex items-center space-x-0.5 sm:space-x-1">
@@ -437,7 +451,7 @@
 										? 'bg-blue-600 text-white border-blue-600'
 										: 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 active:bg-gray-100'
 								]"
-								:aria-label="'Go to page ' + page"
+								:aria-label="__('Go to page {0}', [page])"
 							>
 								{{ page }}
 							</button>
@@ -451,9 +465,9 @@
 									? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
 									: 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 active:bg-gray-100'
 							]"
-							:aria-label="'Go to next page'"
+							:aria-label="__('Go to next page')"
 						>
-							<span class="hidden xs:inline">Next</span>
+							<span class="hidden xs:inline">{{ __('Next') }}</span>
 							<span class="xs:hidden">›</span>
 						</button>
 						<button
@@ -465,9 +479,9 @@
 									? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
 									: 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 active:bg-gray-100'
 							]"
-							:aria-label="'Go to last page'"
+							:aria-label="__('Go to last page')"
 						>
-							<span class="hidden xs:inline">Last</span>
+							<span class="hidden xs:inline">{{ __('Last') }}</span>
 							<span class="xs:hidden">»</span>
 						</button>
 					</div>
@@ -485,12 +499,12 @@
 				<table v-if="paginatedItems.length > 0" class="min-w-full divide-y divide-gray-200">
 					<thead class="bg-gray-50 sticky top-0 z-10">
 						<tr>
-							<th scope="col" class="px-2 sm:px-3 py-2 sm:py-2.5 text-left text-[10px] sm:text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 border-b-2 border-gray-200 sticky top-0 z-10 w-[50px] sm:w-[60px]">Image</th>
-							<th scope="col" class="px-2 sm:px-3 py-2 sm:py-2.5 text-left text-[10px] sm:text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 border-b-2 border-gray-200 sticky top-0 z-10 max-w-[120px] sm:max-w-[180px] md:max-w-[200px]">Name</th>
-							<th scope="col" class="hidden sm:table-cell px-2 sm:px-3 py-2 sm:py-2.5 text-left text-[10px] sm:text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 border-b-2 border-gray-200 sticky top-0 z-10 sm:max-w-[150px]">Code</th>
-							<th scope="col" class="px-2 sm:px-3 py-2 sm:py-2.5 text-left text-[10px] sm:text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 border-b-2 border-gray-200 sticky top-0 z-10 w-[70px] sm:w-[100px]">Rate</th>
-							<th scope="col" class="px-2 sm:px-3 py-2 sm:py-2.5 text-left text-[10px] sm:text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 border-b-2 border-gray-200 sticky top-0 z-10 w-[70px] sm:w-[100px]">Qty</th>
-							<th scope="col" class="hidden md:table-cell px-2 sm:px-3 py-2 sm:py-2.5 text-left text-[10px] sm:text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 border-b-2 border-gray-200 sticky top-0 z-10 md:w-[80px]">UOM</th>
+							<th scope="col" class="px-2 sm:px-3 py-2 sm:py-2.5 text-left text-[10px] sm:text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 border-b-2 border-gray-200 sticky top-0 z-10 w-[50px] sm:w-[60px]">{{ __('Image') }}</th>
+							<th scope="col" class="px-2 sm:px-3 py-2 sm:py-2.5 text-left text-[10px] sm:text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 border-b-2 border-gray-200 sticky top-0 z-10 max-w-[120px] sm:max-w-[180px] md:max-w-[200px]">{{ __('Name') }}</th>
+							<th scope="col" class="hidden sm:table-cell px-2 sm:px-3 py-2 sm:py-2.5 text-left text-[10px] sm:text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 border-b-2 border-gray-200 sticky top-0 z-10 sm:max-w-[150px]">{{ __('Code') }}</th>
+							<th scope="col" class="px-2 sm:px-3 py-2 sm:py-2.5 text-left text-[10px] sm:text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 border-b-2 border-gray-200 sticky top-0 z-10 w-[70px] sm:w-[100px]">{{ __('Rate') }}</th>
+							<th scope="col" class="px-2 sm:px-3 py-2 sm:py-2.5 text-left text-[10px] sm:text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 border-b-2 border-gray-200 sticky top-0 z-10 w-[70px] sm:w-[100px]">{{ __('Qty') }}</th>
+							<th scope="col" class="hidden md:table-cell px-2 sm:px-3 py-2 sm:py-2.5 text-left text-[10px] sm:text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 border-b-2 border-gray-200 sticky top-0 z-10 md:w-[80px]">{{ __('UOM') }}</th>
 						</tr>
 					</thead>
 					<tbody class="bg-white divide-y divide-gray-200">
@@ -549,7 +563,16 @@
 											getStockStatus(item.actual_qty ?? item.stock_qty ?? 0).textColor,
 											(item.actual_qty ?? item.stock_qty ?? 0) <= 0 ? 'group-hover:blur-sm group-hover:brightness-90' : ''
 										]"
-										:title="`${getStockStatus(item.actual_qty ?? item.stock_qty ?? 0).label}: ${Math.floor(item.actual_qty ?? item.stock_qty ?? 0)} ${item.is_bundle ? 'Bundles' : (item.uom || item.stock_uom || 'Nos')}`"
+										:title="item.is_bundle 
+											? __('{0}: {1} Bundles', [
+											getStockStatus(item.actual_qty ?? item.stock_qty ?? 0).label,
+											Math.floor(item.actual_qty ?? item.stock_qty ?? 0)
+										], 'item bundle stock')
+											: __('{0}: {1} {2}', [
+											getStockStatus(item.actual_qty ?? item.stock_qty ?? 0).label,
+											Math.floor(item.actual_qty ?? item.stock_qty ?? 0),
+											(item.uom || item.stock_uom || __('Nos', null, 'UOM'))
+										], 'item stock with uom')"
 									>
 										{{ Math.floor(item.actual_qty ?? item.stock_qty ?? 0) }}
 									</span>
@@ -558,7 +581,7 @@
 										v-if="(item.actual_qty ?? item.stock_qty ?? 0) <= 0"
 										@click.stop="showWarehouseAvailability(item)"
 										class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
-										title="Check availability in other warehouses"
+										:title="__('Check availability in other warehouses')"
 									>
 										<div class="p-1.5 bg-white/90 backdrop-blur-sm rounded-full">
 											<svg class="w-5 h-5 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
@@ -571,11 +594,11 @@
 									v-else
 									class="text-xs sm:text-sm text-gray-400 italic"
 								>
-									N/A
+									{{ __('N/A') }}
 								</span>
 							</td>
 							<td class="hidden md:table-cell px-2 sm:px-3 py-2 whitespace-nowrap md:w-[80px]">
-								<div class="text-xs sm:text-sm text-gray-500">{{ item.uom || item.stock_uom || 'Nos' }}</div>
+								<div class="text-xs sm:text-sm text-gray-500">{{ item.uom || item.stock_uom || __('Nos', null, 'UOM') }}</div>
 							</td>
 						</tr>
 						<!-- Loading More Indicator Row -->
@@ -583,7 +606,7 @@
 							<td colspan="6" class="px-2 sm:px-3 py-4 text-center bg-white">
 								<div class="flex justify-center items-center">
 									<div class="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
-									<p class="ml-2 text-xs text-gray-500">Loading more items...</p>
+									<p class="ml-2 text-xs text-gray-500">{{ __('Loading more items...') }}</p>
 								</div>
 							</td>
 						</tr>
@@ -591,14 +614,14 @@
 						<!-- End of Results Indicator Row - Only show on last page or when all items fit in one page -->
 						<tr v-else-if="!hasMore && filteredItems.length > 0 && !searchTerm && (currentPage === totalPages || totalPages === 1)">
 							<td colspan="6" class="px-2 sm:px-3 py-3 text-center bg-white">
-								<p class="text-xs text-gray-400">All items loaded</p>
+								<p class="text-xs text-gray-400">{{ __('All items loaded') }}</p>
 							</td>
 						</tr>
 
 						<!-- Search Results Count Row -->
 						<tr v-else-if="searchTerm && filteredItems.length > 0">
 							<td colspan="6" class="px-2 sm:px-3 py-3 text-center bg-white">
-								<p class="text-xs text-gray-500">{{ filteredItems.length }} items found</p>
+								<p class="text-xs text-gray-500">{{ __('{0} items found', [filteredItems.length]) }}</p>
 							</td>
 						</tr>
 					</tbody>
@@ -609,7 +632,11 @@
 			<div v-if="totalPages > 1" class="px-2 sm:px-3 py-2 bg-white border-t border-gray-200">
 				<div class="flex flex-col sm:flex-row items-center justify-between gap-2">
 					<div class="text-[10px] sm:text-xs text-gray-600 order-2 sm:order-1">
-						{{ ((currentPage - 1) * itemsPerPage) + 1 }}-{{ Math.min(currentPage * itemsPerPage, filteredItems.length) }} of {{ filteredItems.length }}
+						{{ __('{0} - {1} of {2}', [
+							(((currentPage - 1) * itemsPerPage) + 1),
+							Math.min(currentPage * itemsPerPage, filteredItems.length),
+							filteredItems.length
+						]) }}
 					</div>
 					<div class="flex items-center space-x-1 order-1 sm:order-2">
 						<button
@@ -621,9 +648,9 @@
 									? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
 									: 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 active:bg-gray-100'
 							]"
-							:aria-label="'Go to first page'"
+							:aria-label="__('Go to first page')"
 						>
-							<span class="hidden xs:inline">First</span>
+							<span class="hidden xs:inline">{{ __('First') }}</span>
 							<span class="xs:hidden">«</span>
 						</button>
 						<button
@@ -635,9 +662,9 @@
 									? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
 									: 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 active:bg-gray-100'
 							]"
-							:aria-label="'Go to previous page'"
+							:aria-label="__('Go to previous page')"
 						>
-							<span class="hidden xs:inline">Previous</span>
+							<span class="hidden xs:inline">{{ __('Previous') }}</span>
 							<span class="xs:hidden">‹</span>
 						</button>
 						<div class="flex items-center space-x-0.5 sm:space-x-1">
@@ -651,7 +678,7 @@
 										? 'bg-blue-600 text-white border-blue-600'
 										: 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 active:bg-gray-100'
 								]"
-								:aria-label="'Go to page ' + page"
+								:aria-label="__('Go to page {0}', [page])"
 							>
 								{{ page }}
 							</button>
@@ -665,9 +692,9 @@
 									? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
 									: 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 active:bg-gray-100'
 							]"
-							:aria-label="'Go to next page'"
+							:aria-label="__('Go to next page')"
 						>
-							<span class="hidden xs:inline">Next</span>
+							<span class="hidden xs:inline">{{ __('Next') }}</span>
 							<span class="xs:hidden">›</span>
 						</button>
 						<button
@@ -679,9 +706,9 @@
 									? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
 									: 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 active:bg-gray-100'
 							]"
-							:aria-label="'Go to last page'"
+							:aria-label="__('Go to last page')"
 						>
-							<span class="hidden xs:inline">Last</span>
+							<span class="hidden xs:inline">{{ __('Last') }}</span>
 							<span class="xs:hidden">»</span>
 						</button>
 					</div>
@@ -799,36 +826,36 @@ const totalPages = computed(() => {
 })
 
 const SEARCH_PLACEHOLDERS = Object.freeze({
-	auto: "Auto-Add ON - Type or scan barcode",
-	scanner: "Scanner ON - Enable Auto for automatic addition",
-	default: "Search by item code, name or scan barcode",
+	auto: __("Auto-Add ON - Type or scan barcode"),
+	scanner: __("Scanner ON - Enable Auto for automatic addition"),
+	default: __("Search by item code, name or scan barcode"),
 })
 
 // Sort configuration
 const SORT_OPTIONS = Object.freeze([
 	{
 		field: 'name',
-		label: 'Name',
+		label: __('Name'),
 		icon: 'M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z'
 	},
 	{
 		field: 'quantity',
-		label: 'Quantity',
+		label: __('Quantity'),
 		icon: 'M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4'
 	},
 	{
 		field: 'item_group',
-		label: 'Item Group',
+		label: __('Item Group'),
 		icon: 'M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10'
 	},
 	{
 		field: 'price',
-		label: 'Price',
+		label: __('Price'),
 		icon: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
 	},
 	{
 		field: 'item_code',
-		label: 'Item Code',
+		label: __('Item Code'),
 		icon: 'M7 20l4-16m2 16l4-16M6 9h14M4 15h14'
 	}
 ])
@@ -1089,8 +1116,9 @@ function handleItemClick(itemCode) {
 	// Check stock for stock items AND Product Bundles (bundles now have calculated stock)
 	const qty = Math.floor(item.actual_qty ?? item.stock_qty ?? 0)
 	if ((item.is_stock_item || item.is_bundle) && !item.has_variants && !item.has_serial_no && !item.has_batch_no && qty <= 0 && settingsStore.shouldEnforceStockValidation()) {
-		const itemType = item.is_bundle ? "Bundle" : "Item"
-		showError(`"${item.item_name}" cannot be added to cart. ${itemType} is out of stock. Allow Negative Stock is disabled.`)
+		showError(item.is_bundle 
+			? __('"{0}" cannot be added to cart. Bundle is out of stock. Allow Negative Stock is disabled.', [item.item_name])
+			: __('"{0}" cannot be added to cart. Item is out of stock. Allow Negative Stock is disabled.', [item.item_name]))
 		return
 	}
 
@@ -1128,7 +1156,7 @@ async function handleBarcodeSearch(forceAutoAdd = false) {
 		emit("item-selected", filteredItems.value[0], shouldAutoAdd)
 		itemStore.clearSearch()
 	} else if (filteredItems.value.length === 0) {
-		showWarning(`Item Not Found: No item found with barcode: ${barcode}`)
+		showWarning(__('Item Not Found: No item found with barcode: {0}', [barcode]))
 
 		// If scanner mode is enabled, clear search immediately for next scan
 		if (shouldAutoAdd) {
@@ -1137,9 +1165,9 @@ async function handleBarcodeSearch(forceAutoAdd = false) {
 	} else {
 		if (shouldAutoAdd) {
 			// In scanner mode, don't show manual selection - just notify
-			showWarning(`Multiple Items Found: ${filteredItems.value.length} items match barcode. Please refine search.`)
+			showWarning(__('Multiple Items Found: {0} items match barcode. Please refine search.', [filteredItems.value.length]))
 		} else {
-			showWarning(`Multiple Items Found: ${filteredItems.value.length} items match. Please select one.`)
+			showWarning(__('Multiple Items Found: {0} items match. Please select one.', [filteredItems.value.length]))
 		}
 	}
 }

--- a/POS/src/components/sale/OffersDialog.vue
+++ b/POS/src/components/sale/OffersDialog.vue
@@ -1,20 +1,20 @@
 <template>
 	<Dialog
 		v-model="show"
-		:options="{ title: 'Available Offers', size: 'lg' }"
+		:options="{ title: __('Available Offers'), size: 'lg' }"
 	>
 		<template #body-content>
 			<div class="space-y-4">
 				<!-- Loading State -->
 				<div v-if="loading" class="py-8 text-center">
 					<div class="animate-spin rounded-full h-10 w-10 border-b-2 border-green-500 mx-auto"></div>
-					<p class="mt-3 text-sm text-gray-500">Loading offers...</p>
+					<p class="mt-3 text-sm text-gray-500">{{ __('Loading offers...') }}</p>
 				</div>
 
 				<!-- Applying State -->
 				<div v-else-if="applyingOffer" class="py-8 text-center">
 					<div class="animate-spin rounded-full h-10 w-10 border-b-2 border-green-500 mx-auto"></div>
-					<p class="mt-3 text-sm text-gray-500">Applying offer...</p>
+					<p class="mt-3 text-sm text-gray-500">{{ __('Applying offer...') }}</p>
 				</div>
 
 				<!-- Empty State -->
@@ -24,9 +24,9 @@
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/>
 						</svg>
 					</div>
-					<h3 class="mt-4 text-sm font-medium text-gray-900">No offers available</h3>
+					<h3 class="mt-4 text-sm font-medium text-gray-900">{{ __('No offers available') }}</h3>
 					<p class="mt-2 text-xs text-gray-500">
-						Add items to your cart to see eligible offers
+						{{ __('Add items to your cart to see eligible offers') }}
 					</p>
 				</div>
 
@@ -51,7 +51,7 @@
 							<svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
 								<path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
 							</svg>
-							<span>APPLIED</span>
+							<span>{{ __('APPLIED') }}</span>
 						</div>
 
 						<!-- Source Badge (Pricing Rule vs Promotional Scheme) -->
@@ -64,7 +64,7 @@
 									: 'bg-purple-600 text-white'
 							]"
 						>
-							{{ offer.source === 'Pricing Rule' ? 'PRICING RULE' : 'PROMO SCHEME' }}
+							{{ offer.source === 'Pricing Rule' ? __('PRICING RULE') : __('PROMO SCHEME') }}
 						</div>
 
 						<!-- Offer Header -->
@@ -92,13 +92,13 @@
 								]"
 							>
 								<div class="text-lg font-bold">
-									<span v-if="offer.discount_percentage">{{ Number(offer.discount_percentage).toFixed(2) }}% OFF</span>
-									<span v-else-if="offer.discount_amount">{{ formatCurrency(offer.discount_amount) }} OFF</span>
-									<span v-else>Special Offer</span>
+									<span v-if="offer.discount_percentage">{{ __('{0}% OFF', [Number(offer.discount_percentage).toFixed(2)]) }}</span>
+									<span v-else-if="offer.discount_amount">{{ __('{0} OFF', [formatCurrency(offer.discount_amount)]) }}</span>
+									<span v-else>{{ __('Special Offer') }}</span>
 								</div>
 							</div>
 							<div v-if="offer.offer === 'Give Product'" class="text-xs bg-purple-100 text-purple-700 px-3 py-1 rounded-full font-semibold">
-								+ Free Item
+								{{ __('+ Free Item') }}
 							</div>
 						</div>
 
@@ -110,7 +110,7 @@
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
 								</svg>
 								<div>
-									<p class="text-[10px] text-gray-500">Min Purchase</p>
+									<p class="text-[10px] text-gray-500">{{ __('Min Purchase') }}</p>
 									<p class="text-xs font-semibold text-gray-900">{{ formatCurrency(offer.min_amt) }}</p>
 								</div>
 							</div>
@@ -121,8 +121,8 @@
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/>
 								</svg>
 								<div>
-									<p class="text-[10px] text-gray-500">Min Quantity</p>
-									<p class="text-xs font-semibold text-gray-900">{{ offer.min_qty }} items</p>
+									<p class="text-[10px] text-gray-500">{{ __('Min Quantity') }}</p>
+									<p class="text-xs font-semibold text-gray-900">{{ __('{0} items', [offer.min_qty]) }}</p>
 								</div>
 							</div>
 
@@ -132,7 +132,7 @@
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
 								</svg>
 								<div>
-									<p class="text-[10px] text-gray-500">Valid Until</p>
+									<p class="text-[10px] text-gray-500">{{ __('Valid Until') }}</p>
 									<p class="text-xs font-semibold text-gray-900">{{ formatDate(offer.valid_upto) }}</p>
 								</div>
 							</div>
@@ -143,8 +143,8 @@
 									<path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"/>
 								</svg>
 								<div>
-									<p class="text-[10px] text-gray-500">Type</p>
-									<p class="text-xs font-semibold text-gray-900">{{ offer.offer || 'Discount' }}</p>
+									<p class="text-[10px] text-gray-500">{{ __('Type') }}</p>
+									<p class="text-xs font-semibold text-gray-900">{{ offer.offer || __('Discount') }}</p>
 								</div>
 							</div>
 						</div>
@@ -152,7 +152,7 @@
 						<!-- Progress Bar for Min Amount (only shown if not eligible) -->
 						<div v-if="offer.min_amt && offersStore.cartSnapshot.subtotal < offer.min_amt" class="mt-3">
 							<div class="flex items-center justify-between text-xs mb-1">
-								<span class="text-gray-600">Subtotal (before tax)</span>
+								<span class="text-gray-600">{{ __('Subtotal (before tax)') }}</span>
 								<span class="text-gray-900 font-semibold">
 									{{ formatCurrency(offersStore.cartSnapshot.subtotal) }} / {{ formatCurrency(offer.min_amt) }}
 								</span>
@@ -164,7 +164,7 @@
 								></div>
 							</div>
 							<p class="text-xs text-orange-600 mt-1 font-medium">
-								Add {{ formatCurrency(offersStore.getUnlockAmount(offer)) }} more to unlock
+								{{ __('Add {0} more to unlock', [formatCurrency(offersStore.getUnlockAmount(offer))]) }}
 							</p>
 						</div>
 
@@ -181,7 +181,7 @@
 								applyingOffer ? 'opacity-70 cursor-not-allowed' : ''
 							]"
 						>
-							{{ isOfferApplied(offer) ? 'Remove Offer' : 'Apply Offer' }}
+							{{ isOfferApplied(offer) ? __('Remove Offer') : __('Apply Offer') }}
 						</button>
 					</div>
 				</div>
@@ -191,7 +191,7 @@
 		<template #actions>
 			<div class="flex justify-end w-full">
 				<Button variant="subtle" @click="show = false">
-					Close
+					{{ __('Close') }}
 				</Button>
 			</div>
 		</template>
@@ -212,7 +212,7 @@ const props = defineProps({
 	subtotal: {
 		type: Number,
 		required: true,
-		note: "Cart subtotal BEFORE tax - used for discount calculations",
+		note: __("Cart subtotal BEFORE tax - used for discount calculations"),
 	},
 	items: Array,
 	posProfile: String,

--- a/POS/src/components/sale/OfflineInvoicesDialog.vue
+++ b/POS/src/components/sale/OfflineInvoicesDialog.vue
@@ -1,5 +1,5 @@
 <template>
-	<Dialog v-model="show" :options="{ title: 'Offline Invoices', size: 'xl' }">
+	<Dialog v-model="show" :options="{ title: __('Offline Invoices'), size: 'xl' }">
 		<template #body-content>
 			<div class="space-y-3 sm:space-y-4">
 				<!-- Header Info -->
@@ -9,8 +9,8 @@
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
 						</svg>
 						<div class="min-w-0">
-							<h3 class="font-semibold text-gray-900 text-sm sm:text-base">{{ invoices.length }} Pending Invoice(s)</h3>
-							<p class="text-xs sm:text-sm text-gray-600 truncate">These invoices will be submitted when you're back online</p>
+							<h3 class="font-semibold text-gray-900 text-sm sm:text-base">{{ __('{0} Pending Invoice(s)', [invoices.length]) }}</h3>
+							<p class="text-xs sm:text-sm text-gray-600 truncate">{{ __("These invoices will be submitted when you're back online") }}</p>
 						</div>
 					</div>
 					<Button
@@ -25,7 +25,7 @@
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
 							</svg>
 						</template>
-						Sync All
+						{{ __('Sync All') }}
 					</Button>
 				</div>
 
@@ -39,7 +39,7 @@
 					<svg class="w-16 h-16 mx-auto text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
 					</svg>
-					<p class="mt-4 text-gray-500">No pending offline invoices</p>
+					<p class="mt-4 text-gray-500">{{ __('No pending offline invoices') }}</p>
 				</div>
 
 				<!-- Invoices List -->
@@ -53,18 +53,18 @@
 							<div class="flex-1 min-w-0">
 								<div class="flex flex-wrap items-center gap-2">
 									<h4 class="font-semibold text-gray-900 text-sm sm:text-base truncate">
-										{{ invoice.data.customer || 'Walk-in Customer' }}
+										{{ invoice.data.customer || __('Walk-in Customer') }}
 									</h4>
 									<span
 										v-if="invoice.retry_count > 0"
 										class="text-[10px] sm:text-xs px-2 py-0.5 sm:py-1 bg-red-100 text-red-700 rounded-full flex-shrink-0"
 									>
-										{{ invoice.retry_count }} failed
+										{{ __('{0} failed', [invoice.retry_count]) }}
 									</span>
 								</div>
 								<div class="mt-2 space-y-1 text-xs sm:text-sm text-gray-600">
 									<div class="flex flex-wrap items-center gap-x-3 gap-y-1">
-										<span>{{ invoice.data.items?.length || 0 }} items</span>
+										<span>{{ __('{0} items', [invoice.data.items?.length || 0]) }}</span>
 										<span class="font-semibold text-gray-900">
 											{{ formatCurrency(invoice.data.grand_total || 0) }}
 										</span>
@@ -73,7 +73,7 @@
 										</span>
 									</div>
 									<div v-if="invoice.data.payments?.length > 0" class="flex flex-wrap items-center gap-2">
-										<span class="text-[10px] sm:text-xs text-gray-500">Payments:</span>
+										<span class="text-[10px] sm:text-xs text-gray-500">{{ __('Payments:') }}</span>
 										<span
 											v-for="(payment, idx) in invoice.data.payments"
 											:key="idx"
@@ -88,7 +88,7 @@
 								<button
 									@click="editInvoice(invoice)"
 									class="p-1.5 sm:p-2 hover:bg-blue-50 rounded-lg transition-colors touch-manipulation"
-									title="Edit Invoice"
+									:title="__('Edit Invoice')"
 								>
 									<svg class="w-4 h-4 sm:w-5 sm:h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
@@ -97,7 +97,7 @@
 								<button
 									@click="viewDetails(invoice)"
 									class="p-1.5 sm:p-2 hover:bg-gray-100 rounded-lg transition-colors touch-manipulation"
-									title="View Details"
+									:title="__('View Details')"
 								>
 									<svg class="w-4 h-4 sm:w-5 sm:h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
@@ -107,7 +107,7 @@
 								<button
 									@click="deleteInvoice(invoice)"
 									class="p-1.5 sm:p-2 hover:bg-red-50 rounded-lg transition-colors touch-manipulation"
-									title="Delete"
+									:title="__('Delete')"
 								>
 									<svg class="w-4 h-4 sm:w-5 sm:h-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
@@ -122,16 +122,16 @@
 	</Dialog>
 
 	<!-- Details Dialog -->
-	<Dialog v-model="showDetails" :options="{ title: 'Invoice Details', size: 'lg' }">
+	<Dialog v-model="showDetails" :options="{ title: __('Invoice Details'), size: 'lg' }">
 		<template #body-content>
 			<div v-if="selectedInvoice" class="space-y-3 sm:space-y-4">
 				<div class="bg-gray-50 p-3 sm:p-4 rounded-lg">
-					<h4 class="font-semibold text-gray-900 mb-2 text-sm sm:text-base">Customer</h4>
-					<p class="text-sm sm:text-base">{{ selectedInvoice.data.customer || 'Walk-in Customer' }}</p>
+					<h4 class="font-semibold text-gray-900 mb-2 text-sm sm:text-base">{{ __('Customer') }}</h4>
+					<p class="text-sm sm:text-base">{{ selectedInvoice.data.customer || __('Walk-in Customer') }}</p>
 				</div>
 
 				<div class="bg-gray-50 p-3 sm:p-4 rounded-lg">
-					<h4 class="font-semibold text-gray-900 mb-2 text-sm sm:text-base">Items</h4>
+					<h4 class="font-semibold text-gray-900 mb-2 text-sm sm:text-base">{{ __('Items') }}</h4>
 					<div class="space-y-2">
 						<div
 							v-for="(item, idx) in selectedInvoice.data.items"
@@ -146,25 +146,25 @@
 
 				<div class="bg-gray-50 p-3 sm:p-4 rounded-lg">
 					<div class="flex justify-between mb-1 text-xs sm:text-sm">
-						<span class="text-gray-600">Subtotal</span>
+						<span class="text-gray-600">{{ __('Subtotal') }}</span>
 						<span>{{ formatCurrency(selectedInvoice.data.total || 0) }}</span>
 					</div>
 					<div v-if="selectedInvoice.data.total_tax" class="flex justify-between mb-1 text-xs sm:text-sm">
-						<span class="text-gray-600">Tax</span>
+						<span class="text-gray-600">{{ __('Tax') }}</span>
 						<span>{{ formatCurrency(selectedInvoice.data.total_tax) }}</span>
 					</div>
 					<div v-if="selectedInvoice.data.total_discount" class="flex justify-between mb-1 text-xs sm:text-sm">
-						<span class="text-gray-600">Discount</span>
+						<span class="text-gray-600">{{ __('Discount') }}</span>
 						<span class="text-red-600">-{{ formatCurrency(selectedInvoice.data.total_discount) }}</span>
 					</div>
 					<div class="flex justify-between font-semibold text-base sm:text-lg pt-2 border-t">
-						<span>Grand Total</span>
+						<span>{{ __('Grand Total') }}</span>
 						<span>{{ formatCurrency(selectedInvoice.data.grand_total || 0) }}</span>
 					</div>
 				</div>
 
 				<div v-if="selectedInvoice.data.payments?.length > 0" class="bg-gray-50 p-3 sm:p-4 rounded-lg">
-					<h4 class="font-semibold text-gray-900 mb-2 text-sm sm:text-base">Payments</h4>
+					<h4 class="font-semibold text-gray-900 mb-2 text-sm sm:text-base">{{ __('Payments') }}</h4>
 					<div class="space-y-1">
 						<div
 							v-for="(payment, idx) in selectedInvoice.data.payments"
@@ -179,12 +179,12 @@
 			</div>
 		</template>
 		<template #actions>
-			<Button variant="subtle" @click="showDetails = false" class="w-full sm:w-auto">Close</Button>
+			<Button variant="subtle" @click="showDetails = false" class="w-full sm:w-auto">{{ __('Close') }}</Button>
 		</template>
 	</Dialog>
 
 	<!-- Delete Confirmation Dialog -->
-	<Dialog v-model="showDeleteConfirm" :options="{ title: 'Delete Offline Invoice', size: 'md' }">
+	<Dialog v-model="showDeleteConfirm" :options="{ title: __('Delete Offline Invoice'), size: 'md' }">
 		<template #body-content>
 			<div v-if="invoiceToDelete" class="space-y-3 sm:space-y-4">
 				<div class="flex items-start space-x-2 sm:space-x-3">
@@ -192,29 +192,29 @@
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
 					</svg>
 					<div class="min-w-0 flex-1">
-						<p class="text-gray-900 font-medium mb-2 text-sm sm:text-base">Are you sure you want to delete this offline invoice?</p>
+						<p class="text-gray-900 font-medium mb-2 text-sm sm:text-base">{{ __('Are you sure you want to delete this offline invoice?') }}</p>
 						<div class="bg-gray-50 rounded-lg p-2.5 sm:p-3 space-y-1 text-xs sm:text-sm">
 							<div class="flex justify-between gap-2">
-								<span class="text-gray-600">Customer:</span>
-								<span class="font-semibold truncate">{{ invoiceToDelete.data.customer || 'Walk-in Customer' }}</span>
+								<span class="text-gray-600">{{ __('Customer:') }}</span>
+								<span class="font-semibold truncate">{{ invoiceToDelete.data.customer || __('Walk-in Customer') }}</span>
 							</div>
 							<div class="flex justify-between gap-2">
-								<span class="text-gray-600">Amount:</span>
+								<span class="text-gray-600">{{ __('Amount:') }}</span>
 								<span class="font-semibold">{{ formatCurrency(invoiceToDelete.data.grand_total) }}</span>
 							</div>
 							<div class="flex justify-between gap-2">
-								<span class="text-gray-600">Items:</span>
+								<span class="text-gray-600">{{ __('Items:') }}</span>
 								<span class="font-semibold">{{ invoiceToDelete.data.items?.length || 0 }}</span>
 							</div>
 						</div>
-						<p class="text-red-600 text-xs sm:text-sm mt-3">This action cannot be undone.</p>
+						<p class="text-red-600 text-xs sm:text-sm mt-3">{{ __('This action cannot be undone.') }}</p>
 					</div>
 				</div>
 			</div>
 		</template>
 		<template #actions>
-			<Button variant="subtle" @click="showDeleteConfirm = false" class="w-full sm:w-auto">Cancel</Button>
-			<Button variant="solid" theme="red" @click="confirmDelete" class="w-full sm:w-auto">Delete Invoice</Button>
+			<Button variant="subtle" @click="showDeleteConfirm = false" class="w-full sm:w-auto">{{ __('Cancel') }}</Button>
+			<Button variant="solid" theme="red" @click="confirmDelete" class="w-full sm:w-auto">{{ __('Delete Invoice') }}</Button>
 		</template>
 	</Dialog>
 </template>
@@ -297,11 +297,11 @@ function formatDate(timestamp) {
 	const now = new Date()
 	const diffInSeconds = Math.floor((now - date) / 1000)
 
-	if (diffInSeconds < 60) return "Just now"
+	if (diffInSeconds < 60) return __("Just now")
 	if (diffInSeconds < 3600)
-		return `${Math.floor(diffInSeconds / 60)} minutes ago`
+		return __('{0} minutes ago', [Math.floor(diffInSeconds / 60)])
 	if (diffInSeconds < 86400)
-		return `${Math.floor(diffInSeconds / 3600)} hours ago`
+		return __('{0} hours ago', [Math.floor(diffInSeconds / 3600)])
 
 	return date.toLocaleDateString() + " " + date.toLocaleTimeString()
 }

--- a/POS/src/components/sale/PaymentDialog.vue
+++ b/POS/src/components/sale/PaymentDialog.vue
@@ -1,5 +1,5 @@
 <template>
-	<Dialog v-model="show" :options="{ title: 'Complete Payment', size: '2xl' }">
+	<Dialog v-model="show" :options="{ title: __('Complete Payment'), size: '2xl' }">
 		<template #body-content>
 			<div class="space-y-4">
 				<!-- INFORMATION SECTION (TOP) -->
@@ -8,20 +8,20 @@
 				<div class="bg-gradient-to-br from-blue-50 to-indigo-50 rounded-xl p-4 border border-blue-100">
 					<div class="flex justify-between items-start mb-3">
 						<div>
-							<div class="text-xs font-medium text-gray-600 mb-1">Total Amount</div>
+							<div class="text-xs font-medium text-gray-600 mb-1">{{ __('Total Amount') }}</div>
 							<div class="text-3xl font-bold text-gray-900">
 								{{ formatCurrency(grandTotal) }}
 							</div>
 						</div>
 						<div class="text-right">
 							<div v-if="remainingAmount > 0" class="mb-2">
-								<div class="text-xs font-medium text-orange-600 mb-1">Remaining</div>
+								<div class="text-xs font-medium text-orange-600 mb-1">{{ __('Remaining') }}</div>
 								<div class="text-xl font-bold text-orange-600">
 									{{ formatCurrency(remainingAmount) }}
 								</div>
 							</div>
 							<div v-if="changeAmount > 0">
-								<div class="text-xs font-medium text-green-600 mb-1">Change</div>
+								<div class="text-xs font-medium text-green-600 mb-1">{{ __('Change') }}</div>
 								<div class="text-xl font-bold text-green-600">
 									{{ formatCurrency(changeAmount) }}
 								</div>
@@ -30,7 +30,7 @@
 								<svg class="w-5 h-5 mr-1" fill="currentColor" viewBox="0 0 20 20">
 									<path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
 								</svg>
-								<span class="text-xs font-semibold">Paid in Full</span>
+								<span class="text-xs font-semibold">{{ __('Paid in Full') }}</span>
 							</div>
 						</div>
 					</div>
@@ -46,7 +46,7 @@
 						></div>
 					</div>
 					<div class="text-xs text-gray-600 mt-1">
-						{{ formatCurrency(totalPaid) }} paid of {{ formatCurrency(grandTotal) }}
+						{{ __('{0} paid of {1}', [formatCurrency(totalPaid), formatCurrency(grandTotal)]) }}
 					</div>
 				</div>
 
@@ -105,16 +105,16 @@
 							</div>
 							<div>
 								<div class="text-xs font-semibold text-gray-800">
-									{{ totalAvailableCredit >= 0 ? 'Customer Credit Available' : 'Customer Outstanding Balance' }}
+									{{ totalAvailableCredit >= 0 ? __('Customer Credit Available') : __('Customer Outstanding Balance') }}
 								</div>
 								<div v-if="totalAvailableCredit > 0" class="text-xs text-emerald-700">
-									Credit can be applied to invoice
+									{{ __('Credit can be applied to invoice') }}
 								</div>
 								<div v-else-if="totalAvailableCredit < 0" class="text-xs text-red-700">
-									Amount owed by customer
+									{{ __('Amount owed by customer') }}
 								</div>
 								<div v-else class="text-xs text-gray-600">
-									No outstanding balance
+									{{ __('No outstanding balance') }}
 								</div>
 							</div>
 						</div>
@@ -129,7 +129,7 @@
 										: 'text-gray-700'
 								]"
 							>
-								{{ totalAvailableCredit >= 0 ? 'Available' : 'Outstanding' }}
+								{{ totalAvailableCredit >= 0 ? __('Available') : __('Outstanding') }}
 							</div>
 							<div
 								:class="[
@@ -157,10 +157,15 @@
 								</svg>
 							</div>
 							<span class="text-xs font-bold text-purple-900">
-								Sales Person{{ settingsStore.isMultipleSalesPersons ? 's' : '' }}
+								{{ settingsStore.isMultipleSalesPersons
+									? __('Sales Persons')
+									: __('Sales Person')
+								}}
 							</span>
 							<span v-if="selectedSalesPersons.length > 0" class="text-xs font-bold text-purple-600 bg-purple-100 px-2 py-0.5 rounded">
-								{{ settingsStore.isSingleSalesPerson ? '1 selected' : `${selectedSalesPersons.length} selected` }}
+								{{ settingsStore.isSingleSalesPerson 
+									? __('1 selected') 
+									: __('{0} selected', [selectedSalesPersons.length]) }}
 							</span>
 						</div>
 						<button
@@ -168,7 +173,7 @@
 							@click="clearSalesPersons"
 							class="text-xs text-purple-700 hover:text-purple-900 font-semibold px-2 py-1 bg-purple-100 hover:bg-purple-200 rounded transition-colors"
 						>
-							{{ settingsStore.isSingleSalesPerson ? 'Clear' : 'Clear All' }}
+							{{ settingsStore.isSingleSalesPerson ? __('Clear') : __('Clear All') }}
 						</button>
 					</div>
 
@@ -177,7 +182,7 @@
 						<input
 							v-model="salesPersonSearch"
 							type="text"
-							placeholder="Search sales person..."
+							:placeholder="__('Search sales person...')"
 							class="w-full px-3 py-2 pl-9 text-xs border border-purple-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent bg-white"
 						/>
 						<svg class="w-4 h-4 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -187,7 +192,7 @@
 
 					<!-- Selected Sales Persons (Chips) -->
 					<div v-if="selectedSalesPersons.length > 0" class="mb-2 space-y-1.5">
-						<div class="text-[10px] font-semibold text-purple-700 uppercase tracking-wide mb-1">Selected:</div>
+						<div class="text-[10px] font-semibold text-purple-700 uppercase tracking-wide mb-1">{{ __('Selected:') }}</div>
 						<div
 							v-for="person in selectedSalesPersons"
 							:key="person.sales_person"
@@ -232,7 +237,7 @@
 								<path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
 							</svg>
 							<span class="text-xs font-medium text-yellow-800">
-								Total: {{ totalAllocation }}% (should be 100%)
+								{{ __('Total: {0}% (should be 100%)', [totalAllocation]) }}
 							</span>
 						</div>
 					</div>
@@ -254,7 +259,7 @@
 										{{ person.sales_person_name || person.name }}
 									</div>
 									<div v-if="person.commission_rate" class="text-[10px] text-gray-500">
-										Commission: {{ person.commission_rate }}%
+										{{ __('Commission: {0}%', [person.commission_rate]) }}
 									</div>
 								</div>
 							</div>
@@ -266,17 +271,17 @@
 						<svg class="w-8 h-8 text-gray-300 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
 						</svg>
-						<div class="text-xs text-gray-500">Search to add sales persons</div>
+						<div class="text-xs text-gray-500">{{ __('Search to add sales persons') }}</div>
 					</div>
 
 					<!-- Loading State -->
 					<div v-if="loadingSalesPersons" class="text-center py-3">
-						<div class="text-xs text-gray-500">Loading sales persons...</div>
+						<div class="text-xs text-gray-500">{{ __('Loading sales persons...') }}</div>
 					</div>
 
 					<!-- No Results -->
 					<div v-if="salesPersonSearch && filteredSalesPersons.length === 0 && !loadingSalesPersons" class="text-center py-3">
-						<div class="text-xs text-gray-500">No sales persons found</div>
+						<div class="text-xs text-gray-500">{{ __('No sales persons found') }}</div>
 					</div>
 				</div>
 
@@ -289,7 +294,7 @@
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
 								</svg>
 							</div>
-							<span class="text-[11px] font-bold text-orange-900">Additional Discount</span>
+							<span class="text-[11px] font-bold text-orange-900">{{ __('Additional Discount') }}</span>
 							<span v-if="localAdditionalDiscount > 0" class="text-[10px] font-bold text-red-600 bg-red-100 px-1.5 py-0.5 rounded">
 								-{{ formatCurrency(additionalDiscountType === 'percentage' ? (subtotal * localAdditionalDiscount / 100) : localAdditionalDiscount) }}
 							</span>
@@ -299,7 +304,7 @@
 							@click="clearAdditionalDiscount"
 							class="text-[10px] text-orange-700 hover:text-orange-900 font-semibold px-1.5 py-0.5 bg-orange-100 hover:bg-orange-200 rounded transition-colors"
 						>
-							Clear
+							{{ __('Clear') }}
 						</button>
 					</div>
 					<div class="grid grid-cols-[100px_1fr] gap-1.5">
@@ -309,8 +314,8 @@
 							@change="handleAdditionalDiscountTypeChange"
 							class="w-full px-1.5 py-1.5 text-[11px] font-medium border border-orange-300 rounded focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-transparent bg-white"
 						>
-							<option value="percentage">% Percent</option>
-							<option value="amount">{{ currency }} Amount</option>
+							<option value="percentage">{{ __('% Percent') }}</option>
+							<option value="amount">{{ __('{0} Amount', [currency]) }}</option>
 						</select>
 						<!-- Discount Value Input (Compact) -->
 						<div class="relative">
@@ -335,9 +340,9 @@
 
 				<!-- Payment Methods Grid -->
 				<div>
-					<h3 class="text-sm font-semibold text-gray-700 mb-3">Payment Methods</h3>
+					<h3 class="text-sm font-semibold text-gray-700 mb-3">{{ __('Payment Methods') }}</h3>
 					<div class="text-xs text-gray-500 mb-2">
-						Select payment method to add
+						{{ __('Select payment method to add') }}
 					</div>
 					<div class="grid grid-cols-2 md:grid-cols-3 gap-3">
 						<button
@@ -360,7 +365,7 @@
 											<div class="font-semibold text-sm text-gray-900">
 												{{ method.mode_of_payment }}
 											</div>
-											<div class="text-xs text-gray-500">{{ method.type || "Cash" }}</div>
+											<div class="text-xs text-gray-500">{{ method.type || __('Cash') }}</div>
 										</div>
 									</div>
 								</div>
@@ -372,7 +377,7 @@
 							</div>
 							<div v-if="getMethodTotal(method.mode_of_payment) > 0"
 								class="mt-2 pt-2 border-t border-gray-200">
-								<div class="text-xs text-gray-500">Added</div>
+								<div class="text-xs text-gray-500">{{ __('Added') }}</div>
 								<div class="font-bold text-blue-600">
 									{{ formatCurrency(getMethodTotal(method.mode_of_payment)) }}
 								</div>
@@ -384,7 +389,7 @@
 				<!-- Quick Amount Buttons -->
 				<div v-if="remainingAmount > 0 && lastSelectedMethod" class="bg-gray-50 rounded-lg p-4 border border-gray-200">
 					<div class="text-xs font-medium text-gray-600 mb-2">
-						Quick amounts for {{ lastSelectedMethod.mode_of_payment }}
+						{{ __('Quick amounts for {0}', [lastSelectedMethod.mode_of_payment]) }}
 					</div>
 					<div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
 						<button
@@ -397,7 +402,7 @@
 						</button>
 					</div>
 					<div class="mt-2">
-						<div class="text-xs font-medium text-gray-600 mb-1">Custom amount</div>
+						<div class="text-xs font-medium text-gray-600 mb-1">{{ __('Custom amount') }}</div>
 						<div class="flex space-x-2">
 							<Input
 								v-model="customAmount"
@@ -414,7 +419,7 @@
 								@click="addCustomPayment(lastSelectedMethod, customAmount)"
 								:disabled="!customAmount || customAmount <= 0"
 							>
-								Add
+								{{ __('Add') }}
 							</Button>
 						</div>
 					</div>
@@ -422,7 +427,7 @@
 
 				<!-- Active Payment Entries -->
 				<div v-if="paymentEntries.length > 0">
-					<h3 class="text-sm font-semibold text-gray-700 mb-3">Payment Breakdown</h3>
+					<h3 class="text-sm font-semibold text-gray-700 mb-3">{{ __('Payment Breakdown') }}</h3>
 					<div class="space-y-2 max-h-64 overflow-y-auto">
 						<div
 							v-for="(entry, index) in paymentEntries"
@@ -469,14 +474,14 @@
 					@click="clearAll"
 					theme="red"
 				>
-					Clear All
+					{{ __('Clear All') }}
 				</Button>
 				<div v-else></div>
 
 				<!-- Right: Main Action Buttons -->
 				<div class="flex items-center space-x-2">
 					<Button variant="subtle" @click="show = false">
-						Cancel
+						{{ __('Cancel') }}
 					</Button>
 
 					<!-- Apply Credit Button (if available) -->
@@ -490,7 +495,7 @@
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
 							</svg>
 						</template>
-						Apply Credit
+						{{ __('Apply Credit') }}
 					</Button>
 
 					<!-- Pay on Account Button (if credit sales enabled) -->
@@ -508,7 +513,7 @@
 						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
 						</svg>
-						<span class="truncate">Pay on Account</span>
+						<span class="truncate">{{ __('Pay on Account') }}</span>
 					</button>
 
 					<!-- Complete/Partial Payment Button -->
@@ -844,12 +849,12 @@ const paymentButtonText = computed(() => {
 	})
 
 	if (totalPaid.value >= props.grandTotal) {
-		return "Complete Payment"
+		return __("Complete Payment")
 	}
 	if (props.allowPartialPayment && totalPaid.value > 0) {
-		return "Partial Payment"
+		return __("Partial Payment")
 	}
-	return "Complete Payment"
+	return __("Complete Payment")
 })
 
 const quickAmounts = computed(() => {
@@ -950,7 +955,7 @@ function quickAddPayment(method) {
 	paymentEntries.value.push({
 		mode_of_payment: method.mode_of_payment,
 		amount: Number.parseFloat(remainingAmount.value.toFixed(2)),
-		type: method.type || "Cash",
+		type: method.type || __('Cash'),
 	})
 
 	console.log('[PaymentDialog] Payment added, new entries:', paymentEntries.value)
@@ -971,7 +976,7 @@ function addCustomPayment(method, amount) {
 	paymentEntries.value.push({
 		mode_of_payment: method.mode_of_payment,
 		amount: amt,
-		type: method.type || "Cash",
+		type: method.type || __('Cash'),
 	})
 
 	console.log('[PaymentDialog] Payment added, new entries:', paymentEntries.value)
@@ -1103,7 +1108,7 @@ function handleAdditionalDiscountChange() {
 			localAdditionalDiscount.value = settingsStore.maxDiscountAllowed
 			discountValue = settingsStore.maxDiscountAllowed
 			// Show warning toast
-			showWarning(`Maximum allowed discount is ${settingsStore.maxDiscountAllowed}%`)
+			showWarning(__('Maximum allowed discount is {0}%', [settingsStore.maxDiscountAllowed]))
 		}
 
 		// Ensure percentage is between 0-100
@@ -1126,7 +1131,8 @@ function handleAdditionalDiscountChange() {
 				localAdditionalDiscount.value = maxAmount
 				discountAmount = maxAmount
 				// Show warning toast
-				showWarning(`Maximum allowed discount is ${settingsStore.maxDiscountAllowed}% (${props.currency} ${maxAmount.toFixed(2)})`)
+				showWarning(__('Maximum allowed discount is {0}% ({1} {2})', 
+				[settingsStore.maxDiscountAllowed, props.currency, maxAmount.toFixed(2)]))
 			}
 		}
 	}

--- a/POS/src/components/sale/PromotionManagement.vue
+++ b/POS/src/components/sale/PromotionManagement.vue
@@ -14,8 +14,8 @@
 						<div class="flex items-center space-x-3">
 							<FeatherIcon name="tag" class="w-5 h-5 text-gray-700" />
 							<div>
-								<h2 class="text-lg font-semibold text-gray-900">Promotion & Coupon Management</h2>
-								<p class="text-sm text-gray-600">Manage promotional schemes and coupons</p>
+								<h2 class="text-lg font-semibold text-gray-900">{{ __('Promotion & Coupon Management') }}</h2>
+								<p class="text-sm text-gray-600">{{ __('Manage promotional schemes and coupons') }}</p>
 							</div>
 						</div>
 						<div class="flex items-center space-x-2">
@@ -45,7 +45,7 @@
 							>
 								<div class="flex items-center space-x-2">
 									<FeatherIcon name="percent" class="w-4 h-4" />
-									<span>Promotional Schemes</span>
+									<span>{{ __('Promotional Schemes') }}</span>
 								</div>
 							</button>
 							<button
@@ -59,7 +59,7 @@
 							>
 								<div class="flex items-center space-x-2">
 									<FeatherIcon name="gift" class="w-4 h-4" />
-									<span>Coupons</span>
+									<span>{{ __('Coupons') }}</span>
 								</div>
 							</button>
 						</div>
@@ -76,7 +76,7 @@
 								<FormControl
 									type="text"
 									v-model="searchQuery"
-									placeholder="Search promotions..."
+									:placeholder="__('Search promotions...')"
 								>
 									<template #prefix>
 										<FeatherIcon name="search" class="w-4 h-4 text-gray-500" />
@@ -87,11 +87,11 @@
 									type="select"
 									v-model="filterStatus"
 									:options="[
-										{ label: 'All Status', value: 'all' },
-										{ label: 'Active Only', value: 'active' },
-										{ label: 'Expired Only', value: 'expired' },
-										{ label: 'Not Started', value: 'not_started' },
-										{ label: 'Disabled Only', value: 'disabled' }
+										{ label: __('All Status'), value: 'all' },
+										{ label: __('Active Only'), value: 'active' },
+										{ label: __('Expired Only'), value: 'expired' },
+										{ label: __('Not Started'), value: 'not_started' },
+										{ label: __('Disabled Only'), value: 'disabled' }
 									]"
 								/>
 							</div>
@@ -107,7 +107,7 @@
 									<template #prefix>
 										<FeatherIcon name="plus-circle" class="w-4 h-4" />
 									</template>
-									Create New Promotion
+									{{ __('Create New Promotion') }}
 								</Button>
 								<!-- Permission Warning -->
 								<div v-else class="px-3 py-2 bg-amber-50 border border-amber-200 rounded-lg">
@@ -116,7 +116,7 @@
 											<path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
 										</svg>
 										<div class="flex-1">
-											<p class="text-xs font-medium text-amber-900">Create permission required</p>
+											<p class="text-xs font-medium text-amber-900">{{ __('Create permission required') }}</p>
 										</div>
 									</div>
 								</div>
@@ -129,7 +129,7 @@
 									<template #prefix>
 										<FeatherIcon name="refresh-cw" class="w-4 h-4" />
 									</template>
-									Refresh
+									{{ __('Refresh') }}
 								</Button>
 							</div>
 
@@ -139,7 +139,7 @@
 								<div v-if="loading && promotions.length === 0" class="flex items-center justify-center py-12">
 									<div class="text-center">
 										<LoadingIndicator class="w-6 h-6 mx-auto mb-2" />
-										<p class="text-sm text-gray-600">Loading...</p>
+										<p class="text-sm text-gray-600">{{ __('Loading...') }}</p>
 									</div>
 								</div>
 
@@ -148,7 +148,7 @@
 									<div class="text-gray-400 mb-3">
 										<FeatherIcon name="inbox" class="w-12 h-12 mx-auto" />
 									</div>
-									<p class="text-sm text-gray-600">No promotions found</p>
+									<p class="text-sm text-gray-600">{{ __('No promotions found') }}</p>
 								</div>
 
 								<!-- Promotion Items -->
@@ -179,7 +179,7 @@
 														theme="blue"
 														size="sm"
 													>
-														Rule
+														{{ __('Rule') }}
 													</Badge>
 													<Badge
 														v-else-if="promotion.source === 'Promotional Scheme'"
@@ -187,17 +187,17 @@
 														theme="purple"
 														size="sm"
 													>
-														Scheme
+														{{ __('Scheme') }}
 													</Badge>
 												</div>
-												<p class="text-xs text-gray-500 mt-0.5">{{ promotion.items_count || 0 }} items</p>
+												<p class="text-xs text-gray-500 mt-0.5">{{ __('{0} items', [promotion.items_count || 0]) }}</p>
 											</div>
 											<Badge
 												variant="subtle"
 												:theme="getStatusTheme(promotion.status)"
 												size="sm"
 											>
-												{{ promotion.status || 'Active' }}
+												{{ promotion.status || __('Active') }}
 											</Badge>
 										</div>
 										<div class="flex items-center justify-between text-xs">
@@ -205,7 +205,7 @@
 												{{ promotion.apply_on }}
 											</Badge>
 											<span class="text-gray-500">
-												{{ promotion.valid_upto ? formatDate(promotion.valid_upto) : 'No expiry' }}
+												{{ promotion.valid_upto ? formatDate(promotion.valid_upto) : __('No expiry') }}
 											</span>
 										</div>
 									</button>
@@ -221,8 +221,8 @@
 									<div class="text-gray-300 mb-4">
 										<FeatherIcon name="tag" class="w-16 h-16 mx-auto" />
 									</div>
-									<h3 class="text-xl font-semibold text-gray-900 mb-2">Select a Promotion</h3>
-									<p class="text-sm text-gray-600 mb-6">Choose a promotion from the list to view and edit, or create a new one to get started</p>
+									<h3 class="text-xl font-semibold text-gray-900 mb-2">{{ __('Select a Promotion') }}</h3>
+									<p class="text-sm text-gray-600 mb-6">{{ __('Choose a promotion from the list to view and edit, or create a new one to get started') }}</p>
 									<Button
 										v-if="permissions.create"
 										@click="handleCreateNew"
@@ -231,10 +231,10 @@
 										<template #prefix>
 											<FeatherIcon name="plus" class="w-4 h-4" />
 										</template>
-										Create New Promotion
+										{{ __('Create New Promotion') }}
 									</Button>
 									<p v-else class="text-sm text-amber-600">
-										You don't have permission to create promotions
+										{{ __("You don't have permission to create promotions") }}
 									</p>
 								</div>
 							</div>
@@ -247,7 +247,7 @@
 										<div>
 											<div class="flex items-center space-x-3">
 												<h3 class="text-xl font-semibold text-gray-900">
-													{{ isCreating ? 'Create New Promotion' : 'Edit Promotion' }}
+													{{ isCreating ? __('Create New Promotion') : __('Edit Promotion') }}
 												</h3>
 												<Badge
 													v-if="!isCreating && selectedPromotion?.source === 'Pricing Rule'"
@@ -255,7 +255,7 @@
 													theme="blue"
 													size="md"
 												>
-													Pricing Rule
+													{{ __('Pricing Rule') }}
 												</Badge>
 												<Badge
 													v-else-if="!isCreating && selectedPromotion?.source === 'Promotional Scheme'"
@@ -263,18 +263,26 @@
 													theme="purple"
 													size="md"
 												>
-													Promotional Scheme
+													{{ __('Promotional Scheme') }}
 												</Badge>
 											</div>
 											<p class="text-sm text-gray-600 mt-1">
-												{{ isCreating ? 'Fill in the details to create a new promotional scheme' : isPricingRule ? 'View pricing rule details (read-only)' : 'Update the promotion details below' }}
+												<span v-if="isCreating">
+													{{ __('Fill in the details to create a new promotional scheme') }}
+												</span>
+												<span v-else-if="isPricingRule">
+													{{ __('View pricing rule details (read-only)') }}
+												</span>
+												<span v-else>
+													{{ __('Update the promotion details below') }}
+												</span>
 											</p>
 										</div>
 										<div class="flex items-center space-x-2">
 											<!-- Show info badge for read-only Pricing Rules -->
 											<div v-if="isPricingRule" class="flex items-center space-x-2 px-3 py-1 bg-blue-50 rounded-lg">
 												<FeatherIcon name="info" class="w-4 h-4 text-blue-600" />
-												<span class="text-xs text-blue-700 font-medium">Read-only: Edit in ERPNext</span>
+												<span class="text-xs text-blue-700 font-medium">{{ __('Read-only: Edit in ERPNext') }}</span>
 											</div>
 
 											<Button
@@ -286,7 +294,7 @@
 												<template #prefix>
 													<FeatherIcon name="trash-2" class="w-4 h-4" />
 												</template>
-												Delete
+												{{ __('Delete') }}
 											</Button>
 											<Button
 												v-if="!isCreating && !isPricingRule && permissions.write"
@@ -297,14 +305,14 @@
 												<template #prefix>
 													<FeatherIcon :name="selectedPromotion.disable ? 'check-circle' : 'x-circle'" class="w-4 h-4" />
 												</template>
-												{{ selectedPromotion.disable ? 'Enable' : 'Disable' }}
+												{{ selectedPromotion.disable ? __('Enable') : __('Disable') }}
 											</Button>
 											<div v-if="!isPricingRule && (permissions.write || permissions.delete)" class="w-px h-6 bg-gray-200"></div>
 											<Button
 												@click="handleCancel"
 												variant="ghost"
 											>
-												{{ isPricingRule ? 'Close' : 'Cancel' }}
+												{{ isPricingRule ? __('Close') : __('Cancel') }}
 											</Button>
 											<Button
 												v-if="!isPricingRule && (isCreating ? permissions.create : permissions.write)"
@@ -315,7 +323,7 @@
 												<template #prefix>
 													<FeatherIcon :name="isCreating ? 'plus' : 'save'" class="w-4 h-4" />
 												</template>
-												{{ isCreating ? 'Create' : 'Update' }}
+												{{ isCreating ? __('Create') : __('Update') }}
 											</Button>
 										</div>
 									</div>
@@ -327,44 +335,44 @@
 											<div class="p-5">
 												<div class="flex items-center space-x-2 mb-4">
 													<FeatherIcon name="info" class="w-4 h-4 text-blue-600" />
-													<h4 class="text-sm font-semibold text-gray-900">Basic Information</h4>
+													<h4 class="text-sm font-semibold text-gray-900">{{ __('Basic Information') }}</h4>
 												</div>
 												<div class="grid grid-cols-3 gap-4">
 													<div class="col-span-3">
 														<FormControl
 															type="text"
-															label="Promotion Name"
+															:label="__('Promotion Name')"
 															v-model="form.name"
 															:disabled="!isCreating"
-															placeholder="e.g., Summer Sale 2025"
+															:placeholder="__('e.g., Summer Sale 2025')"
 															required
 														/>
 													</div>
 
 													<FormControl
 														type="date"
-														label="Valid From"
+														:label="__('Valid From')"
 														v-model="form.valid_from"
 														:disabled="isPricingRule"
 													/>
 
 													<FormControl
 														type="date"
-														label="Valid Until"
+														:label="__('Valid Until')"
 														v-model="form.valid_upto"
 														:disabled="isPricingRule"
 													/>
 
 													<FormControl
 														type="select"
-														label="Apply On"
+														:label="__('Apply On')"
 														v-model="form.apply_on"
 														:disabled="!isCreating || isPricingRule"
 														:options="[
-															{ label: 'Specific Items', value: 'Item Code' },
-															{ label: 'Item Groups', value: 'Item Group' },
-															{ label: 'Brands', value: 'Brand' },
-															{ label: 'Entire Transaction', value: 'Transaction' }
+															{ label: __('Specific Items'), value: 'Item Code' },
+															{ label: __('Item Groups'), value: 'Item Group' },
+															{ label: __('Brands'), value: 'Brand' },
+															{ label: __('Entire Transaction'), value: 'Transaction' }
 														]"
 														required
 													/>
@@ -377,8 +385,8 @@
 											<div class="p-5">
 												<div class="flex items-center space-x-2 mb-4">
 													<FeatherIcon name="list" class="w-4 h-4 text-green-600" />
-													<h4 class="text-sm font-semibold text-gray-900">Select {{ form.apply_on }}</h4>
-													<Badge variant="subtle" theme="red" size="sm">Required</Badge>
+													<h4 class="text-sm font-semibold text-gray-900">{{ __('Select {0}', [form.apply_on]) }}</h4>
+													<Badge variant="subtle" theme="red" size="sm">{{ __('Required') }}</Badge>
 												</div>
 
 												<!-- Item Code Search -->
@@ -388,13 +396,13 @@
 															type="text"
 															v-model="itemSearch"
 															:disabled="!isCreating"
-															placeholder="Search items... (min 2 characters)"
+															:placeholder="__('Search items... (min 2 characters)')"
 														>
 															<template #prefix>
 																<FeatherIcon name="search" class="w-4 h-4 text-gray-500" />
 															</template>
 														</FormControl>
-														<p class="text-xs text-gray-500 mt-1">Searching from {{ itemSearchStore.allItems.length }} cached items</p>
+														<p class="text-xs text-gray-500 mt-1">{{ __('Searching from {0} cached items', [itemSearchStore.allItems.length]) }}</p>
 													</div>
 
 													<!-- Search Results -->
@@ -439,7 +447,7 @@
 														:disabled="!isCreating"
 														@change="addItemGroup"
 														:options="[
-															{ label: '-- Select Item Group --', value: '' },
+															{ label: __('-- Select Item Group --'), value: '' },
 															...itemGroups.map(g => ({ label: g.name, value: g.name }))
 														]"
 													/>
@@ -470,7 +478,7 @@
 														:disabled="!isCreating"
 														@change="addBrand"
 														:options="[
-															{ label: '-- Select Brand --', value: '' },
+															{ label: __('-- Select Brand --'), value: '' },
 															...brands.map(b => ({ label: b.name, value: b.name }))
 														]"
 													/>
@@ -500,14 +508,14 @@
 											<div class="p-5">
 												<div class="flex items-center space-x-2 mb-4">
 													<FeatherIcon name="percent" class="w-4 h-4 text-purple-600" />
-													<h4 class="text-sm font-semibold text-gray-900">Discount Details</h4>
-													<Badge variant="subtle" theme="red" size="sm">Required</Badge>
+													<h4 class="text-sm font-semibold text-gray-900">{{ __('Discount Details') }}</h4>
+													<Badge variant="subtle" theme="red" size="sm">{{ __('Required') }}</Badge>
 												</div>
 
 												<div class="space-y-4">
 													<!-- Discount Type Selection -->
 													<div>
-														<label class="block text-sm font-medium text-gray-700 mb-3">Discount Type</label>
+														<label class="block text-sm font-medium text-gray-700 mb-3">{{ __('Discount Type') }}</label>
 														<div class="grid grid-cols-3 gap-3">
 															<button
 																v-for="type in discountTypes"
@@ -533,7 +541,7 @@
 														<FormControl
 															v-if="form.discount_type !== 'free_item'"
 															type="number"
-															:label="form.discount_type === 'percentage' ? 'Discount (%)' : `Discount (${currency})`"
+															:label="form.discount_type === 'percentage' ? __('Discount (%)') : __('discount ({0})', [currency])"
 															v-model="form.discount_value"
 															placeholder="0"
 															:disabled="isPricingRule"
@@ -542,14 +550,14 @@
 
 														<!-- Free Item Search -->
 														<div v-if="form.discount_type === 'free_item'" class="space-y-2">
-															<label class="block text-sm font-medium text-gray-700">Free Item <span class="text-red-500">*</span></label>
+															<label class="block text-sm font-medium text-gray-700">{{ __('Free Item') }}<span class="text-red-500"> *</span></label>
 
 															<!-- Search Input -->
 															<FormControl
 																v-if="!form.free_item"
 																type="text"
 																v-model="freeItemSearch"
-																placeholder="Search item... (min 2 characters)"
+																:placeholder="__('Search item... (min 2 characters)')"
 															>
 																<template #prefix>
 																	<FeatherIcon name="search" class="w-4 h-4 text-gray-500" />
@@ -590,7 +598,7 @@
 														<FormControl
 															v-if="form.discount_type === 'free_item'"
 															type="number"
-															label="Free Quantity"
+															:label="__('Free Quantity')"
 															v-model="form.free_qty"
 															placeholder="1"
 															:disabled="isPricingRule"
@@ -599,7 +607,7 @@
 
 														<FormControl
 															type="number"
-															label="Minimum Quantity"
+															:label="__('Minimum Quantity')"
 															v-model="form.min_qty"
 															placeholder="0"
 															:disabled="isPricingRule"
@@ -607,7 +615,7 @@
 
 														<FormControl
 															type="number"
-															label="Maximum Quantity"
+															:label="__('Maximum Quantity')"
 															v-model="form.max_qty"
 															placeholder="0"
 															:disabled="isPricingRule"
@@ -615,7 +623,7 @@
 
 														<FormControl
 															type="number"
-															:label="`Minimum Amount (${currency})`"
+															:label="__('Minimum Amount ({0})', [currency])"
 															v-model="form.min_amt"
 															placeholder="0"
 															:disabled="isPricingRule"
@@ -623,7 +631,7 @@
 
 														<FormControl
 															type="number"
-															:label="`Maximum Amount (${currency})`"
+															:label="__('Maximum Amount ({0})', [currency])"
 															v-model="form.max_amt"
 															placeholder="0"
 															:disabled="isPricingRule"
@@ -664,12 +672,14 @@
 									</div>
 								</div>
 								<div class="flex-1">
-									<h3 class="text-lg font-semibold text-gray-900 mb-2">Delete Promotion</h3>
-									<p class="text-sm text-gray-600 mb-1">
-										Are you sure you want to delete <strong>"{{ promotionToDelete?.name }}"</strong>?
-									</p>
+									<h3 class="text-lg font-semibold text-gray-900 mb-2">{{ __('Delete Promotion') }}</h3>
+									<TranslatedHTML
+										:tag="'p'"
+										class="text-sm text-gray-600 mb-1"
+										:inner="__('Are you sure you want to delete &lt;strong&gt;&quot;{0}&quot;&lt;strong&gt;?', [promotionToDelete?.name])"
+									/>
 									<p class="text-sm text-gray-500">
-										This will also delete all associated pricing rules. This action cannot be undone.
+										{{ __('This will also delete all associated pricing rules. This action cannot be undone.') }}
 									</p>
 								</div>
 							</div>
@@ -678,7 +688,7 @@
 									@click="cancelDelete"
 									variant="ghost"
 								>
-									Cancel
+									{{ __('Cancel') }}
 								</Button>
 								<Button
 									@click="confirmDelete"
@@ -688,7 +698,7 @@
 									<template #prefix>
 										<FeatherIcon name="trash-2" class="w-4 h-4" />
 									</template>
-									Delete Promotion
+									{{ __('Delete Promotion') }}
 								</Button>
 							</div>
 						</div>
@@ -714,6 +724,7 @@ import {
 } from "frappe-ui"
 import { FeatherIcon } from "frappe-ui"
 import { computed, onMounted, ref, watch } from "vue"
+import TranslatedHTML from "../common/TranslatedHTML.vue"
 
 // Use shared toast
 const { showSuccess, showError, showWarning } = useToast()
@@ -783,9 +794,9 @@ const selectedBrand = ref("")
 
 // Discount types
 const discountTypes = [
-	{ value: "percentage", label: "Percentage", icon: "percent" },
-	{ value: "amount", label: "Fixed Amount", icon: "dollar-sign" },
-	{ value: "free_item", label: "Free Item", icon: "gift" },
+	{ value: "percentage", label: __("Percentage"), icon: "percent" },
+	{ value: "amount", label: __("Fixed Amount"), icon: "dollar-sign" },
+	{ value: "free_item", label: __("Free Item"), icon: "gift" },
 ]
 
 // Computed
@@ -887,7 +898,7 @@ const itemGroupsResource = createResource({
 	},
 	onError(error) {
 		console.error("Error loading item groups:", error)
-		handleError(error, "Failed to load item groups")
+		handleError(error, __("Failed to load item groups"))
 	},
 })
 
@@ -899,7 +910,7 @@ const brandsResource = createResource({
 	},
 	onError(error) {
 		console.error("Error loading brands:", error)
-		handleError(error, "Failed to load brands")
+		handleError(error, __("Failed to load brands"))
 	},
 })
 
@@ -913,7 +924,7 @@ const savePromotionResource = createResource({
 		loading.value = false
 		const responseData = data?.message || data
 		const successMessage =
-			responseData?.message || "Promotion created successfully"
+			responseData?.message || __("Promotion created successfully")
 
 		showSuccess(successMessage)
 		emit("promotion-saved", responseData)
@@ -922,7 +933,7 @@ const savePromotionResource = createResource({
 	},
 	onError(error) {
 		loading.value = false
-		handleError(error, "Failed to create promotion")
+		handleError(error, __('Failed to create promotion'))
 	},
 })
 
@@ -949,7 +960,7 @@ const updatePromotionResource = createResource({
 		loading.value = false
 		const responseData = data?.message || data
 		const successMessage =
-			responseData?.message || "Promotion updated successfully"
+			responseData?.message || __("Promotion updated successfully")
 
 		showSuccess(successMessage)
 		loadPromotions()
@@ -957,7 +968,7 @@ const updatePromotionResource = createResource({
 	},
 	onError(error) {
 		loading.value = false
-		handleError(error, "Failed to update promotion")
+		handleError(error, __("Failed to update promotion"))
 	},
 })
 
@@ -965,11 +976,11 @@ const toggleResource = createResource({
 	url: "pos_next.api.promotions.toggle_promotion",
 	auto: false,
 	onSuccess() {
-		showSuccess("Promotion status updated successfully")
+		showSuccess(__("Promotion status updated successfully"))
 		loadPromotions()
 	},
 	onError(error) {
-		handleError(error, "Failed to update promotion status")
+		handleError(error, __("Failed to update promotion status"))
 	},
 })
 
@@ -979,7 +990,7 @@ const deleteResource = createResource({
 	onSuccess(data) {
 		const responseData = data?.message || data
 		const successMessage =
-			responseData?.message || "Promotion deleted successfully"
+			responseData?.message || __("Promotion deleted successfully")
 
 		showSuccess(successMessage)
 
@@ -995,7 +1006,7 @@ const deleteResource = createResource({
 		loading.value = false
 		showDeleteConfirm.value = false
 		promotionToDelete.value = null
-		handleError(error, "Failed to delete promotion")
+		handleError(error, __("Failed to delete promotion"))
 	},
 })
 
@@ -1013,7 +1024,7 @@ const promotionDetailsResource = createResource({
 	},
 	onError(error) {
 		loading.value = false
-		handleError(error, "Failed to load promotion details")
+		handleError(error, __("Failed to load promotion details"))
 	},
 })
 
@@ -1076,18 +1087,18 @@ function parseErrorMessage(error) {
 					typeof messages[0] === "string"
 						? JSON.parse(messages[0])
 						: messages[0]
-				return firstMessage.message || error.message || "An error occurred"
+				return firstMessage.message || error.message || __("An error occurred")
 			}
 		}
 		// Fallback to error.message
-		return error.message || "An error occurred"
+		return error.message || __("An error occurred")
 	} catch (e) {
-		return error.message || "An error occurred"
+		return error.message || __("An error occurred")
 	}
 }
 
 // Utility: Show error with proper parsing
-function handleError(error, defaultMessage = "An error occurred") {
+function handleError(error, defaultMessage = __("An error occurred")) {
 	const errorMessage = parseErrorMessage(error)
 	showError(errorMessage || defaultMessage)
 }
@@ -1156,7 +1167,7 @@ function cancelDelete() {
 function handleSubmit() {
 	// Validate
 	if (!form.value.name) {
-		showWarning("Please enter a promotion name")
+		showWarning(__("Please enter a promotion name"))
 		return
 	}
 
@@ -1167,14 +1178,14 @@ function handleSubmit() {
 		)
 		if (duplicate) {
 			showWarning(
-				`Promotion "${form.value.name}" already exists. Please use a different name.`,
+				__('Promotion "{0}" already exists. Please use a different name.', [form.value.name])
 			)
 			return
 		}
 	}
 
 	if (form.value.apply_on !== "Transaction" && form.value.items.length === 0) {
-		showWarning(`Please select at least one ${form.value.apply_on}`)
+		showWarning(__('`Please select at least one {0}`', [form.value.apply_on]))
 		return
 	}
 

--- a/POS/src/components/sale/ReturnInvoiceDialog.vue
+++ b/POS/src/components/sale/ReturnInvoiceDialog.vue
@@ -1,14 +1,14 @@
 <template>
 	<Dialog
-		v-model="show"
-		:options="{ title: 'Create Return Invoice', size: '5xl' }"
-	>
+        v-model="show"
+        :options="{ title: __('Create Return Invoice'), size: '5xl' }"
+    >
 		<template #body-content>
 			<div class="space-y-4">
 				<!-- Recent Invoices List -->
 				<div>
 					<label class="block text-sm font-medium text-gray-700 mb-3">
-						Select Invoice to Return
+						{{ __('Select Invoice to Return') }}
 					</label>
 
 					<!-- Search/Filter Input -->
@@ -16,7 +16,7 @@
 									<Input
 										v-model="invoiceListFilter"
 										type="text"
-										placeholder="Search by invoice number or customer name..."
+										:placeholder="__('Search by invoice number or customer name...')"
 										class="w-full"
 									/>
 								</div>
@@ -24,7 +24,7 @@
 								<!-- Loading State -->
 								<div v-if="loadInvoicesResource.loading" class="text-center py-8">
 									<div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"></div>
-									<p class="mt-2 text-xs text-gray-500">Loading invoices...</p>
+									<p class="mt-2 text-xs text-gray-500">{{ __('Loading invoices...') }}</p>
 								</div>
 
 								<!-- Invoice List -->
@@ -52,7 +52,7 @@
 										</div>
 									</div>
 									<p v-if="!loadInvoicesResource.loading && filteredInvoiceList.length === 0" class="text-center py-8 text-gray-500 text-sm">
-										No invoices found
+										{{ __('No invoices found') }}
 									</p>
 								</div>
 				</div>
@@ -60,7 +60,7 @@
 		</template>
 		<template #actions>
 			<Button variant="subtle" @click="show = false">
-				Close
+				{{ __('Close') }}
 			</Button>
 		</template>
 	</Dialog>
@@ -68,7 +68,7 @@
 	<!-- Return Process Modal -->
 	<Dialog
 		v-model="returnModal.visible"
-		:options="{ title: 'Process Return', size: '5xl' }"
+		:options="{ title: __('Process Return'), size: '5xl' }"
 	>
 		<template #body-content>
 			<div class="space-y-4">
@@ -91,16 +91,16 @@
 						</div>
 						<div class="space-y-2">
 							<div>
-								<p class="text-xs text-gray-500">Customer</p>
+								<p class="text-xs text-gray-500">{{ __('Customer') }}</p>
 								<p class="text-sm font-semibold text-gray-900">{{ originalInvoice.customer_name }}</p>
 							</div>
 							<div class="flex items-center justify-between">
 								<div>
-									<p class="text-xs text-gray-500">Date</p>
+									<p class="text-xs text-gray-500">{{ __('Date') }}</p>
 									<p class="text-sm font-semibold text-gray-900">{{ formatDate(originalInvoice.posting_date) }}</p>
 								</div>
 								<div class="text-right">
-									<p class="text-xs text-gray-500 mb-1">Total</p>
+									<p class="text-xs text-gray-500 mb-1">{{ __('Total') }}</p>
 									<p class="text-xl font-bold text-gray-900">
 										{{ formatCurrency(originalInvoice.grand_total) }}
 									</p>
@@ -125,17 +125,17 @@
 							</div>
 							<div class="mt-3 grid grid-cols-2 gap-3">
 								<div>
-									<p class="text-xs text-gray-500">Customer</p>
+									<p class="text-xs text-gray-500">{{ __('Customer') }}</p>
 									<p class="text-sm font-semibold text-gray-900">{{ originalInvoice.customer_name }}</p>
 								</div>
 								<div>
-									<p class="text-xs text-gray-500">Date</p>
+									<p class="text-xs text-gray-500">{{ __('Date') }}</p>
 									<p class="text-sm font-semibold text-gray-900">{{ formatDate(originalInvoice.posting_date) }}</p>
 								</div>
 							</div>
 						</div>
 						<div class="text-right ml-4">
-							<p class="text-xs text-gray-500 mb-1">Total Amount</p>
+							<p class="text-xs text-gray-500 mb-1">{{ __('Total Amount') }}</p>
 							<p class="text-2xl font-bold text-gray-900">
 								{{ formatCurrency(originalInvoice.grand_total) }}
 							</p>
@@ -147,14 +147,14 @@
 				<div v-if="originalInvoice">
 								<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 gap-2">
 									<label class="text-sm font-medium text-gray-700">
-										Select Items to Return
+										{{ __('Select Items to Return') }}
 									</label>
 									<div class="flex gap-2 self-start sm:self-auto">
 										<Button size="sm" variant="subtle" @click="selectAllItems">
-											<span class="text-xs whitespace-nowrap">Select All</span>
+											<span class="text-xs whitespace-nowrap">{{ __('Select All') }}</span>
 										</Button>
 										<Button size="sm" variant="subtle" @click="deselectAllItems">
-											<span class="text-xs whitespace-nowrap">Clear All</span>
+											<span class="text-xs whitespace-nowrap">{{ __('Clear All') }}</span>
 										</Button>
 									</div>
 								</div>
@@ -191,7 +191,7 @@
 															{{ item.item_code }}
 														</p>
 														<p v-if="item.already_returned > 0" class="text-xs text-amber-600 mt-1">
-															⚠️ {{ item.already_returned }} already returned
+															{{ __('⚠️ {0} already returned', [item.already_returned]) }}
 														</p>
 													</div>
 												</div>
@@ -199,7 +199,7 @@
 
 											<!-- Quantity Controls -->
 											<div class="flex items-center space-x-3 bg-gray-50 rounded-lg px-3 py-2 border border-gray-200" @click.stop>
-												<span class="text-xs font-medium text-gray-600">Return Qty:</span>
+												<span class="text-xs font-medium text-gray-600">{{ __('Return Qty:') }}</span>
 												<div class="flex items-center space-x-2">
 													<button
 														@click="decrementQty(item)"
@@ -231,7 +231,7 @@
 														</svg>
 													</button>
 												</div>
-												<span class="text-xs font-semibold text-gray-700">of {{ item.qty }}</span>
+												<span class="text-xs font-semibold text-gray-700">{{ __('of {0}', [item.qty], "item qty") }}</span>
 											</div>
 
 											<!-- Rate & Amount -->
@@ -261,7 +261,7 @@
 														{{ item.item_code }}
 													</p>
 													<p v-if="item.already_returned > 0" class="text-xs text-amber-600 mt-1">
-														⚠️ {{ item.already_returned }} already returned
+														{{ __('⚠️ {0} already returned', [item.already_returned]) }}
 													</p>
 												</div>
 											</div>
@@ -269,8 +269,8 @@
 											<!-- Quantity Controls -->
 											<div class="space-y-2" @click.stop>
 												<div class="flex items-center justify-between">
-													<span class="text-xs font-medium text-gray-600">Return Qty:</span>
-													<span class="text-xs text-gray-500">of {{ item.qty }}</span>
+													<span class="text-xs font-medium text-gray-600">{{ __('Return Qty:') }}</span>
+													<span class="text-xs text-gray-500">{{ __('of {0}', [item.qty], "item qty") }}</span>
 												</div>
 												<div class="flex items-center gap-2">
 													<button
@@ -303,7 +303,7 @@
 
 											<!-- Price -->
 											<div class="flex items-center justify-between px-1 pt-2 border-t border-gray-100">
-												<span class="text-xs text-gray-600">Amount:</span>
+												<span class="text-xs text-gray-600">{{ __('Amount:') }}</span>
 												<div class="text-right">
 													<p class="text-base font-bold text-gray-900">
 														{{ formatCurrency(item.rate * item.return_qty) }}
@@ -315,7 +315,7 @@
 									</div>
 								</div>
 								<p v-if="returnItems.length === 0" class="text-center py-8 text-gray-500">
-									No items available for return
+									{{ __('No items available for return') }}
 								</p>
 							</div>
 
@@ -323,10 +323,10 @@
 							<div v-if="selectedItems.length > 0">
 								<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 gap-2">
 									<label class="text-sm font-medium text-gray-700">
-										Refund Payment Methods
+										{{ __('Refund Payment Methods') }}
 									</label>
 									<Button size="sm" variant="subtle" @click="addPaymentRow" class="self-start sm:self-auto">
-										<span class="text-xs">+ Add Payment</span>
+										<span class="text-xs">{{ __('+ Add Payment') }}</span>
 									</Button>
 								</div>
 
@@ -347,7 +347,7 @@
 													v-model="payment.mode_of_payment"
 													class="flex-1 px-3 py-3 border-2 border-gray-300 rounded-lg text-base font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
 												>
-													<option value="">Select method...</option>
+													<option value="">{{ __('Select method...', null, 'payment') }}</option>
 													<option v-for="method in paymentMethods" :key="method.mode_of_payment" :value="method.mode_of_payment">
 														{{ method.mode_of_payment }}
 													</option>
@@ -365,7 +365,7 @@
 
 											<!-- Amount Input Row -->
 											<div class="flex items-center gap-3 pl-1">
-												<label class="text-sm font-medium text-gray-600 w-20">Amount:</label>
+												<label class="text-sm font-medium text-gray-600 w-20">{{ __('Amount:') }}</label>
 												<input
 													v-model.number="payment.amount"
 													type="number"
@@ -390,7 +390,7 @@
 													v-model="payment.mode_of_payment"
 													class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
 												>
-													<option value="">Select payment method...</option>
+													<option value="">{{ __('Select payment method...') }}</option>
 													<option v-for="method in paymentMethods" :key="method.mode_of_payment" :value="method.mode_of_payment">
 														{{ method.mode_of_payment }}
 													</option>
@@ -404,7 +404,7 @@
 													step="1"
 													min="0"
 													:max="returnTotal"
-													placeholder="Amount"
+													:placeholder="__('Amount')"
 													class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm text-right focus:outline-none focus:ring-2 focus:ring-blue-500"
 												/>
 											</div>
@@ -424,11 +424,11 @@
 								<!-- Payment Summary -->
 								<div class="mt-3 p-3 bg-gray-50 rounded-lg border border-gray-200">
 									<div class="flex items-center justify-between text-sm">
-										<span class="text-gray-600">Total Refund:</span>
+										<span class="text-gray-600">{{ __('Total Refund:') }}</span>
 										<span class="font-bold text-gray-900">{{ formatCurrency(returnTotal) }}</span>
 									</div>
 									<div class="flex items-center justify-between text-sm mt-1">
-										<span class="text-gray-600">Payment Total:</span>
+										<span class="text-gray-600">{{ __('Payment Total:') }}</span>
 										<span :class="[
 											'font-bold',
 											totalPaymentAmount === returnTotal ? 'text-green-600' : 'text-red-600'
@@ -437,7 +437,7 @@
 										</span>
 									</div>
 									<p v-if="totalPaymentAmount !== returnTotal" class="mt-2 text-xs text-amber-600">
-										⚠️ Payment total must equal refund amount
+										{{ __('⚠️ Payment total must equal refund amount') }}
 									</p>
 								</div>
 							</div>
@@ -448,17 +448,17 @@
 									<svg class="w-5 h-5 text-red-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2zM10 8.5a.5.5 0 11-1 0 .5.5 0 011 0zm5 5a.5.5 0 11-1 0 .5.5 0 011 0z"/>
 									</svg>
-									<h3 class="text-sm font-bold text-gray-900">Return Summary</h3>
+									<h3 class="text-sm font-bold text-gray-900">{{ __('Return Summary') }}</h3>
 								</div>
 								<div class="space-y-3">
 									<div class="flex justify-between items-center">
-										<span class="text-sm text-gray-600">Items to Return:</span>
+										<span class="text-sm text-gray-600">{{ __('Items to Return:') }}</span>
 										<span class="px-2 py-1 bg-white rounded-lg text-sm font-bold text-gray-900 border border-red-200">
 											{{ selectedItems.length }}
 										</span>
 									</div>
 									<div class="flex justify-between items-center pt-2 border-t border-red-200">
-										<span class="text-sm sm:text-base font-semibold text-gray-700">Refund Amount:</span>
+										<span class="text-sm sm:text-base font-semibold text-gray-700">{{ __('Refund Amount:') }}</span>
 										<span class="text-xl sm:text-2xl font-bold text-red-600">
 											{{ formatCurrency(returnTotal) }}
 										</span>
@@ -468,13 +468,15 @@
 
 							<!-- Return Reason -->
 							<div v-if="selectedItems.length > 0">
-								<label class="block text-sm font-medium text-gray-700 mb-2">
-									Return Reason <span class="text-gray-400">(optional)</span>
-								</label>
+								<TranslatedHTML 
+									:tag="'label'"
+									class="block text-sm font-medium text-gray-700 mb-2"
+									:inner="__('Return Reason &lt;span class=&quot;text-gray-400&quot;&gt;(optional)&lt;/span&gt;')"
+								/>
 								<textarea
 									v-model="returnReason"
 									rows="3"
-									placeholder="Enter reason for return (e.g., defective product, wrong item, customer request)..."
+									:placeholder="__('Enter reason for return (e.g., defective product, wrong item, customer request)...')"
 									class="w-full px-4 py-3 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 resize-none"
 								></textarea>
 				</div>
@@ -485,11 +487,11 @@
 				<p v-if="submitError" class="text-xs text-red-600">{{ submitError }}</p>
 				<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between w-full gap-2 sm:gap-3">
 					<p v-if="selectedItems.length > 0" class="text-xs text-gray-500 flex-shrink-0 order-2 sm:order-1">
-						{{ selectedItems.length }} item(s) selected
+						{{ __('{0} item(s) selected', [selectedItems.length]) }}
 					</p>
 					<div class="flex gap-2 w-full sm:w-auto sm:ml-auto flex-shrink-0 order-1 sm:order-2">
 						<Button variant="subtle" @click="closeReturnModal" class="flex-1 sm:flex-initial">
-							<span class="text-sm">Cancel</span>
+							<span class="text-sm">{{ __('Cancel') }}</span>
 						</Button>
 						<Button
 							variant="solid"
@@ -499,7 +501,7 @@
 							:loading="isSubmitting"
 							class="flex-1 sm:flex-initial"
 						>
-							<span class="text-sm whitespace-nowrap">Create Return</span>
+							<span class="text-sm whitespace-nowrap">{{ __('Create Return') }}</span>
 						</Button>
 					</div>
 				</div>
@@ -525,7 +527,7 @@
 		</template>
 		<template #actions>
 			<div class="flex justify-end w-full">
-				<Button variant="solid" theme="red" @click="closeErrorDialog">OK</Button>
+				<Button variant="solid" theme="red" @click="closeErrorDialog">{{ __('OK') }}</Button>
 			</div>
 		</template>
 	</Dialog>
@@ -536,6 +538,7 @@ import { useToast } from "@/composables/useToast"
 import { getPaymentIcon } from "@/utils/payment"
 import { Button, Dialog, Input, createResource } from "frappe-ui"
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from "vue"
+import TranslatedHTML from "../common/TranslatedHTML.vue"
 
 const { showSuccess, showError, showWarning } = useToast()
 
@@ -558,7 +561,7 @@ const submitError = ref("")
 const isSubmitting = ref(false)
 const errorDialog = reactive({
 	visible: false,
-	title: "Validation Error",
+	title: __("Validation Error"),
 	message: "",
 })
 const returnModal = reactive({
@@ -581,7 +584,7 @@ const loadInvoicesResource = createResource({
 	},
 	onError(error) {
 		console.error("Error loading invoices:", error)
-		showError("Failed to load recent invoices")
+		showError(__("Failed to load recent invoices"))
 	},
 })
 
@@ -614,11 +617,11 @@ const fetchInvoiceResource = createResource({
 		if (data) {
 			// Validate that invoice can be returned
 			if (data.docstatus !== 1) {
-				showWarning("Invoice must be submitted to create a return")
+				showWarning(__("Invoice must be submitted to create a return"))
 				return
 			}
 			if (data.is_return === 1) {
-				showWarning("Cannot create return against a return invoice")
+				showWarning(__("Cannot create return against a return invoice"))
 				return
 			}
 
@@ -626,7 +629,7 @@ const fetchInvoiceResource = createResource({
 			const availableItems = data.items.filter((item) => item.qty > 0)
 
 			if (availableItems.length === 0) {
-				showWarning("All items from this invoice have already been returned")
+				showWarning(__("All items from this invoice have already been returned"))
 				originalInvoice.value = null
 				returnItems.value = []
 				return
@@ -652,7 +655,7 @@ const fetchInvoiceResource = createResource({
 	},
 	onError(error) {
 		console.error("Error fetching invoice:", error)
-		showError("Failed to load invoice details")
+		showError(__("Failed to load invoice details"))
 	},
 })
 
@@ -686,7 +689,7 @@ const createReturnResource = createResource({
 				amount: -Math.abs(payment.amount), // Negative for refunds
 			})),
 			remarks:
-				returnReason.value || `Return against ${originalInvoice.value.name}`,
+				returnReason.value || __('Return against {0}', [originalInvoice.value.name]),
 		}
 
 		// Return in the correct format: invoice as JSON string
@@ -713,7 +716,7 @@ const createReturnResource = createResource({
 
 		// Close return modal and go back to invoice list
 		closeReturnModal()
-		showSuccess(`Return invoice ${data.name} created successfully`)
+		showSuccess(__('Return invoice {0} created successfully', [data.name]))
 	},
 	onError(error) {
 		isSubmitting.value = false
@@ -833,7 +836,7 @@ watch(returnTotal, (newTotal) => {
 // Methods
 function extractErrorMessage(
 	error,
-	fallback = "Failed to create return invoice",
+	fallback = __("Failed to create return invoice"),
 ) {
 	if (!error) return fallback
 
@@ -877,7 +880,7 @@ function extractErrorMessage(
 	return fallback
 }
 
-function openErrorDialog(message, title = "Validation Error") {
+function openErrorDialog(message, title = __("Validation Error")) {
 	errorDialog.title = title
 	errorDialog.message = message
 	errorDialog.visible = true
@@ -912,9 +915,12 @@ function validateSelectedItems() {
 	}
 	invalidItems.forEach(normalizeItemQty)
 	const details = invalidItems
-		.map((item) => `${item.item_name || item.item_code}: maximum ${item.qty}`)
+		.map((item) => __('{0}: maximum {1}', [
+			(item.item_name || item.item_code),
+			item.qty
+		]))
 		.join("\n")
-	const message = `Adjust return quantities before submitting.\n\n${details}`
+	const message = __('Adjust return quantities before submitting.\n\n{0}', [details])
 	submitError.value = message
 	openErrorDialog(message)
 	return false

--- a/POS/src/components/sale/WarehouseAvailabilityDialog.vue
+++ b/POS/src/components/sale/WarehouseAvailabilityDialog.vue
@@ -23,14 +23,14 @@
 								</svg>
 							</div>
 							<div>
-								<h2 class="text-lg font-semibold text-gray-900">Warehouse Availability</h2>
+								<h2 class="text-lg font-semibold text-gray-900">{{ __('Warehouse Availability') }}</h2>
 								<p class="text-sm text-gray-500">{{ itemName }}</p>
 							</div>
 						</div>
 						<button
 							@click="$emit('close')"
 							class="p-2 hover:bg-gray-100 rounded-lg transition-colors"
-							aria-label="Close dialog"
+							:aria-label="__('Close dialog')"
 						>
 							<svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
@@ -44,7 +44,7 @@
 						<div v-if="loading" class="flex items-center justify-center py-12">
 							<div class="text-center">
 								<div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto"></div>
-								<p class="mt-4 text-sm text-gray-500">Checking warehouse availability...</p>
+								<p class="mt-4 text-sm text-gray-500">{{ __('Checking warehouse availability...') }}</p>
 							</div>
 						</div>
 
@@ -59,7 +59,7 @@
 									@click="loadAvailability"
 									class="mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
 								>
-									Try Again
+									{{ __('Try Again') }}
 								</button>
 							</div>
 						</div>
@@ -84,14 +84,14 @@
 											<span v-if="warehouse.reserved_qty > 0" class="text-orange-600">
 												{{ Math.floor(warehouse.reserved_qty) }} reserved
 											</span>
-											<span v-else>Available</span>
+											<span v-else>{{ __('Available') }}</span>
 										</div>
 									</div>
 								</div>
 								<!-- Actual vs Available -->
 								<div v-if="warehouse.actual_qty !== warehouse.available_qty" class="mt-2 pt-2 border-t border-gray-200">
 									<div class="flex items-center justify-between text-xs text-gray-600">
-										<span>Actual Stock:</span>
+										<span>{{ __('Actual Stock:') }}</span>
 										<span class="font-medium">{{ Math.floor(warehouse.actual_qty) }} {{ uom }}</span>
 									</div>
 								</div>
@@ -104,8 +104,8 @@
 								<svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
 								</svg>
-								<p class="mt-4 text-sm text-gray-700 font-medium">No stock available</p>
-								<p class="mt-1 text-sm text-gray-500">This item is out of stock in all warehouses</p>
+								<p class="mt-4 text-sm text-gray-700 font-medium">{{ __('No stock available') }}</p>
+								<p class="mt-1 text-sm text-gray-500">{{ __('This item is out of stock in all warehouses') }}</p>
 							</div>
 						</div>
 					</div>
@@ -114,19 +114,22 @@
 					<div class="px-6 py-4 border-t border-gray-200 bg-gray-50 rounded-b-xl">
 						<div class="flex items-center justify-between">
 							<div class="text-sm text-gray-600">
-								<span class="font-medium">Total Available:</span>
+								<span class="font-medium">{{ __('Total Available:') }}</span>
 								<span class="ml-2 text-gray-900 font-semibold">
 									{{ totalAvailable }} {{ uom }}
 								</span>
 								<span v-if="warehouses && warehouses.length > 0" class="ml-2 text-gray-500">
-									across {{ warehouses.length }} {{ warehouses.length === 1 ? 'warehouse' : 'warehouses' }}
+									{{ warehouses.length === 1
+										? __('across 1 warehouse')
+										: __('across {0} warehouses', [warehouses.length])
+									}}
 								</span>
 							</div>
 							<button
 								@click="$emit('close')"
 								class="px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors"
 							>
-								Close
+								{{ __('Close') }}
 							</button>
 						</div>
 					</div>

--- a/POS/src/components/settings/POSSettings.vue
+++ b/POS/src/components/settings/POSSettings.vue
@@ -19,7 +19,7 @@
 								</svg>
 							</div>
 							<div>
-								<h2 class="text-xl font-bold text-gray-900">POS Settings</h2>
+								<h2 class="text-xl font-bold text-gray-900">{{ __('POS Settings') }}</h2>
 								<p class="text-sm text-gray-600 flex items-center mt-0.5">
 									<svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
@@ -40,7 +40,7 @@
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
 									</svg>
 								</template>
-								Refresh
+								{{ __('Refresh') }}
 							</Button>
 							<Button
 								@click="saveSettings"
@@ -53,7 +53,7 @@
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
 									</svg>
 								</template>
-								Save Changes
+								{{ __('Save Changes') }}
 							</Button>
 							<button
 								@click="handleClose"
@@ -71,7 +71,7 @@
 						<!-- Loading State -->
 						<div v-if="loading" class="flex flex-col items-center justify-center py-16">
 							<div class="animate-spin rounded-full h-12 w-12 border-b-3 border-blue-500 mb-4"></div>
-							<p class="text-sm font-medium text-gray-600">Loading settings...</p>
+							<p class="text-sm font-medium text-gray-600">{{ __('Loading settings...') }}</p>
 						</div>
 
 						<!-- Settings Form -->
@@ -87,15 +87,15 @@
 												</svg>
 											</div>
 											<div>
-												<h3 class="text-lg font-bold text-gray-900">Stock Management</h3>
-												<p class="text-xs text-gray-600 mt-0.5">Configure warehouse and inventory settings</p>
+												<h3 class="text-lg font-bold text-gray-900">{{ __('Stock Management') }}</h3>
+												<p class="text-xs text-gray-600 mt-0.5">{{ __('Configure warehouse and inventory settings') }}</p>
 											</div>
 										</div>
 										<div :class="stockSectionClasses.badge">
 											<svg :class="stockSectionClasses.badgeIcon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="icons.checkCircle"/>
 											</svg>
-											<span :class="stockSectionClasses.badgeText">Stock Controls</span>
+											<span :class="stockSectionClasses.badgeText">{{ __('Stock Controls') }}</span>
 										</div>
 									</div>
 								</div>
@@ -106,20 +106,20 @@
 											<svg :class="warehouseSubsectionClasses.icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="icons.location"/>
 											</svg>
-											<h4 class="text-sm font-semibold text-gray-900">Warehouse Selection</h4>
+											<h4 class="text-sm font-semibold text-gray-900">{{ __('Warehouse Selection') }}</h4>
 										</div>
 										<div v-if="warehouseOptions.length === 0" class="flex items-center p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
 											<svg class="w-5 h-5 text-yellow-600 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="icons.warning"/>
 											</svg>
-											<p class="text-sm text-yellow-800 font-medium">Loading warehouses...</p>
+											<p class="text-sm text-yellow-800 font-medium">{{ __('Loading warehouses...') }}</p>
 										</div>
 										<SelectField
 											v-else
 											v-model="selectedWarehouse"
-											label="Active Warehouse"
+											:label="__('Active Warehouse')"
 											:options="warehouseOptions"
-											description="All stock operations will use this warehouse. Stock quantities will refresh after saving."
+											:description="__('All stock operations will use this warehouse. Stock quantities will refresh after saving.')"
 										/>
 									</div>
 
@@ -129,23 +129,24 @@
 											<svg :class="stockPolicySubsectionClasses.icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="icons.clipboard"/>
 											</svg>
-											<h4 class="text-sm font-semibold text-gray-900">Stock Validation Policy</h4>
+											<h4 class="text-sm font-semibold text-gray-900">{{ __('Stock Validation Policy') }}</h4>
 										</div>
 										<div class="space-y-3">
 											<CheckboxField
 												v-model="settings.allow_negative_stock"
-												label="Allow Negative Stock"
-												description="Enable selling items even when stock reaches zero or below. Integrates with ERPNext stock settings."
+												:label="__('Allow Negative Stock')"
+												:description="__('Enable selling items even when stock reaches zero or below. Integrates with ERPNext stock settings.')"
 											/>
 											<div class="mt-3 p-3 bg-blue-100 rounded-md">
 												<div class="flex items-start space-x-2">
 													<svg class="w-4 h-4 text-blue-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 														<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="icons.info"/>
 													</svg>
-													<p class="text-xs text-blue-800 leading-relaxed">
-														<strong>Note:</strong> When enabled, the system will allow sales even when stock quantity is zero or negative.
-														This is useful for handling stock sync delays or backorders. All transactions are tracked in the stock ledger.
-													</p>
+													<TranslatedHTML 
+														:tag="'p'"
+														class="text-xs text-blue-800 leading-relaxed" 
+														:inner="__('&lt;strong&gt;Note:&lt;strong&gt; When enabled, the system will allow sales even when stock quantity is zero or negative. This is useful for handling stock sync delays or backorders. All transactions are tracked in the stock ledger.')"
+													/>
 												</div>
 											</div>
 										</div>
@@ -157,14 +158,14 @@
 											<svg :class="stockSyncSubsectionClasses.icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
 											</svg>
-											<h4 class="text-sm font-semibold text-gray-900">Background Stock Sync</h4>
+											<h4 class="text-sm font-semibold text-gray-900">{{ __('Background Stock Sync') }}</h4>
 											<div v-if="stockSyncStatus.enabled" class="ml-auto flex items-center px-2.5 py-1 bg-green-100 border border-green-300 rounded-full">
 												<div class="w-2 h-2 bg-green-500 rounded-full animate-pulse mr-2"></div>
-												<span class="text-xs font-medium text-green-800">Active</span>
+												<span class="text-xs font-medium text-green-800">{{ __('Active') }}</span>
 											</div>
 											<div v-else class="ml-auto flex items-center px-2.5 py-1 bg-gray-100 border border-gray-300 rounded-full">
 												<div class="w-2 h-2 bg-gray-400 rounded-full mr-2"></div>
-												<span class="text-xs font-medium text-gray-600">Inactive</span>
+												<span class="text-xs font-medium text-gray-600">{{ __('Inactive') }}</span>
 											</div>
 										</div>
 
@@ -172,16 +173,16 @@
 											<!-- Enable Sync Toggle -->
 											<CheckboxField
 												v-model="stockSyncEnabled"
-												label="Enable Automatic Stock Sync"
-												description="Periodically sync stock quantities from server in the background (runs in Web Worker)"
+												:label="__('Enable Automatic Stock Sync')"
+												:description="__('Periodically sync stock quantities from server in the background (runs in Web Worker)')"
 											/>
 
 											<!-- Sync Interval -->
 											<div v-if="stockSyncEnabled" class="pl-6 space-y-3 border-l-2 border-blue-200">
 												<NumberField
 													v-model="stockSyncIntervalSeconds"
-													label="Sync Interval (seconds)"
-													description="How often to check server for stock updates (minimum 10 seconds)"
+													:label="__('Sync Interval (seconds)')"
+													:description="__('How often to check server for stock updates (minimum 10 seconds)')"
 													:min="10"
 													:max="300"
 													:step="10"
@@ -194,13 +195,28 @@
 															<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="icons.info"/>
 														</svg>
 														<div class="text-xs text-blue-800 space-y-1">
-															<p><strong>Status:</strong> {{ stockSyncStatus.enabled ? 'Running' : 'Stopped' }}</p>
-															<p><strong>Items Tracked:</strong> {{ stockSyncStatus.itemCount || 0 }}</p>
-															<p><strong>Warehouse:</strong> {{ stockSyncStatus.warehouse || 'Not set' }}</p>
-															<p v-if="stockSyncStatus.lastSync">
-																<strong>Last Sync:</strong> {{ formatSyncTime(stockSyncStatus.lastSync) }}
-															</p>
-															<p v-else><strong>Last Sync:</strong> Never</p>
+															<TranslatedHTML 
+																:tag="'p'"
+																:inner="stockSyncStatus.enabled 
+																	? __('&lt;strong&gt;Status:&lt;strong&gt; Running')
+																	: __('&lt;strong&gt;Status:&lt;strong&gt; Stopped')"
+															/>
+															<TranslatedHTML
+																:tag="'p'"
+																:inner="__('&lt;strong&gt;Items Tracked:&lt;strong&gt; {0}', [stockSyncStatus.itemCount || 0])"
+															/>
+															<TranslatedHTML 
+																:tag="'p'"
+																:inner="stockSyncStatus.warehouse
+																	? __('&lt;strong&gt;Warehouse:&lt;strong&gt; {0}', [stockSyncStatus.warehouse])
+																	: __('Warehouse not set')"
+															/>
+															<TranslatedHTML 
+																:tag="'p'"
+																:inner="stockSyncStatus.lastSync
+																	? __('&lt;strong&gt;Last Sync:&lt;strong&gt; {0}', [formatSyncTime(stockSyncStatus.lastSync)]) 
+																	: __('&lt;strong&gt;Last Sync:&lt;strong&gt; Never')"
+															/>
 														</div>
 													</div>
 												</div>
@@ -212,9 +228,9 @@
 															<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
 														</svg>
 														<div class="text-xs text-gray-700">
-															<p class="font-medium mb-1">Network Usage:</p>
-															<p>~15 KB per sync cycle</p>
-															<p>~{{ Math.round((3600 / stockSyncIntervalSeconds) * 15 / 1024) }} MB per hour</p>
+															<p class="font-medium mb-1">{{ __('Network Usage:') }}</p>
+															<p>{{ __('~15 KB per sync cycle') }}</p>
+															<p>{{ __('~{0} MB per hour', [Math.round((3600 / stockSyncIntervalSeconds) * 15 / 1024)]) }}</p>
 														</div>
 													</div>
 												</div>
@@ -235,15 +251,15 @@
 												</svg>
 											</div>
 											<div>
-												<h3 class="text-lg font-bold text-gray-900">Sales Management</h3>
-												<p class="text-xs text-gray-600 mt-0.5">Configure pricing, discounts, and sales operations</p>
+												<h3 class="text-lg font-bold text-gray-900">{{ __('Sales Management') }}</h3>
+												<p class="text-xs text-gray-600 mt-0.5">{{ __('Configure pricing, discounts, and sales operations') }}</p>
 											</div>
 										</div>
 										<div :class="salesSectionClasses.badge">
 											<svg :class="salesSectionClasses.badgeIcon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="icons.currency"/>
 											</svg>
-											<span :class="salesSectionClasses.badgeText">Sales Controls</span>
+											<span :class="salesSectionClasses.badgeText">{{ __('Sales Controls') }}</span>
 										</div>
 									</div>
 								</div>
@@ -254,40 +270,40 @@
 											<svg :class="pricingSubsectionClasses.icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="icons.tag"/>
 											</svg>
-											<h4 class="text-sm font-semibold text-gray-900">Pricing & Discounts</h4>
+											<h4 class="text-sm font-semibold text-gray-900">{{ __('Pricing & Discounts') }}</h4>
 										</div>
 										<div class="space-y-3">
 											<CheckboxField
 												v-model="settings.tax_inclusive"
-												label="Tax Inclusive"
-												description="When enabled, displayed prices include tax. When disabled, tax is calculated separately. Changes apply immediately to your cart when you save."
+												:label="__('Tax Inclusive')"
+												:description="__('When enabled, displayed prices include tax. When disabled, tax is calculated separately. Changes apply immediately to your cart when you save.')"
 											/>
 											<NumberField
 												v-model="settings.max_discount_allowed"
-												label="Max Discount (%)"
-												description="Maximum discount per item"
+												:label="__('Max Discount (%)')"
+												:description="__('Maximum discount per item')"
 												:min="0"
 												:max="100"
 											/>
 											<CheckboxField
 												v-model="settings.use_percentage_discount"
-												label="Use Percentage Discount"
-												description="Show discounts as percentages"
+												:label="__('Use Percentage Discount')"
+												:description="__('Show discounts as percentages')"
 											/>
 											<CheckboxField
 												v-model="settings.allow_user_to_edit_additional_discount"
-												label="Allow Additional Discount"
-												description="Enable invoice-level discount"
+												:label="__('Allow Additional Discount')"
+												:description="__('Enable invoice-level discount')"
 											/>
 											<CheckboxField
 												v-model="settings.allow_user_to_edit_item_discount"
-												label="Allow Item Discount"
-												description="Enable item-level discount in edit dialog"
+												:label="__('Allow Item Discount')"
+												:description="__('Enable item-level discount in edit dialog')"
 											/>
 											<CheckboxField
 												v-model="settings.disable_rounded_total"
-												label="Disable Rounded Total"
-												description="Show exact totals without rounding"
+												:label="__('Disable Rounded Total')"
+												:description="__('Show exact totals without rounding')"
 											/>
 										</div>
 									</div>
@@ -298,33 +314,33 @@
 											<svg :class="operationsSubsectionClasses.icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="icons.checkCircle"/>
 											</svg>
-											<h4 class="text-sm font-semibold text-gray-900">Sales Operations</h4>
+											<h4 class="text-sm font-semibold text-gray-900">{{ __('Sales Operations') }}</h4>
 										</div>
 										<div class="space-y-3">
 											<CheckboxField
 												v-model="settings.allow_credit_sale"
-												label="Allow Credit Sale"
-												description="Enable sales on credit"
+												:label="__('Allow Credit Sale')"
+												:description="__('Enable sales on credit')"
 											/>
 											<CheckboxField
 												v-model="settings.allow_return"
-												label="Allow Return"
-												description="Enable product returns"
+												:label="__('Allow Return')"
+												:description="__('Enable product returns')"
 											/>
 											<CheckboxField
 												v-model="settings.allow_write_off_change"
-												label="Allow Write Off Change"
-												description="Write off small change amounts"
+												:label="__('Allow Write Off Change')"
+												:description="__('Write off small change amounts')"
 											/>
 											<CheckboxField
 												v-model="settings.allow_partial_payment"
-												label="Allow Partial Payment"
-												description="Enable partial payment for invoices"
+												:label="__('Allow Partial Payment')"
+												:description="__('Enable partial payment for invoices')"
 											/>
 											<CheckboxField
 												v-model="settings.silent_print"
-												label="Silent Print"
-												description="Print without confirmation"
+												:label="__('Silent Print')"
+												:description="__('Print without confirmation')"
 											/>
 										</div>
 									</div>
@@ -339,8 +355,8 @@
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
 							</svg>
-							<p class="text-gray-600 font-medium">No POS Profile Selected</p>
-							<p class="text-gray-500 text-sm mt-1">Please select a POS Profile to configure settings</p>
+							<p class="text-gray-600 font-medium">{{ __('No POS Profile Selected') }}</p>
+							<p class="text-gray-500 text-sm mt-1">{{ __('Please select a POS Profile to configure settings') }}</p>
 						</div>
 					</div>
 				</div>
@@ -364,6 +380,7 @@ import {
 import { offlineWorker } from "@/utils/offline/workerClient"
 import { logger } from "@/utils/logger"
 import { usePOSEvents } from "@/composables/usePOSEvents"
+import TranslatedHTML from "../common/TranslatedHTML.vue"
 
 const log = logger.create('POSSettings')
 const { detectSettingsChanges, updateSettingsSnapshot, emitStockSyncConfigured } = usePOSEvents()
@@ -475,7 +492,7 @@ const settingsResource = createResource({
 	},
 	onError(error) {
 		loading.value = false
-		showError("Failed to load settings")
+		showError(__("Failed to load settings"))
 	},
 })
 
@@ -560,7 +577,7 @@ async function loadSettings() {
 
 async function saveSettings() {
 	if (!props.posProfile) {
-		showError("POS Profile not found")
+		showError(__("POS Profile not found"))
 		return
 	}
 
@@ -633,20 +650,21 @@ async function saveSettings() {
 		}
 
 		// Show success toast for other changes
-		let successMessage = "Settings saved successfully"
+		let successMessage = __("Settings saved successfully")
 		if (warehouseChanged && taxInclusiveChanged) {
-			successMessage = "Settings saved, warehouse updated, and tax mode changed. Cart will be recalculated."
+			successMessage = __("Settings saved, warehouse updated, and tax mode changed. Cart will be recalculated.")
 		} else if (warehouseChanged) {
-			successMessage = "Settings saved and warehouse updated. Reloading stock..."
+			successMessage = __("Settings saved and warehouse updated. Reloading stock...")
 		} else if (taxInclusiveChanged) {
-			const mode = settings.value.tax_inclusive ? 'inclusive' : 'exclusive'
-			successMessage = `Settings saved. Tax mode is now ${mode}. Cart will be recalculated.`
+			successMessage = settings.value.tax_inclusive
+				? __('Settings saved. Tax mode is now "inclusive". Cart will be recalculated.')
+				: __('Settings saved. Tax mode is now "exclusive". Cart will be recalculated.')
 		}
 
 		showSuccess(successMessage)
 	} catch (error) {
 		log.error("Error saving settings:", error)
-		showError(error.message || "Failed to save settings")
+		showError(error.message || __("Failed to save settings"))
 	} finally {
 		saving.value = false
 	}
@@ -726,15 +744,15 @@ async function applyStockSyncConfig() {
 
 // Format sync time for display
 function formatSyncTime(timestamp) {
-	if (!timestamp) return 'Never'
+	if (!timestamp) return __('Never')
 
 	const now = Date.now()
 	const diff = now - timestamp
 
 	if (diff < 60000) {
-		return `${Math.floor(diff / 1000)}s ago`
+		return __('{0}s ago', [Math.floor(diff / 1000)])
 	} else if (diff < 3600000) {
-		return `${Math.floor(diff / 60000)}m ago`
+		return __('{0}m ago', [Math.floor(diff / 60000)])
 	} else {
 		const date = new Date(timestamp)
 		return date.toLocaleTimeString()

--- a/POS/src/components/settings/SelectField.vue
+++ b/POS/src/components/settings/SelectField.vue
@@ -9,7 +9,7 @@
 			@change="$emit('update:modelValue', $event.target.value)"
 			class="w-full px-2.5 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent bg-white cursor-pointer"
 		>
-			<option value="">-- Select --</option>
+			<option value="">{{ __('-- Select --') }}</option>
 			<option
 				v-for="option in options"
 				:key="option.value"

--- a/POS/src/composables/useInvoiceFilters.js
+++ b/POS/src/composables/useInvoiceFilters.js
@@ -255,21 +255,21 @@ export function useInvoiceFilters(invoices) {
  * Exported for use in filter UI components
  */
 export const DATE_PRESETS = [
-	{ label: "Today", value: "today", action: "setToday" },
-	{ label: "Yesterday", value: "yesterday", action: "setYesterday" },
-	{ label: "This Week", value: "week", action: "setThisWeek" },
-	{ label: "This Month", value: "month", action: "setThisMonth" },
-	{ label: "Last 7 Days", value: "last7", action: "setLast7Days" },
-	{ label: "Last 30 Days", value: "last30", action: "setLast30Days" },
+	{ label: __("Today"), value: "today", action: "setToday" },
+	{ label: __("Yesterday"), value: "yesterday", action: "setYesterday" },
+	{ label: __("This Week"), value: "week", action: "setThisWeek" },
+	{ label: __("This Month"), value: "month", action: "setThisMonth" },
+	{ label: __("Last 7 Days"), value: "last7", action: "setLast7Days" },
+	{ label: __("Last 30 Days"), value: "last30", action: "setLast30Days" },
 ]
 
 /**
  * Payment status options
  */
 export const PAYMENT_STATUS_OPTIONS = [
-	{ label: "All Status", value: "" },
-	{ label: "Paid", value: "Paid" },
-	{ label: "Unpaid", value: "Unpaid" },
-	{ label: "Partly Paid", value: "Partly Paid" },
-	{ label: "Overdue", value: "Overdue" },
+	{ label: __("All Status"), value: "" },
+	{ label: __("Paid"), value: "Paid" },
+	{ label: __("Unpaid"), value: "Unpaid" },
+	{ label: __("Partly Paid"), value: "Partly Paid" },
+	{ label: __("Overdue"), value: "Overdue" },
 ]

--- a/POS/src/composables/useStock.js
+++ b/POS/src/composables/useStock.js
@@ -26,7 +26,7 @@ export function useStock() {
 				level: "negative",
 				color: "bg-red-500",
 				textColor: "text-white",
-				label: "Negative Stock",
+				label: __("Negative Stock"),
 			}
 		}
 
@@ -35,7 +35,7 @@ export function useStock() {
 				level: "out",
 				color: "bg-red-500",
 				textColor: "text-white",
-				label: "Out of Stock",
+				label: __("Out of Stock"),
 			}
 		}
 
@@ -44,7 +44,7 @@ export function useStock() {
 				level: "low",
 				color: "bg-amber-500",
 				textColor: "text-white",
-				label: "Low Stock",
+				label: __("Low Stock"),
 			}
 		}
 
@@ -52,7 +52,7 @@ export function useStock() {
 			level: "safe",
 			color: "bg-green-500",
 			textColor: "text-white",
-			label: "In Stock",
+			label: __("In Stock"),
 		}
 	}
 

--- a/POS/src/main.js
+++ b/POS/src/main.js
@@ -12,6 +12,7 @@ import {
 	onCSRFTokenRefresh,
 } from "./utils/csrf"
 import { offlineWorker } from "./utils/offline/workerClient"
+import translationPlugin from "./utils/translation"
 
 import {
 	Alert,
@@ -113,6 +114,7 @@ async function initializeApp() {
 	app.use(pinia)
 	app.use(resourcesPlugin)
 	app.use(pageMetaPlugin)
+	app.use(translationPlugin)
 
 	for (const key in globalComponents) {
 		app.component(key, globalComponents[key])

--- a/POS/src/pages/Home.vue
+++ b/POS/src/pages/Home.vue
@@ -5,12 +5,12 @@
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
           <div class="flex items-center space-x-4">
-            <h1 class="text-xl font-semibold text-gray-900">POS Next</h1>
+            <h1 class="text-xl font-semibold text-gray-900">{{ __('POS Next') }}</h1>
 
             <!-- Shift Status Indicator -->
             <div v-if="hasOpenShift" class="flex items-center space-x-2 px-3 py-1 bg-green-100 rounded-full">
               <div class="h-2 w-2 bg-green-500 rounded-full"></div>
-              <span class="text-xs font-medium text-green-700">Shift Open</span>
+              <span class="text-xs font-medium text-green-700">{{ __('Shift Open') }}</span>
             </div>
           </div>
 
@@ -37,7 +37,7 @@
               :loading="session.logout.loading"
               class="text-gray-500 hover:text-gray-700"
             >
-              {{ session.logout.loading ? 'Signing out...' : 'Sign out' }}
+              {{ session.logout.loading ? __('Signing out...') : __('Sign out') }}
             </Button>
           </div>
         </div>
@@ -50,17 +50,17 @@
         <div class="border-4 border-dashed border-gray-200 rounded-lg min-h-96 p-8">
           <div class="text-center">
             <h2 class="text-2xl font-bold text-gray-900 mb-4">
-              Welcome to POS Next!
+              {{ __('Welcome to POS Next!') }}
             </h2>
             <p class="text-gray-600 mb-8">
-              Your point of sale system is ready to use.
+              {{ __('Your point of sale system is ready to use.') }}
             </p>
 
             <!-- Shift Management Section -->
             <div class="max-w-2xl mx-auto space-y-4">
               <!-- Shift Status Card -->
               <div class="bg-white p-6 rounded-lg shadow">
-                <h3 class="text-lg font-medium text-gray-900 mb-4">Shift Status</h3>
+                <h3 class="text-lg font-medium text-gray-900 mb-4">{{ __('Shift Status') }}</h3>
 
                 <div v-if="hasOpenShift" class="space-y-4">
                   <div class="bg-green-50 border border-green-200 rounded-lg p-4">
@@ -68,12 +68,21 @@
                       <div class="flex-1">
                         <div class="flex items-center space-x-2 mb-2">
                           <div class="h-3 w-3 bg-green-500 rounded-full"></div>
-                          <span class="font-medium text-green-900">Shift is Open</span>
+                          <span class="font-medium text-green-900">{{ __('Shift is Open') }}</span>
                         </div>
                         <div class="text-sm text-green-700 space-y-1">
-                          <p><strong>POS Profile:</strong> {{ currentProfile?.name }}</p>
-                          <p><strong>Company:</strong> {{ currentCompany?.name }}</p>
-                          <p><strong>Opened:</strong> {{ formatDateTime(currentShift?.period_start_date) }}</p>
+                          <TranslatedHTML 
+                            :tag="'p'"
+                            :inner="__('&lt;strong&gt;POS Profile:&lt;strong&gt; {0}', [currentProfile?.name])"
+                          />
+                          <TranslatedHTML 
+                            :tag="'p'"
+                            :inner="__('&lt;strong&gt;Company:&lt;strong&gt;', [currentCompany?.name])"
+                          />
+                          <TranslatedHTML 
+                            :tag="'p'"
+                            :inner="__('&lt;strong&gt;Opened:&lt;strong&gt;', [formatDateTime(currentShift?.period_start_date)])"
+                          />
                         </div>
                       </div>
                     </div>
@@ -86,7 +95,7 @@
                       @click="openCloseShiftDialog"
                       class="flex-1"
                     >
-                      Close Shift
+                      {{ __('Close Shift') }}
                     </Button>
                     <Button
                       variant="solid"
@@ -94,7 +103,7 @@
                       @click="startSale"
                       class="flex-1"
                     >
-                      Start Sale
+                      {{ __('Start Sale') }}
                     </Button>
                   </div>
                 </div>
@@ -105,10 +114,10 @@
                       <svg class="h-5 w-5 text-yellow-600" fill="currentColor" viewBox="0 0 20 20">
                         <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
                       </svg>
-                      <span class="font-medium text-yellow-900">No Active Shift</span>
+                      <span class="font-medium text-yellow-900">{{ __('No Active Shift') }}</span>
                     </div>
                     <p class="text-sm text-yellow-700">
-                      You need to open a shift before you can start making sales.
+                      {{ __('You need to open a shift before you can start making sales.') }}
                     </p>
                   </div>
 
@@ -118,14 +127,14 @@
                     @click="showOpenShiftDialog = true"
                     class="w-full"
                   >
-                    Open Shift
+                    {{ __('Open Shift') }}
                   </Button>
                 </div>
               </div>
 
               <!-- System Test -->
               <div class="bg-white p-6 rounded-lg shadow">
-                <h3 class="text-lg font-medium text-gray-900 mb-4">System Test</h3>
+                <h3 class="text-lg font-medium text-gray-900 mb-4">{{ __('System Test') }}</h3>
                 <Button
                   theme="blue"
                   variant="solid"
@@ -133,18 +142,18 @@
                   :loading="ping.loading"
                   class="w-full"
                 >
-                  Test Connection
+                  {{ __('Test Connection') }}
                 </Button>
 
                 <div v-if="ping.data" class="mt-4 p-3 bg-green-50 rounded-md">
                   <div class="text-sm text-green-800">
-                    ✓ Connection successful: {{ ping.data }}
+                    {{ __('✓ Connection successful: {0}', [ping.data]) }}
                   </div>
                 </div>
 
                 <div v-if="ping.error" class="mt-4 p-3 bg-red-50 rounded-md">
                   <div class="text-sm text-red-800">
-                    ✗ Connection failed: {{ ping.error }}
+                    {{ __('✗ Connection failed: {0}', [ping.error]) }}
                   </div>
                 </div>
               </div>
@@ -157,7 +166,7 @@
     <!-- Logout Confirmation Dialog -->
     <Dialog
       v-model="showLogoutDialog"
-      :options="{ title: 'Confirm Sign Out' }"
+      :options="{ title: __('Confirm Sign Out') }"
       :dismissable="!session.logout.loading"
     >
       <template #body-content>
@@ -171,17 +180,17 @@
               </div>
               <div class="ml-3">
                 <h3 class="text-sm font-medium text-yellow-800">
-                  Active Shift Detected
+                  {{ __('Active Shift Detected') }}
                 </h3>
                 <div class="mt-2 text-sm text-yellow-700">
-                  <p>You have an active shift open. Would you like to:</p>
+                  <p>{{ __('You have an active shift open. Would you like to:') }}</p>
                 </div>
               </div>
             </div>
           </div>
 
           <p v-else class="text-sm text-gray-500">
-            Are you sure you want to sign out of POS Next?
+            {{ __('Are you sure you want to sign out of POS Next?') }}
           </p>
         </div>
       </template>
@@ -194,7 +203,7 @@
             @click="showLogoutDialog = false"
             :disabled="session.logout.loading"
           >
-            Cancel
+            {{ __('Cancel') }}
           </Button>
           <Button
             v-if="hasOpenShift"
@@ -202,7 +211,7 @@
             variant="solid"
             @click="logoutWithCloseShift"
           >
-            Close Shift & Sign Out
+            {{ __('Close Shift & Sign Out') }}
           </Button>
           <Button
             theme="red"
@@ -210,7 +219,7 @@
             @click="handleLogout"
             :loading="session.logout.loading"
           >
-            {{ hasOpenShift ? 'Sign Out Only' : 'Sign Out' }}
+            {{ hasOpenShift ? __('Sign Out Only') : __('Sign Out') }}
           </Button>
         </div>
       </template>
@@ -241,6 +250,7 @@ import ShiftClosingDialog from "../components/ShiftClosingDialog.vue"
 import ShiftOpeningDialog from "../components/ShiftOpeningDialog.vue"
 import { useShift } from "../composables/useShift"
 import { session } from "../data/session"
+import TranslatedHTML from "../components/common/TranslatedHTML.vue"
 
 const router = useRouter()
 

--- a/POS/src/pages/Login.vue
+++ b/POS/src/pages/Login.vue
@@ -3,10 +3,10 @@
     <div class="max-w-md w-full space-y-8">
       <div class="text-center">
         <h2 class="mt-6 text-3xl font-extrabold text-gray-900">
-          Sign in to POS Next
+          {{ __('Sign in to POS Next') }}
         </h2>
         <p class="mt-2 text-sm text-gray-600">
-          Access your point of sale system
+          {{ __('Access your point of sale system') }}
         </p>
       </div>
 
@@ -21,7 +21,7 @@
               </div>
               <div class="ml-3">
                 <h3 class="text-sm font-medium text-red-800">
-                  Login Failed
+                  {{ __('Login Failed') }}
                 </h3>
                 <div class="mt-2 text-sm text-red-700">
                   <p>{{ session.login.error.messages.join('\n') }}</p>
@@ -36,22 +36,22 @@
               required
               name="email"
               type="text"
-              placeholder="Enter your username or email"
-              label="User ID / Email"
+              :placeholder="__('Enter your username or email')"
+              :label="__('User ID / Email')"
               :disabled="session.login.loading"
             />
           </div>
 
           <div>
             <label class="block">
-              <span class="mb-2 block text-sm leading-4 text-gray-700">Password</span>
+              <span class="mb-2 block text-sm leading-4 text-gray-700">{{ __('Password') }}</span>
               <div class="relative">
                 <input
                   v-model="loginForm.password"
                   required
                   name="password"
                   :type="showPassword ? 'text' : 'password'"
-                  placeholder="Enter your password"
+                  :placeholder="__('Enter your password')"
                   :disabled="session.login.loading"
                   class="form-input block w-full border-gray-400 placeholder-gray-500 pr-10"
                 />
@@ -61,7 +61,7 @@
                   class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-600 hover:text-gray-800 transition-colors focus:outline-none"
                   :disabled="session.login.loading"
                   tabindex="-1"
-                  :aria-label="showPassword ? 'Hide password' : 'Show password'"
+                  :aria-label="showPassword ? __('Hide password') : __('Show password')"
                 >
                   <FeatherIcon
                     :name="showPassword ? 'eye-off' : 'eye'"
@@ -80,7 +80,7 @@
               class="w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
               type="submit"
             >
-              {{ session.login.loading ? 'Signing in...' : 'Sign in' }}
+              {{ session.login.loading ? __('Signing in...') : __('Sign in') }}
             </Button>
           </div>
         </form>

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -36,7 +36,7 @@
 						<svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
 						</svg>
-						<span>View Shift</span>
+						<span>{{ __('View Shift') }}</span>
 					</button>
 					<button
 						@click="uiStore.showDraftDialog = true"
@@ -45,7 +45,7 @@
 						<svg class="w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
 						</svg>
-						<span>Draft Invoices</span>
+						<span>{{ __('Draft Invoices') }}</span>
 						<span v-if="draftsStore.draftsCount > 0" class="ml-auto text-xs bg-purple-600 text-white px-1.5 py-0.5 rounded-full">
 							{{ draftsStore.draftsCount }}
 						</span>
@@ -57,7 +57,7 @@
 						<svg class="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
 						</svg>
-						<span>Invoice History</span>
+						<span>{{ __('Invoice History') }}</span>
 					</button>
 					<button
 						v-if="offlineStore.pendingInvoicesCount > 0"
@@ -67,7 +67,7 @@
 						<svg class="w-5 h-5 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
 						</svg>
-						<span>Offline Invoices</span>
+						<span>{{ __('Offline Invoices') }}</span>
 						<span class="ml-auto text-xs bg-orange-600 text-white px-1.5 py-0.5 rounded-full">
 							{{ offlineStore.pendingInvoicesCount }}
 						</span>
@@ -79,7 +79,7 @@
 						<svg class="w-5 h-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/>
 						</svg>
-						<span>Return Invoice</span>
+						<span>{{ __('Return Invoice') }}</span>
 					</button>
 				</template>
 				<template #additional-actions>
@@ -90,7 +90,7 @@
 						<svg class="w-5 h-5 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
 						</svg>
-						<span>Close Shift</span>
+						<span>{{ __('Close Shift') }}</span>
 					</button>
 				</template>
 			</POSHeader>
@@ -118,7 +118,7 @@
 							? 'text-blue-600 border-b-3 border-blue-600 bg-blue-50'
 							: 'text-gray-600 hover:text-gray-800 hover:bg-gray-50 active:bg-gray-100'
 					]"
-					:aria-label="'View items'"
+					:aria-label="__('View items')"
 					:aria-selected="uiStore.mobileActiveTab === 'items'"
 					role="tab"
 				>
@@ -126,7 +126,7 @@
 						<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
 						</svg>
-						<span>Items</span>
+						<span>{{ __('Items') }}</span>
 					</div>
 				</button>
 				<button
@@ -137,7 +137,7 @@
 							? 'text-blue-600 border-b-3 border-blue-600 bg-blue-50'
 							: 'text-gray-600 hover:text-gray-800 hover:bg-gray-50 active:bg-gray-100'
 					]"
-					:aria-label="'View cart'"
+					:aria-label="__('View cart')"
 					:aria-selected="uiStore.mobileActiveTab === 'cart'"
 					role="tab"
 				>
@@ -145,7 +145,7 @@
 						<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"/>
 						</svg>
-						<span>Cart</span>
+						<span>{{ __('Cart') }}</span>
 						<span v-if="cartStore.itemCount > 0" class="bg-blue-600 text-white text-[10px] font-bold rounded-full min-w-[20px] h-5 px-1.5 flex items-center justify-center shadow-sm">
 							{{ cartStore.itemCount }}
 						</span>
@@ -243,7 +243,7 @@
 				v-if="!uiStore.isDesktop && uiStore.mobileActiveTab === 'items' && cartStore.itemCount > 0"
 				@click="uiStore.setMobileTab('cart')"
 				class="lg:hidden fixed bottom-20 right-4 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-full p-4 shadow-2xl hover:shadow-3xl hover:from-blue-700 hover:to-blue-800 active:from-blue-800 active:to-blue-900 transition-[background,box-shadow,transform] duration-200 z-50 touch-manipulation active:scale-95 ring-4 ring-blue-100"
-				:aria-label="'View cart with ' + cartStore.itemCount + ' items'"
+				:aria-label="__('View cart with {0} items', [cartStore.itemCount])"
 			>
 				<div class="relative">
 					<svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5">
@@ -268,15 +268,15 @@
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
 					</svg>
 				</div>
-				<h3 class="mt-4 text-lg font-medium text-gray-900">Welcome to POS Next</h3>
-				<p class="mt-2 text-sm text-gray-500">Please open a shift to start making sales</p>
+				<h3 class="mt-4 text-lg font-medium text-gray-900">{{ __('Welcome to POS Next') }}</h3>
+				<p class="mt-2 text-sm text-gray-500">{{ __('Please open a shift to start making sales') }}</p>
 				<Button
 					variant="solid"
 					theme="blue"
 					@click="uiStore.showOpenShiftDialog = true"
 					class="mt-6"
 				>
-					Open Shift
+					{{ __('Open Shift') }}
 				</Button>
 			</div>
 		</div>
@@ -453,22 +453,22 @@
 		<!-- Clear Cart Confirmation Dialog -->
 		<Dialog
 			v-model="uiStore.showClearCartDialog"
-			:options="{ title: 'Clear Cart?', size: 'xs' }"
+			:options="{ title: __('Clear Cart?'), size: 'xs' }"
 		>
 			<template #body-content>
 				<div class="py-3">
 					<p class="text-sm text-gray-600">
-						Remove all {{ cartStore.itemCount }} items from cart?
+						{{ __('Remove all {0} items from cart?', [cartStore.itemCount]) }}
 					</p>
 				</div>
 			</template>
 			<template #actions>
 				<div class="flex space-x-2 w-full">
 					<Button class="flex-1" variant="subtle" @click="uiStore.showClearCartDialog = false">
-						Cancel
+						{{ __('Cancel') }}
 					</Button>
 					<Button class="flex-1" variant="solid" theme="red" @click="confirmClearCart">
-						Clear All
+						{{ __('Clear All') }}
 					</Button>
 				</div>
 			</template>
@@ -477,7 +477,7 @@
 		<!-- Logout Confirmation Dialog -->
 		<Dialog
 			v-model="uiStore.showLogoutDialog"
-			:options="{ title: 'Sign Out Confirmation', size: 'md' }"
+			:options="{ title: __('Sign Out Confirmation'), size: 'md' }"
 			:dismissable="!session.logout.loading"
 		>
 			<template #body-content>
@@ -490,10 +490,10 @@
 							</svg>
 						</div>
 						<h3 class="text-lg font-bold text-red-600 mb-2">
-							Your Shift is Still Open!
+							{{ __('Your Shift is Still Open!') }}
 						</h3>
 						<p class="text-sm text-gray-600 max-w-sm mx-auto">
-							Close your shift first to save all transactions properly
+							{{ __('Close your shift first to save all transactions properly') }}
 						</p>
 					</div>
 
@@ -508,7 +508,7 @@
 							<svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"/>
 							</svg>
-							Close Shift & Sign Out
+							{{ __('Close Shift & Sign Out') }}
 						</button>
 
 						<!-- Alternative Actions -->
@@ -518,14 +518,14 @@
 								:disabled="session.logout.loading"
 								class="px-4 py-3 bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white font-semibold text-sm rounded-lg shadow-md hover:shadow-red-500/30 transition-[background,box-shadow,opacity] duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
 							>
-								Skip & Sign Out
+								{{ __('Skip & Sign Out') }}
 							</button>
 							<button
 								@click="uiStore.showLogoutDialog = false"
 								:disabled="session.logout.loading"
 								class="px-4 py-3 bg-white hover:bg-gray-50 text-gray-700 font-semibold text-sm rounded-lg transition-[background-color,border-color,opacity] duration-200 disabled:opacity-50 disabled:cursor-not-allowed border border-gray-300 hover:border-gray-400"
 							>
-								Cancel
+								{{ __('Cancel') }}
 							</button>
 						</div>
 					</div>
@@ -540,10 +540,10 @@
 							</svg>
 						</div>
 						<h3 class="text-lg font-bold text-red-600 mb-2">
-							Sign Out?
+							{{ __('Sign Out?') }}
 						</h3>
 						<p class="text-sm text-gray-600">
-							You will be logged out of POS Next
+							{{ __('You will be logged out of POS Next') }}
 						</p>
 					</div>
 
@@ -553,20 +553,20 @@
 							:disabled="session.logout.loading"
 							class="px-5 py-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg shadow-md hover:shadow-blue-500/30 transition-[background-color,box-shadow,opacity,transform] duration-200 disabled:opacity-50 transform hover:scale-[1.02] active:scale-[0.98]"
 						>
-							Cancel
+							{{ __('Cancel') }}
 						</button>
 						<button
 							@click="confirmLogout"
 							:disabled="session.logout.loading"
 							class="px-5 py-4 bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800 text-white font-semibold rounded-lg shadow-lg hover:shadow-red-500/30 transition-[background,box-shadow,opacity,transform] duration-200 disabled:opacity-50 disabled:cursor-not-allowed transform hover:scale-[1.02] active:scale-[0.98]"
 						>
-							<span v-if="!session.logout.loading">Sign Out</span>
+							<span v-if="!session.logout.loading">{{ __('Sign Out') }}</span>
 							<span v-else class="flex items-center justify-center">
 								<svg class="animate-spin h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24">
 									<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
 									<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
 								</svg>
-								Signing Out...
+								{{ __('Signing Out...') }}
 							</span>
 						</button>
 					</div>
@@ -577,7 +577,7 @@
 		<!-- Success Dialog -->
 		<Dialog
 			v-model="uiStore.showSuccessDialog"
-			:options="{ title: 'Invoice Created Successfully', size: 'md' }"
+			:options="{ title: __('Invoice Created Successfully'), size: 'md' }"
 		>
 			<template #body-content>
 				<div class="text-center py-6">
@@ -587,20 +587,20 @@
 						</svg>
 					</div>
 					<h3 class="mt-4 text-lg font-medium text-gray-900">
-						Invoice {{ uiStore.lastInvoiceName }} created successfully!
+						{{ __('Invoice {0} created successfully!', [uiStore.lastInvoiceName]) }}
 					</h3>
 					<p class="mt-2 text-sm text-gray-500">
-						Total: {{ formatCurrency(uiStore.lastInvoiceTotal) }}
+						{{ __('Total: {0}', [formatCurrency(uiStore.lastInvoiceTotal)]) }}
 					</p>
 				</div>
 			</template>
 			<template #actions>
 				<div class="flex space-x-2">
 					<Button variant="subtle" @click="uiStore.showSuccessDialog = false">
-						Close
+						{{ __('Close') }}
 					</Button>
 					<Button variant="solid" theme="blue" @click="() => { handlePrintInvoice({ name: uiStore.lastInvoiceName }); uiStore.showSuccessDialog = false }">
-						Print Invoice
+						{{ __('Print Invoice') }}
 					</Button>
 				</div>
 			</template>
@@ -609,12 +609,12 @@
 		<!-- Error Dialog -->
 		<Dialog
 			v-model="uiStore.showErrorDialog"
-			:options="{ title: uiStore.errorDialogTitle || 'Error', size: 'md' }"
+			:options="{ title: uiStore.errorDialogTitle || __('Error'), size: 'md' }"
 		>
 			<template #body-content>
 				<div class="py-3">
 					<p class="text-sm text-gray-700 whitespace-pre-line">
-						{{ uiStore.errorDialogMessage || 'An unexpected error occurred.' }}
+						{{ uiStore.errorDialogMessage || __('An unexpected error occurred.') }}
 					</p>
 					<div v-if="uiStore.errorDetails" class="mt-3 pt-3 border-t border-gray-200">
 						<p class="text-xs text-gray-500">{{ uiStore.errorDetails }}</p>
@@ -629,19 +629,19 @@
 						theme="red"
 						@click="handleDeleteFailedInvoice"
 					>
-						Delete Invoice
+						{{ __('Delete Invoice') }}
 					</Button>
 					<div v-else></div>
 					<div class="flex space-x-2">
 						<Button variant="subtle" @click="uiStore.clearError()">
-							Close
+							{{ __('Close') }}
 						</Button>
 						<Button
 							v-if="uiStore.errorRetryAction"
 							variant="solid"
 							@click="handleErrorRetry"
 						>
-							Try Again
+							{{ __('Try Again') }}
 						</Button>
 					</div>
 				</div>
@@ -904,14 +904,15 @@ onMounted(async () => {
 			cartStore.rebuildIncrementalCache()
 
 			const message = changes.hasOwnProperty('tax_inclusive')
-				? 'Tax mode updated. Cart recalculated with new tax settings.'
-				: 'Discount settings changed. Cart recalculated.'
+				? __('Tax mode updated. Cart recalculated with new tax settings.')
+				: __('Discount settings changed. Cart recalculated.')
 
 			showSuccess(message)
 		} else if (changes.hasOwnProperty('tax_inclusive')) {
 			// Show feedback even if cart is empty
-			const mode = changes.tax_inclusive.new ? 'inclusive' : 'exclusive'
-			showSuccess(`Prices are now ${mode} of tax. This will apply to new items added to cart.`)
+			showSuccess(changes.tax_inclusive.new
+				? __('Prices are now tax-inclusive. This will apply to new items added to cart.')
+				: __('Prices are now tax-exclusive. This will apply to new items added to cart.'))
 		}
 	})
 
@@ -923,8 +924,8 @@ onMounted(async () => {
 			const isNowAllowed = changes.allow_negative_stock.new
 
 			const message = isNowAllowed
-				? 'Negative stock sales are now allowed'
-				: 'Negative stock sales are now restricted'
+				? __('Negative stock sales are now allowed')
+				: __('Negative stock sales are now restricted')
 
 			showSuccess(message)
 		}
@@ -939,11 +940,11 @@ onMounted(async () => {
 
 		// Show notification for specific important changes
 		const changeLabels = {
-			allow_credit_sale: 'Credit Sale',
-			allow_return: 'Returns',
-			allow_write_off_change: 'Write Off Change',
-			allow_partial_payment: 'Partial Payment',
-			silent_print: 'Silent Print'
+			allow_credit_sale: __('Credit Sale'),
+			allow_return: __('Returns'),
+			allow_write_off_change: __('Write Off Change'),
+			allow_partial_payment: __('Partial Payment'),
+			silent_print: __('Silent Print')
 		}
 
 		const changedSettings = Object.keys(changes)
@@ -952,7 +953,7 @@ onMounted(async () => {
 			.join(', ')
 
 		if (changedSettings) {
-			showSuccess(`${changedSettings} settings applied immediately`)
+			showSuccess(__('{0} settings applied immediately', [changedSettings]))
 		}
 	})
 
@@ -1310,12 +1311,12 @@ async function handleShiftOpened() {
 		// Load tax rules with tax_inclusive setting
 		await cartStore.loadTaxRules(shiftStore.profileName, posSettingsStore.settings)
 	}
-	showSuccess("You can now start making sales")
+	showSuccess(__("You can now start making sales"))
 }
 
 function handleShiftClosed() {
 	uiStore.showCloseShiftDialog = false
-	showSuccess("Shift closed successfully")
+	showSuccess(__("Shift closed successfully"))
 
 	// Check if logout should happen after closing shift
 	if (logoutAfterClose.value) {
@@ -1337,9 +1338,9 @@ function handleItemSelected(item, autoAdd = false) {
 			cartStore.addItem(item, 1, true, shiftStore.currentProfile)
 		} catch (error) {
 			uiStore.showError(
-				"Insufficient Stock",
+				__("Insufficient Stock"),
 				error.message,
-				`Item: ${item.item_code}`,
+				__("Item: {0}", [item.item_code]),
 			)
 		}
 		return
@@ -1352,8 +1353,9 @@ function handleItemSelected(item, autoAdd = false) {
 		const actualQty = Math.floor(item.actual_qty ?? item.stock_qty ?? 0)
 
 		if (actualQty <= 0) {
-			const itemType = item.is_bundle ? "Bundle" : "Item"
-			showError(`"${item.item_name}" cannot be added to cart. ${itemType} is out of stock. Allow Negative Stock is disabled.`)
+			showError(item.is_bundle
+			 ? __('"{0}" cannot be added to cart. Bundle is out of stock. Allow Negative Stock is disabled.', [item.item_name])
+			 : __('"{0}" cannot be added to cart. Item is out of stock. Allow Negative Stock is disabled.', [item.item_name]))
 			return
 		}
 	}
@@ -1384,9 +1386,9 @@ function handleItemSelected(item, autoAdd = false) {
 		cartStore.addItem(item, 1, false, shiftStore.currentProfile)
 	} catch (error) {
 		uiStore.showError(
-			"Insufficient Stock",
+			__("Insufficient Stock"),
 			error.message,
-			`Item: ${item.item_code}`,
+			__("Item: {0}", [item.item_code]),
 		)
 	}
 }
@@ -1407,7 +1409,7 @@ function handleCustomerSelected(selectedCustomer) {
 	if (selectedCustomer) {
 		cartStore.setCustomer(selectedCustomer)
 		uiStore.showCustomerDialog = false
-		showSuccess(`${selectedCustomer.customer_name} selected`)
+		showSuccess(__('{0} selected', [selectedCustomer.customer_name]))
 
 		if (pendingPaymentAfterCustomer.value) {
 			pendingPaymentAfterCustomer.value = false
@@ -1425,13 +1427,13 @@ function handleCreateCustomer(searchValue) {
 
 function handleProceedToPayment() {
 	if (cartStore.isEmpty) {
-		showWarning("Please add items to cart before proceeding to payment")
+		showWarning(__("Please add items to cart before proceeding to payment"))
 		return
 	}
 
 	const customerValue = cartStore.customer?.name || cartStore.customer
 	if (!customerValue && !shiftStore.profileCustomer) {
-		showWarning("Please select a customer before proceeding")
+		showWarning(__("Please select a customer before proceeding"))
 		uiStore.showCustomerDialog = true
 		pendingPaymentAfterCustomer.value = true
 		return
@@ -1471,7 +1473,7 @@ async function handlePaymentCompleted(paymentData) {
 	try {
 		const customerValue = cartStore.customer?.name || cartStore.customer
 		if (!customerValue && !shiftStore.profileCustomer) {
-			showWarning("Please select a customer before proceeding")
+			showWarning(__("Please select a customer before proceeding"))
 			uiStore.showPaymentDialog = false
 			uiStore.showCustomerDialog = true
 			return
@@ -1515,7 +1517,7 @@ async function handlePaymentCompleted(paymentData) {
 			// Reset cart hash after successful payment
 			previousCartHash = ""
 
-			showWarning("Invoice saved and will sync when online")
+			showWarning(__("Invoice saved and will sync when online"))
 		} else {
 			// Get item codes from cart before clearing
 			const soldItemCodes = cartStore.invoiceItems.map(item => item.item_code)
@@ -1523,7 +1525,7 @@ async function handlePaymentCompleted(paymentData) {
 			const result = await cartStore.submitInvoice()
 
 			if (result) {
-				const invoiceName = result.name || result.message?.name || "Unknown"
+				const invoiceName = result.name || result.message?.name || __('Unknown')
 				const invoiceTotal = result.grand_total || result.total || 0
 
 				uiStore.showPaymentDialog = false
@@ -1537,14 +1539,14 @@ async function handlePaymentCompleted(paymentData) {
 				if (shiftStore.autoPrintEnabled) {
 					try {
 						await handlePrintInvoice({ name: invoiceName })
-						showSuccess(`Invoice ${invoiceName} created and sent to printer`)
+						showSuccess(__('Invoice {0} created and sent to printer', [invoiceName]))
 					} catch (error) {
 						log.error("Auto-print error:", error)
-						showWarning(`Invoice ${invoiceName} created but print failed`)
+						showWarning(__('Invoice {0} created but print failed', [invoiceName]))
 					}
 				} else {
 					uiStore.showSuccess(invoiceName, invoiceTotal)
-					showSuccess(`Invoice ${invoiceName} created successfully`)
+					showSuccess(__('Invoice {0} created successfully', [invoiceName]))
 				}
 			}
 		}
@@ -1554,8 +1556,8 @@ async function handlePaymentCompleted(paymentData) {
 
 		const errorContext = parseError(error)
 		uiStore.showError(
-			errorContext.title || "Error",
-			errorContext.message || "An unexpected error occurred",
+			errorContext.title || __('Error'),
+			errorContext.message || __("An unexpected error occurred"),
 			errorContext.technicalDetails || null,
 			errorContext.retryable ? "payment" : null,
 		)
@@ -1580,7 +1582,7 @@ function confirmClearCart() {
 	// Reset cart hash when cart is cleared
 	previousCartHash = ""
 	uiStore.showClearCartDialog = false
-	showSuccess("All items removed from cart")
+	showSuccess(__("All items removed from cart"))
 }
 
 async function handleOptionSelected(option) {
@@ -1604,7 +1606,7 @@ async function handleOptionSelected(option) {
 					cartStore.addItem(variant, cartStore.pendingItemQty, false, shiftStore.currentProfile)
 					uiStore.showItemSelectionDialog = false
 					cartStore.clearPendingItem()
-					showSuccess(`${variant.item_name} added to cart`)
+					showSuccess(__('{0} added to cart', [variant.item_name]))
 				} catch (error) {
 					showError(error.message)
 				}
@@ -1635,7 +1637,7 @@ async function handleOptionSelected(option) {
 					cartStore.addItem(itemToAdd, cartStore.pendingItemQty, false, shiftStore.currentProfile)
 					uiStore.showItemSelectionDialog = false
 					cartStore.clearPendingItem()
-					showSuccess(`${itemToAdd.item_name} (${option.uom}) added to cart`)
+					showSuccess(__('{0} ({1}) added to cart', [itemToAdd.item_name, option.uom]))
 				} catch (error) {
 					showError(error.message)
 				}
@@ -1643,7 +1645,7 @@ async function handleOptionSelected(option) {
 		}
 	} catch (error) {
 		log.error("Error handling option selection:", error)
-		showError("Failed to process selection. Please try again.")
+		showError(__("Failed to process selection. Please try again."))
 	}
 }
 
@@ -1711,7 +1713,7 @@ async function handleLoadDraft(draft) {
 }
 
 function handleReturnCreated(returnInvoice) {
-	showSuccess(`Return invoice ${returnInvoice.name} created successfully`)
+	showSuccess(__('Return invoice {0} created successfully', [returnInvoice.name]))
 }
 
 function handleDiscountApplied(discount) {
@@ -1752,13 +1754,13 @@ function handleBatchSerialSelected(batchSerial) {
 
 function handleCreateReturnFromHistory(invoice) {
 	uiStore.showReturnDialog = true
-	showWarning(`Creating return for invoice ${invoice.name}`)
+	showWarning(__('Creating return for invoice {0}', [invoice.name]))
 }
 
 function handleCustomerCreated(newCustomer) {
 	cartStore.setCustomer(newCustomer)
 	uiStore.showCreateCustomerDialog = false
-	showSuccess(`${newCustomer.customer_name} created and selected`)
+	showSuccess(__('{0} created and selected', [newCustomer.customer_name]))
 }
 
 async function handleRefresh() {
@@ -1828,7 +1830,7 @@ async function confirmClearCache() {
 				clearCacheOverlayRef.value.reset()
 			}
 
-			showSuccess("All cached data has been cleared successfully")
+			showSuccess(__("All cached data has been cleared successfully"))
 		} else {
 			throw new Error('Failed to clear cache completely')
 		}
@@ -1841,7 +1843,7 @@ async function confirmClearCache() {
 			clearCacheOverlayRef.value.reset()
 		}
 
-		showError("Failed to clear cache. Please try again.")
+		showError(__("Failed to clear cache. Please try again."))
 	}
 }
 
@@ -1867,7 +1869,7 @@ async function handleEditOfflineInvoice(invoice) {
 
 		await offlineStore.deleteOfflineInvoice(invoice.id)
 
-		showSuccess("Invoice loaded to cart for editing")
+		showSuccess(__("Invoice loaded to cart for editing"))
 	} catch (error) {
 		log.error("Error editing offline invoice:", error)
 	}
@@ -1888,12 +1890,12 @@ async function handleSyncClick() {
 		return
 	}
 
-	showSuccess("No pending invoices to sync")
+	showSuccess(__("No pending invoices to sync"))
 }
 
 async function handleSyncAll() {
 	if (offlineStore.isOffline) {
-		showWarning("Cannot sync while offline")
+		showWarning(__("Cannot sync while offline"))
 		return
 	}
 
@@ -1911,13 +1913,13 @@ async function handleSyncAll() {
 
 			uiStore.showError(
 				errorContext.title,
-				`Failed to sync invoice for ${firstError.customer}\n\n${errorContext.message}\n\nYou can delete this invoice from the offline queue if you don't need it.`,
-				errorContext.technicalDetails || `Invoice ID: ${firstError.invoiceId}`,
+				__("Failed to sync invoice for {0}\n\n${1}\n\nYou can delete this invoice from the offline queue if you don't need it.", [firstError.customer, errorContext.message]),
+				errorContext.technicalDetails || __('Invoice ID: {0}', [firstError.invoiceId]),
 				"sync",
 				{ failedInvoiceId: firstError.invoiceId },
 			)
 		} else if (result.failed > 0) {
-			showWarning(`${result.failed} invoice(s) failed to sync`)
+			showWarning(__('{0} invoice(s) failed to sync', [result.failed]))
 		}
 	} catch (error) {
 		log.error("Sync error:", error)
@@ -2128,15 +2130,15 @@ async function handleWarehouseChanged(newWarehouse) {
 			await itemsSelectorRef.value.loadItems()
 		}
 
-		showSuccess(`Switched to ${newWarehouse}. Stock quantities refreshed.`)
+		showSuccess(__('Switched to {0}. Stock quantities refreshed.', [newWarehouse]))
 	} catch (error) {
 		log.error("Error handling warehouse change:", error)
-		showWarning(`Warehouse updated but failed to reload stock. Please refresh manually.`)
+		showWarning(__('Warehouse updated but failed to reload stock. Please refresh manually.'))
 	}
 }
 
 function handlePromotionSaved(data) {
-	showSuccess(data.message || "Promotion saved successfully")
+	showSuccess(data.message || __("Promotion saved successfully"))
 }
 
 // Optimized tab switching for mobile with RAF for smooth transitions

--- a/POS/src/stores/customerSearch.js
+++ b/POS/src/stores/customerSearch.js
@@ -172,7 +172,7 @@ export const useCustomerSearchStore = defineStore("customerSearch", () => {
 		if (/^\d+$/.test(term)) {
 			recs.push({
 				type: "phone",
-				text: `Search by phone: ${term}`,
+				text: __('Search by phone: {0}', [term]),
 				icon: "📱",
 			})
 		}
@@ -181,7 +181,7 @@ export const useCustomerSearchStore = defineStore("customerSearch", () => {
 		if (term.includes("@")) {
 			recs.push({
 				type: "email",
-				text: `Search by email: ${term}`,
+				text: __('Search by email: {0}', [term]),
 				icon: "✉️",
 			})
 		}
@@ -193,7 +193,7 @@ export const useCustomerSearchStore = defineStore("customerSearch", () => {
 		if (!exactMatch && filteredCustomers.value.length < 5) {
 			recs.push({
 				type: "create",
-				text: `Create new customer "${term}"`,
+				text: __('Create new customer: {0}', [term]),
 				icon: "➕",
 			})
 		}

--- a/POS/src/stores/invoiceFilters.js
+++ b/POS/src/stores/invoiceFilters.js
@@ -249,10 +249,10 @@ export const useInvoiceFiltersStore = defineStore("invoiceFilters", () => {
 			return `${formatDateDisplay(dateFrom.value)} - ${formatDateDisplay(dateTo.value)}`
 		}
 		if (dateFrom.value) {
-			return `From ${formatDateDisplay(dateFrom.value)}`
+			return __('From {0}', [formatDateDisplay(dateFrom.value)])
 		}
 		if (dateTo.value) {
-			return `Until ${formatDateDisplay(dateTo.value)}`
+			return __('Until {0}', [formatDateDisplay(dateTo.value)])
 		}
 		return ""
 	}

--- a/POS/src/stores/itemSearch.js
+++ b/POS/src/stores/itemSearch.js
@@ -263,7 +263,7 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 		},
 		auto: false,
 		onSuccess(data) {
-			itemGroups.value = data?.message || data || []
+			itemGroups.value = (data?.message || data || [])
 		},
 		onError(error) {
 			log.error("Error fetching item groups", error)

--- a/POS/src/stores/posCart.js
+++ b/POS/src/stores/posCart.js
@@ -130,7 +130,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 	function applyDiscountToCart(discount) {
 		applyDiscount(discount)
 		appliedCoupon.value = discount
-		showSuccess(`${discount.name} applied successfully`)
+		showSuccess(__('{0} applied successfully', [discount.name]))
 	}
 
 	function removeDiscountFromCart() {
@@ -138,7 +138,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		appliedOffers.value = []
 		removeDiscount()
 		appliedCoupon.value = null
-		showSuccess("Discount has been removed from cart")
+		showSuccess(__("Discount has been removed from cart"))
 	}
 
 	function buildInvoiceDataForOffers(currentProfile) {
@@ -302,7 +302,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		}
 
 		if (!posProfile.value || invoiceItems.value.length === 0) {
-			showWarning("Add items to the cart before applying an offer.")
+			showWarning(__("Add items to the cart before applying an offer."))
 			offersDialogRef?.resetApplyingState()
 			return false
 		}
@@ -349,7 +349,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 					}
 				}
 
-				showWarning("Your cart doesn't meet the requirements for this offer.")
+				showWarning(__("Your cart doesn't meet the requirements for this offer."))
 				offersDialogRef?.resetApplyingState()
 				return false
 			}
@@ -376,12 +376,12 @@ export const usePOSCartStore = defineStore("posCart", () => {
 			})
 			appliedOffers.value = updatedEntries
 
-			showSuccess(`${offer.title || offer.name} applied successfully`)
+			showSuccess(__('{0} applied successfully', [(offer.title || offer.name)]))
 
 			return true
 		} catch (error) {
 			console.error("Error applying offer:", error)
-			showError("Failed to apply offer. Please try again.")
+			showError(__("Failed to apply offer. Please try again."))
 			offersDialogRef?.resetApplyingState()
 			return false
 		}
@@ -401,7 +401,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 			appliedOffers.value = []
 			processFreeItems([]) // Remove all free items
 			removeDiscount()
-			showSuccess("Offer has been removed from cart")
+			showSuccess(__("Offer has been removed from cart"))
 			offersDialogRef?.resetApplyingState()
 			return true
 		}
@@ -416,7 +416,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 			appliedOffers.value = []
 			processFreeItems([]) // Remove all free items
 			removeDiscount()
-			showSuccess("Offer has been removed from cart")
+			showSuccess(__("Offer has been removed from cart"))
 			offersDialogRef?.resetApplyingState()
 			return true
 		}
@@ -441,12 +441,12 @@ export const usePOSCartStore = defineStore("posCart", () => {
 				remainingCodes.includes(entry.code),
 			)
 
-			showSuccess("Offer has been removed from cart")
+			showSuccess(__("Offer has been removed from cart"))
 			offersDialogRef?.resetApplyingState()
 			return true
 		} catch (error) {
 			console.error("Error removing offer:", error)
-			showError("Failed to update cart after removing offer.")
+			showError(__("Failed to update cart after removing offer."))
 			offersDialogRef?.resetApplyingState()
 			return false
 		}
@@ -592,10 +592,10 @@ export const usePOSCartStore = defineStore("posCart", () => {
 
 			recalculateItem(cartItem)
 
-			showSuccess(`Unit changed to ${newUom}`)
+			showSuccess(__('Unit changed to {0}', [newUom]))
 		} catch (error) {
 			console.error("Error changing UOM:", error)
-			showError("Failed to update UOM. Please try again.")
+			showError(__("Failed to update UOM. Please try again."))
 		}
 	}
 
@@ -665,12 +665,12 @@ export const usePOSCartStore = defineStore("posCart", () => {
 			// Rebuild cache after item update to ensure totals are accurate
 			rebuildIncrementalCache()
 
-			showSuccess(`${cartItem.item_name} updated successfully`)
+			showSuccess(__('{0} updated successfully', [cartItem.item_name]))
 
 			return true
 		} catch (error) {
 			console.error("Error updating item details:", error)
-			showError(parseError(error) || "Failed to update item. Please try again.")
+			showError(parseError(error) || __("Failed to update item. Please try again."))
 			return false
 		}
 	}

--- a/POS/src/stores/posDrafts.js
+++ b/POS/src/stores/posDrafts.js
@@ -26,7 +26,7 @@ export const usePOSDraftsStore = defineStore("posDrafts", () => {
 		appliedOffers = [],
 	) {
 		if (invoiceItems.length === 0) {
-			showWarning("Cannot save an empty cart as draft")
+			showWarning(__("Cannot save an empty cart as draft"))
 			return false
 		}
 
@@ -41,12 +41,12 @@ export const usePOSDraftsStore = defineStore("posDrafts", () => {
 			await saveDraft(draftData)
 			await updateDraftsCount()
 
-			showSuccess("Invoice saved as draft successfully")
+			showSuccess(__("Invoice saved as draft successfully"))
 
 			return true
 		} catch (error) {
 			console.error("Error saving draft:", error)
-			showError("Failed to save draft")
+			showError(__("Failed to save draft"))
 			return false
 		}
 	}
@@ -57,7 +57,7 @@ export const usePOSDraftsStore = defineStore("posDrafts", () => {
 			await deleteDraft(draft.draft_id)
 			await updateDraftsCount()
 
-			showSuccess("Draft invoice loaded successfully")
+			showSuccess(__("Draft invoice loaded successfully"))
 
 			return {
 				items: draft.items || [],
@@ -66,7 +66,7 @@ export const usePOSDraftsStore = defineStore("posDrafts", () => {
 			}
 		} catch (error) {
 			console.error("Error loading draft:", error)
-			showError("Failed to load draft")
+			showError(__("Failed to load draft"))
 			throw error
 		}
 	}

--- a/POS/src/stores/posOffers.js
+++ b/POS/src/stores/posOffers.js
@@ -87,7 +87,7 @@ export const usePOSOffersStore = defineStore("posOffers", () => {
 		if (offer?.min_qty && itemCount < offer.min_qty) {
 			return {
 				eligible: false,
-				reason: `At least ${offer.min_qty} items required`,
+				reason: __('At least {0} items required', [offer.min_qty]),
 			}
 		}
 
@@ -95,7 +95,7 @@ export const usePOSOffersStore = defineStore("posOffers", () => {
 		if (offer?.max_qty && itemCount > offer.max_qty) {
 			return {
 				eligible: false,
-				reason: `Maximum ${offer.max_qty} items allowed for this offer`,
+				reason: __('Maximum {0} items allowed for this offer', [offer.max_qty]),
 			}
 		}
 
@@ -103,7 +103,7 @@ export const usePOSOffersStore = defineStore("posOffers", () => {
 		if (offer?.min_amt && subtotal < offer.min_amt) {
 			return {
 				eligible: false,
-				reason: `Minimum cart value of ${offer.min_amt} required`,
+				reason: __('Minimum cart value of {0} required', [offer.min_amt]),
 			}
 		}
 
@@ -111,7 +111,7 @@ export const usePOSOffersStore = defineStore("posOffers", () => {
 		if (offer?.max_amt && subtotal > offer.max_amt) {
 			return {
 				eligible: false,
-				reason: `Maximum cart value exceeded (${offer.max_amt})`,
+				reason: __('Maximum cart value exceeded ({0})', [offer.max_amt]),
 			}
 		}
 
@@ -126,7 +126,7 @@ export const usePOSOffersStore = defineStore("posOffers", () => {
 				if (!hasEligibleItem) {
 					return {
 						eligible: false,
-						reason: "Cart does not contain eligible items for this offer",
+						reason: __("Cart does not contain eligible items for this offer"),
 					}
 				}
 			}
@@ -140,7 +140,7 @@ export const usePOSOffersStore = defineStore("posOffers", () => {
 				if (!hasEligibleGroup) {
 					return {
 						eligible: false,
-						reason: "Cart does not contain items from eligible groups",
+						reason: __("Cart does not contain items from eligible groups"),
 					}
 				}
 			}

--- a/POS/src/stores/posShift.js
+++ b/POS/src/stores/posShift.js
@@ -38,7 +38,7 @@ export const usePOSShiftStore = defineStore("posShift", () => {
 		const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60))
 		const seconds = Math.floor((diff % (1000 * 60)) / 1000)
 
-		shiftDuration.value = `${hours}h ${minutes}m ${seconds}s`
+		shiftDuration.value = __('{0}h {1}m {2}s', [hours, minutes, seconds])
 	}
 
 	function updateCurrentTime() {

--- a/POS/src/stores/posSync.js
+++ b/POS/src/stores/posSync.js
@@ -47,17 +47,17 @@ export const usePOSSyncStore = defineStore("posSync", () => {
 		try {
 			await deletePending(invoiceId)
 			await loadPendingInvoices()
-			showSuccess("Offline invoice deleted successfully")
+			showSuccess(__("Offline invoice deleted successfully"))
 		} catch (error) {
 			console.error("Error deleting offline invoice:", error)
-			showError(error.message || "Failed to delete offline invoice")
+			showError(error.message || __("Failed to delete offline invoice"))
 			throw error
 		}
 	}
 
 	async function syncAllPending() {
 		if (isOffline.value) {
-			showWarning("Cannot sync while offline")
+			showWarning(__("Cannot sync while offline"))
 			return { success: 0, failed: 0, errors: [] }
 		}
 
@@ -65,7 +65,7 @@ export const usePOSSyncStore = defineStore("posSync", () => {
 			const result = await syncPending()
 
 			if (result.success > 0) {
-				showSuccess(`${result.success} invoice(s) synced successfully`)
+				showSuccess(__('{0} invoice(s) synced successfully', [result.success]))
 				await loadPendingInvoices()
 			}
 
@@ -114,7 +114,7 @@ export const usePOSSyncStore = defineStore("posSync", () => {
 				// to prevent duplicate fetches and improve performance.
 				// Only cache customers here (payment methods already loaded above).
 
-				showSuccess("Loading customers for offline use...")
+				showSuccess(__("Loading customers for offline use..."))
 
 				// Fetch customers (items handled by itemStore, payment methods already loaded above)
 				const customersData = await cacheCustomersFromServer(currentProfile.name)
@@ -122,18 +122,18 @@ export const usePOSSyncStore = defineStore("posSync", () => {
 				// Cache customers using composable
 				await cacheData([], customersData.customers || [])
 
-				showSuccess("Data is ready for offline use")
+				showSuccess(__("Data is ready for offline use"))
 			}
 		} catch (error) {
 			console.error("Error pre-loading data:", error)
-			showWarning("Some data may not be available offline")
+			showWarning(__("Some data may not be available offline"))
 		}
 	}
 
 	async function checkOfflineCacheAvailability() {
 		const cacheReady = await checkCacheReady()
 		if (!cacheReady && isOffline.value) {
-			showWarning("POS is offline without cached data. Please connect to sync.")
+			showWarning(__("POS is offline without cached data. Please connect to sync."))
 		}
 		return cacheReady
 	}

--- a/POS/src/utils/errorHandler.js
+++ b/POS/src/utils/errorHandler.js
@@ -56,8 +56,8 @@ function cleanErrorMessage(rawMessage) {
  */
 export function parseError(error) {
 	const context = {
-		title: "Error",
-		message: "An unexpected error occurred",
+		title: __("Error"),
+		message: __("An unexpected error occurred"),
 		type: "error", // error, warning, validation
 		retryable: false,
 		technicalDetails: null,
@@ -65,26 +65,26 @@ export function parseError(error) {
 
 	// Build technical details
 	const detailsParts = []
-	if (error.exc_type) detailsParts.push(`Type: ${error.exc_type}`)
+	if (error.exc_type) detailsParts.push(__('Type: {0}', [error.exc_type]))
 	if (error.httpStatus || error.status)
-		detailsParts.push(`Status: ${error.httpStatus || error.status}`)
-	if (error.exception) detailsParts.push(`Exception: ${error.exception}`)
+		detailsParts.push(__('Status: {0}', [error.httpStatus || error.status]))
+	if (error.exception) detailsParts.push(__('Exception: {0}', [error.exception], "Error"))
 	context.technicalDetails =
 		detailsParts.length > 0 ? detailsParts.join(" | ") : null
 
 	// Detect error type from status code
 	if (error.httpStatus === 417 || error.status === 417) {
 		context.type = "validation"
-		context.title = "Validation Error"
+		context.title = __("Validation Error")
 	} else if (error.httpStatus === 403 || error.status === 403) {
 		context.type = "error"
-		context.title = "Permission Denied"
+		context.title = __("Permission Denied")
 	} else if (error.httpStatus === 404 || error.status === 404) {
 		context.type = "warning"
-		context.title = "Not Found"
+		context.title = __("Not Found")
 	} else if (error.httpStatus >= 500 || error.status >= 500) {
 		context.type = "error"
-		context.title = "Server Error"
+		context.title = __("Server Error")
 	}
 
 	// Extract primary message
@@ -123,7 +123,7 @@ export function parseError(error) {
 		normalizedMessage.includes("negative stock")
 	) {
 		context.type = "warning"
-		context.title = "Insufficient Stock"
+		context.title = __("Insufficient Stock")
 
 		// Parse the message to extract item and quantity information
 		// Example: "1.0 units of Item IPhone 17-WHI needed in Warehouse Goods In Transit - BrD"
@@ -141,7 +141,7 @@ export function parseError(error) {
 			context.message === "An unexpected error occurred"
 		) {
 			context.message =
-				"Not enough stock available in the warehouse.\n\nPlease reduce the quantity or check stock availability."
+				__("Not enough stock available in the warehouse.\n\nPlease reduce the quantity or check stock availability.")
 		}
 
 		context.retryable = true
@@ -149,7 +149,7 @@ export function parseError(error) {
 	// Validation Errors
 	else if (excType === "validationerror" || context.type === "validation") {
 		context.type = "validation"
-		context.title = "Validation Error"
+		context.title = __("Validation Error")
 		context.retryable = true
 	}
 	// Price List Errors
@@ -158,7 +158,7 @@ export function parseError(error) {
 		normalizedMessage.includes("price not found")
 	) {
 		context.type = "warning"
-		context.title = "Pricing Error"
+		context.title = __("Pricing Error")
 		context.retryable = true
 	}
 	// Customer/Party Errors
@@ -167,7 +167,7 @@ export function parseError(error) {
 		normalizedMessage.includes("party")
 	) {
 		context.type = "validation"
-		context.title = "Customer Error"
+		context.title = __("Customer Error")
 		context.retryable = true
 	}
 	// Tax Errors
@@ -176,7 +176,7 @@ export function parseError(error) {
 		normalizedMessage.includes("account")
 	) {
 		context.type = "warning"
-		context.title = "Tax Configuration Error"
+		context.title = __("Tax Configuration Error")
 		context.retryable = false
 	}
 	// Payment Errors
@@ -185,7 +185,7 @@ export function parseError(error) {
 		normalizedMessage.includes("mode of payment")
 	) {
 		context.type = "validation"
-		context.title = "Payment Error"
+		context.title = __("Payment Error")
 		context.retryable = true
 	}
 	// Series/Naming Errors
@@ -194,7 +194,7 @@ export function parseError(error) {
 		normalizedMessage.includes("naming")
 	) {
 		context.type = "error"
-		context.title = "Naming Series Error"
+		context.title = __("Naming Series Error")
 		context.retryable = false
 	}
 	// Permission Errors
@@ -203,7 +203,7 @@ export function parseError(error) {
 		normalizedMessage.includes("not allowed")
 	) {
 		context.type = "error"
-		context.title = "Permission Denied"
+		context.title = __("Permission Denied")
 		context.retryable = false
 	}
 	// Network/Connection Errors
@@ -214,9 +214,9 @@ export function parseError(error) {
 		normalizedMessage.includes("fetch")
 	) {
 		context.type = "warning"
-		context.title = "Connection Error"
+		context.title = __("Connection Error")
 		context.message =
-			"Unable to connect to server. Check your internet connection."
+			__("Unable to connect to server. Check your internet connection.")
 		context.retryable = true
 	}
 	// Duplicate Errors
@@ -225,7 +225,7 @@ export function parseError(error) {
 		normalizedMessage.includes("already exists")
 	) {
 		context.type = "validation"
-		context.title = "Duplicate Entry"
+		context.title = __("Duplicate Entry")
 		context.retryable = false
 	}
 
@@ -240,27 +240,27 @@ export function parseError(error) {
  */
 export function formatErrorReport(errorContext, additionalInfo = {}) {
 	const lines = [
-		"Error Report - POS Next",
+		__("Error Report - POS Next"),
 		"=".repeat(40),
-		`Title: ${errorContext.title}`,
-		`Type: ${errorContext.type}`,
-		`Message: ${errorContext.message}`,
+		__('Title: {0}', [errorContext.title]),
+		__('Type: {0}', [errorContext.type]),
+		__('Message: {0}', [errorContext.message]),
 		"",
 	]
 
 	if (errorContext.technicalDetails) {
-		lines.push(`Technical: ${errorContext.technicalDetails}`)
+		lines.push(__('Technical: {0}', [errorContext.technicalDetails]))
 		lines.push("")
 	}
 
 	if (additionalInfo.timestamp) {
-		lines.push(`Timestamp: ${additionalInfo.timestamp}`)
+		lines.push(__('Timestamp: {0}', [additionalInfo.timestamp]))
 	}
 	if (additionalInfo.user) {
-		lines.push(`User: ${additionalInfo.user}`)
+		lines.push(__('User: {0}', [additionalInfo.user]))
 	}
 	if (additionalInfo.posProfile) {
-		lines.push(`POS Profile: ${additionalInfo.posProfile}`)
+		lines.push(__('POS Profile: {0}', [additionalInfo.posProfile]))
 	}
 
 	return lines.join("\n")

--- a/POS/src/utils/offline/sync.js
+++ b/POS/src/utils/offline/sync.js
@@ -273,7 +273,7 @@ if (typeof window !== "undefined") {
 				console.log(`Successfully synced ${result.success} invoices`)
 				if (window.frappe?.msgprint) {
 					window.frappe.msgprint({
-						title: "Sync Complete",
+						title: __("Sync Complete"),
 						message: `Successfully synced ${result.success} offline invoices`,
 						indicator: "green",
 					})

--- a/POS/src/utils/printInvoice.js
+++ b/POS/src/utils/printInvoice.js
@@ -87,7 +87,7 @@ function printInvoiceCustom(invoiceData) {
 		<html>
 		<head>
 			<meta charset="UTF-8">
-			<title>Invoice - ${invoiceData.name}</title>
+			<title>${__('Invoice - {0}', [invoiceData.name])}</title>
 			<style>
 				* {
 					margin: 0;
@@ -254,24 +254,24 @@ function printInvoiceCustom(invoiceData) {
 				<!-- Header -->
 				<div class="header">
 					<div class="company-name">${invoiceData.company || "POS Next"}</div>
-					<div style="font-size: 12px;">TAX INVOICE</div>
+					<div style="font-size: 12px;">${__('TAX INVOICE')}</div>
 				</div>
 
 				<!-- Invoice Info -->
 				<div class="invoice-info">
 					<div>
-						<span>Invoice #:</span>
+						<span>${__('Invoice #:')}</span>
 						<span><strong>${invoiceData.name}</strong></span>
 					</div>
 					<div>
-						<span>Date:</span>
+						<span>${__('Date:')}</span>
 						<span>${new Date(invoiceData.posting_date || Date.now()).toLocaleString()}</span>
 					</div>
 					${
 						invoiceData.customer_name
 							? `
 					<div>
-						<span>Customer:</span>
+						<span>${__('Customer:')}</span>
 						<span>${invoiceData.customer_name}</span>
 					</div>
 					`
@@ -281,8 +281,8 @@ function printInvoiceCustom(invoiceData) {
 						(invoiceData.status === "Partly Paid" || (invoiceData.outstanding_amount && invoiceData.outstanding_amount > 0 && invoiceData.outstanding_amount < invoiceData.grand_total))
 							? `
 					<div class="partial-status">
-						<span>Status:</span>
-						<span>PARTIAL PAYMENT</span>
+						<span>${__('Status:')}</span>
+						<span>${__('PARTIAL PAYMENT')}</span>
 					</div>
 					`
 							: ""
@@ -310,7 +310,7 @@ function printInvoiceCustom(invoiceData) {
 							return `
 						<div class="item-row">
 							<div class="item-name">
-								${item.item_name || item.item_code}${isFree ? " (FREE)" : ""}
+								${item.item_name || item.item_code} ${isFree ? __('(FREE)') : ""}
 							</div>
 							<div class="item-details">
 								<span>${qty} × ${formatCurrency(displayRate)}</span>
@@ -339,11 +339,11 @@ function printInvoiceCustom(invoiceData) {
 						invoiceData.total_taxes_and_charges > 0
 							? `
 					<div class="total-row">
-						<span>Subtotal:</span>
+						<span>${__('Subtotal:')}</span>
 						<span>${formatCurrency((invoiceData.grand_total || 0) - (invoiceData.total_taxes_and_charges || 0))}</span>
 					</div>
 					<div class="total-row">
-						<span>Tax:</span>
+						<span>${__('Tax:')}</span>
 						<span>${formatCurrency(invoiceData.total_taxes_and_charges)}</span>
 					</div>
 					`
@@ -360,7 +360,7 @@ function printInvoiceCustom(invoiceData) {
 							: ""
 					}
 					<div class="total-row grand-total">
-						<span>TOTAL:</span>
+						<span>${__('TOTAL:')}</span>
 						<span>${formatCurrency(invoiceData.grand_total)}</span>
 					</div>
 				</div>
@@ -382,14 +382,14 @@ function printInvoiceCustom(invoiceData) {
 						)
 						.join("")}
 					<div class="payment-row total-paid">
-						<span>Total Paid:</span>
+						<span>${__('Total Paid:')}</span>
 						<span>${formatCurrency(invoiceData.paid_amount || 0)}</span>
 					</div>
 					${
 						invoiceData.change_amount && invoiceData.change_amount > 0
 							? `
 					<div class="payment-row" style="font-weight: bold; margin-top: 5px;">
-						<span>Change:</span>
+						<span>${__('Change:')}</span>
 						<span>${formatCurrency(invoiceData.change_amount)}</span>
 					</div>
 					`
@@ -399,7 +399,7 @@ function printInvoiceCustom(invoiceData) {
 						invoiceData.outstanding_amount && invoiceData.outstanding_amount > 0
 							? `
 					<div class="outstanding-row">
-						<span>BALANCE DUE:</span>
+						<span>${__('BALANCE DUE:')}</span>
 						<span>${formatCurrency(invoiceData.outstanding_amount)}</span>
 					</div>
 					`
@@ -412,17 +412,17 @@ function printInvoiceCustom(invoiceData) {
 
 				<!-- Footer -->
 				<div class="footer">
-					<div style="margin-bottom: 5px;">Thank you for your business!</div>
+					<div style="margin-bottom: 5px;">${__('Thank you for your business!')}</div>
 					<div style="font-size: 10px;">Powered by <a href="https://nexus.brainwise.me" target="_blank" style="color: #3b82f6; text-decoration: none; font-weight: 600;">BrainWise</a></div>
 				</div>
 			</div>
 
 			<div class="no-print" style="text-align: center; margin-top: 20px;">
 				<button onclick="window.print()" style="padding: 10px 20px; font-size: 14px; cursor: pointer;">
-					Print Receipt
+					${__('Print Receipt')}
 				</button>
 				<button onclick="window.close()" style="padding: 10px 20px; font-size: 14px; cursor: pointer; margin-left: 10px;">
-					Close
+					${__('Close')}
 				</button>
 			</div>
 		</body>

--- a/POS/src/utils/translation.ts
+++ b/POS/src/utils/translation.ts
@@ -1,0 +1,72 @@
+import { createResource } from "frappe-ui";
+import { App } from "vue";
+
+type Replace = { [key: string]: string };
+type TranslatedMessages = Replace;
+
+declare global {
+  interface Window {
+    __: (message: string, replace?: Replace, context?: string | null) => string;
+    translatedMessages?: TranslatedMessages;
+  }
+}
+
+export default function translationPlugin(app: App) {
+  app.config.globalProperties.__ = translate;
+  window.__ = translate;
+  if (!window.translatedMessages) fetchTranslations();
+}
+
+function format(message: string, replace?: Replace) {
+  if (!replace) return message;
+  return message.replace(/{(\d+)}/g, function (match, number) {
+    return typeof replace[number] != "undefined" ? replace[number] : match;
+  });
+}
+
+export function translate(
+  message: string,
+  replace?: Replace,
+  context: string | null = null,
+) {
+  let translatedMessages = window.translatedMessages || {};
+  let translatedMessage = "";
+
+  if (context) {
+    let key = `${message}:${context}`;
+    if (translatedMessages[key]) {
+      translatedMessage = translatedMessages[key];
+    }
+  }
+
+  if (!translatedMessage) {
+    translatedMessage = translatedMessages[message] || message;
+  }
+
+  const hasPlaceholders = /{\d+}/.test(message);
+  if (!hasPlaceholders) {
+    return translatedMessage;
+  }
+
+  return format(translatedMessage, replace);
+}
+
+function fetchTranslations() {
+  createResource({
+    url: "frappe.translate.get_app_translations",
+    cache: "translations",
+    auto: true,
+    transform: (messages: TranslatedMessages) => {
+      window.translatedMessages = messages;
+    },
+  });
+}
+
+export function __(
+  message: string,
+  replace?: Replace,
+  context: string | null = null,
+): string {
+  if (!window.__) return message;
+  return translate(message, replace, context);
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pos_next",
   "version": "1.0.0",
-  "description": "\u201cPOS built on ERPNext that brings together real-time billing, stock management, multi-user access, offline mode, and direct ERP integration. Run your store or restaurant with confidence and control, while staying 100% open source.",
+  "description": "POS built on ERPNext that brings together real-time billing, stock management, multi-user access, offline mode, and direct ERP integration. Run your store or restaurant with confidence and control, while staying 100% open source.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -11,5 +11,8 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "dompurify": "^3.3.0"
+  }
 }

--- a/pos_next/pos_next/doctype/pos_closing_shift/pos_closing_shift.py
+++ b/pos_next/pos_next/doctype/pos_closing_shift/pos_closing_shift.py
@@ -53,8 +53,8 @@ class POSClosingShift(Document):
         if user:
             frappe.throw(
                 _(
-                    "POS Closing Shift {} against {} between selected period".format(
-                        frappe.bold("already exists"), frappe.bold(self.user)
+                    "POS Closing Shift <strong>already exists</strong> against {0} between selected period".format(
+                        frappe.bold(self.user)
                     )
                 ),
                 title=_("Invalid Period"),


### PR DESCRIPTION
# Description

This PR adds translation support for all text that is displayed to the user in the front-end. It uses Frappe's built-in translation system.

# Implementation

In [POS/src/utils/translation.ts](35/files#diff-7ce2b3fef4d39c29de7998b423f798a3131586c420f282e2aca3a8c3aa7d120d) a plugin is defined that adds a `__` function to the window object. The app loads it at startup. This is the exact same implementation used in frappe/crm.

All relevant text strings in the app's files are wrapped inside a `__()` function call. Text strings that are not displayed in the UI (such as console logs) remain untouched.

Sometimes, it is necessary to have HTML inside of the translatable strings. For this purpose a [TranslatedHTML component](35/files#diff-e885453a85017bd6f38eb424c502f978862ebbc495632784296b63fae743f24e) has been added that sanitizes the text string before embedding it.

# Considerations

## Naming convention

Naming the method `__()` aligns with Frappe conventions as well as frappe-ui's draft pull request [frappe/frappe-ui#232](https://github.com/frappe/frappe-ui/pull/232) which would allow for directly plugging it in (replacing the current implementation) once that gets merged.

It also allows for using Frappe's built-in `bench get-untranslated` command to extract the strings to translate, however this requires running `bench build` first, as frappe will only see the strings once they are bundled and included inside the public folder.

## Error handling

There is currently some logic in the [error handler](35/files#diff-3f0d156cae8f1661136bf8262e47fff57bdd2645989fe0fae07419d2b931f688) that parses error messages, which is not compatible with translated strings. That function will have to be either updated or removed.

# TODO

1. Update error handling
2. Test more thoroughly