### PR TITLE
feat: Allow editing selling price from POS

### DIFF
--- a/POS/src/components/sale/EditItemDialog.vue
+++ b/POS/src/components/sale/EditItemDialog.vue
@@ -89,13 +89,20 @@
 									{{ currencySymbol }}
 								</span>
 								<input
-									v-model.number="localRate"
-									type="number"
-									min="0"
-									step="0.01"
-									readonly
-									class="w-full h-10 border border-gray-300 rounded-lg pl-16 pr-3 text-sm font-semibold bg-gray-50 cursor-not-allowed"
-								/>
+									<input
+										v-model.number="localRate"
+										type="number"
+										min="0"
+										step="0.01"
+										:readonly="!settingsStore.allowEditSellingPrice"
+										@input="calculateTotals"
+										:class="[
+											'w-full h-10 border border-gray-300 rounded-lg pl-16 pr-3 text-sm font-semibold',
+											settingsStore.allowEditSellingPrice
+												? 'bg-white focus:outline-none focus:ring-2 focus:ring-blue-500'
+												: 'bg-gray-50 cursor-not-allowed',
+										]"
+									/>
 							</div>
 						</div>
 					</div>

--- a/POS/src/stores/posSettings.js
+++ b/POS/src/stores/posSettings.js
@@ -33,6 +33,7 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 		allow_print_draft_invoices: 0,
 		// Pricing & Display
 		decimal_precision: "2",
+		allow_user_to_edit_selling_price: 0,
 		// Customer Settings
 		allow_customer_purchase_order: 0,
 		allow_duplicate_customer_names: 0,
@@ -130,6 +131,9 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 	// Computed - Pricing & Display
 	const decimalPrecision = computed(
 		() => Number.parseInt(settings.value.decimal_precision) || 2,
+	)
+	const allowEditSellingPrice = computed(() =>
+		Boolean(settings.value.allow_user_to_edit_selling_price),
 	)
 
 	// Computed - Customer Settings
@@ -256,6 +260,7 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 			allow_free_batch_return: 0,
 			allow_print_draft_invoices: 0,
 			decimal_precision: "2",
+			allow_user_to_edit_selling_price: 0,
 			allow_customer_purchase_order: 0,
 			allow_duplicate_customer_names: 0,
 			fetch_coupon: 0,
@@ -362,6 +367,7 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 
 		// Computed - Pricing & Display
 		decimalPrecision,
+		allowEditSellingPrice,
 
 		// Computed - Customer Settings
 		allowCustomerPurchaseOrder,

--- a/pos_next/pos_next/doctype/pos_settings/pos_settings.json
+++ b/pos_next/pos_next/doctype/pos_settings/pos_settings.json
@@ -35,6 +35,7 @@
   "allow_free_batch_return",
   "allow_print_draft_invoices",
   "section_break_pricing",
+  "allow_user_to_edit_selling_price",
   "decimal_precision",
   "tax_inclusive",
   "section_break_customer",
@@ -266,6 +267,12 @@
    "fieldname": "section_break_pricing",
    "fieldtype": "Section Break",
    "label": "Pricing & Display"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_user_to_edit_selling_price",
+   "fieldtype": "Check",
+   "label": "Allow User to Edit Selling Price"
   },
   {
    "default": "2",


### PR DESCRIPTION
This commit introduces a new feature that allows users to modify the selling price of an item directly from the POS interface.

A new setting, 'Allow User to Edit Selling Price', has been added to the POS Settings. When enabled, the rate field in the 'Edit Item' dialog becomes editable, allowing for price adjustments on the fly.

The backend logic in `pos_next/api/invoices.py` has been verified to correctly handle the modified rate by reverse-calculating the `price_list_rate`, ensuring the user's intended price is saved on the invoice.