### PR TITLE
fix(localization): correctly set user language when switching locale

### DIFF
--- a/POS/src/composables/useLocale.js
+++ b/POS/src/composables/useLocale.js
@@ -1,4 +1,6 @@
 import { ref, computed, onMounted } from "vue"
+import { sessionUser } from "../data/session"
+import { call } from "frappe-ui"
 
 // Reactive locale state (shared across all components)
 const currentLocale = ref("en")
@@ -104,22 +106,18 @@ export function useLocale() {
 		}
 
 		// Update Frappe user settings
-		if (typeof window !== "undefined" && window.frappe?.call) {
 			try {
-				await window.frappe.call({
-					method: "frappe.client.set_value",
-					args: {
+				await call(
+					"frappe.client.set_value",
+					{
 						doctype: "User",
-						name: window.frappe.session.user,
+						name: sessionUser(),
 						fieldname: "language",
 						value: newLocale.toLowerCase(),
-					},
-					freeze: false,
-				})
+					})
 			} catch (error) {
 				console.error("Failed to save language preference to Frappe:", error)
 			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
## Description

Currently, useLocale's `changeLocale` method incorrectly attempts to use window.frappe (which is not available in the Vue frontend) to set the user's language. This PR changes the method to use frappe-ui's `call` function instead.

## TODO

App needs to reload translations when logging in or switching locale. For the latter, a simple reload would be enough, however this may not be acceptable to do a full reload when login happens. A listener that loads translation on login should work provided rendering is stopped until the translations are fetched, which I'm not sure whether it is trivial.