### PR TITLE
fix: prevent draft deletion on load multiple drafts and auto-save active cart when switching

### DIFF
--- a/POS/src/stores/posCart.js
+++ b/POS/src/stores/posCart.js
@@ -51,6 +51,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 	const appliedCoupon = ref(null)
 	const selectionMode = ref("uom") // 'uom' or 'variant'
 	const suppressOfferReapply = ref(false)
+	const currentDraftId = ref(null)
 
 	// Toast composable
 	const { showSuccess, showError, showWarning } = useToast()
@@ -110,6 +111,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		customer.value = null
 		appliedOffers.value = []
 		appliedCoupon.value = null
+		currentDraftId.value = null
 	}
 
 	function setCustomer(selectedCustomer) {
@@ -780,6 +782,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		appliedCoupon,
 		selectionMode,
 		suppressOfferReapply,
+		currentDraftId,
 		// Computed
 		itemCount,
 		isEmpty,


### PR DESCRIPTION
Enhance Draft Management.

- Modified `loadDraft` in `posDrafts.js` to stop deleting the draft immediately upon loading.
- Added `currentDraftId` to `posCart.js` to track the active draft.
- Updated `saveDraftInvoice` in `posDrafts.js` to support updating an existing draft via `updateDraft`.
- Implemented logic in `POSSale.vue` to auto-save the current cart (updating the existing draft if applicable) before loading a new draft.
- Ensured drafts are deleted only after successful payment/submission in `POSSale.vue`.
- Added safety check to abort draft switching if auto-save fails.