### PR TITLE
feat: Allow item-level negative stock override in POS

### DIFF
--- a/POS/src/components/sale/ItemsSelector.vue
+++ b/POS/src/components/sale/ItemsSelector.vue
@@ -1095,7 +1095,9 @@ function handleItemClick(itemCode) {
 	// - Item templates (has_variants) - variants have their own stock, template shouldn't be checked
 	// Check stock for stock items AND Product Bundles (bundles now have calculated stock)
 	const qty = Math.floor((item.actual_qty ?? item.stock_qty ?? 0))
-	if ((item.is_stock_item || item.is_bundle) && !item.has_variants && !item.has_serial_no && !item.has_batch_no && qty <= 0 && settingsStore.shouldEnforceStockValidation()) {
+	const itemAllowsNegativeStock = Boolean(item.allow_negative_stock)
+
+	if ((item.is_stock_item || item.is_bundle) && !itemAllowsNegativeStock && !item.has_variants && !item.has_serial_no && !item.has_batch_no && qty <= 0 && settingsStore.shouldEnforceStockValidation()) {
 		showError(item.is_bundle 
 			? __('"{0}" cannot be added to cart. Bundle is out of stock. Allow Negative Stock is disabled.', [item.item_name])
 			: __('"{0}" cannot be added to cart. Item is out of stock. Allow Negative Stock is disabled.', [item.item_name]))

--- a/POS/src/composables/useToast.js
+++ b/POS/src/composables/useToast.js
@@ -1,4 +1,5 @@
 import { ref } from "vue"
+import { playSuccessSound, playErrorSound } from "@/utils/soundFeedback"
 
 // Global toast state
 const toastNotification = ref(null)
@@ -20,14 +21,17 @@ export function useToast() {
 
 	function showSuccess(message) {
 		showToastNotification("Success", message, "success")
+		playSuccessSound()
 	}
 
 	function showError(message) {
 		showToastNotification("Error", message, "error")
+		playErrorSound()
 	}
 
 	function showWarning(message) {
 		showToastNotification("Validation Error", message, "warning")
+		playErrorSound()
 	}
 
 	function hideToast() {

--- a/POS/src/stores/posCart.js
+++ b/POS/src/stores/posCart.js
@@ -7,6 +7,7 @@ import {
 	formatStockError,
 } from "@/utils/stockValidator"
 import { useToast } from "@/composables/useToast"
+import { playSuccessSound } from "@/utils/soundFeedback"
 import { defineStore } from "pinia"
 import { computed, nextTick, ref, toRaw, watch } from "vue"
 
@@ -107,6 +108,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 
 		// Add item to cart - no toast notification for performance
 		addItemToInvoice(item, qty)
+		playSuccessSound()
 	}
 
 	function clearCart() {

--- a/POS/src/stores/posCart.js
+++ b/POS/src/stores/posCart.js
@@ -75,7 +75,10 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		const hasActualQty = item.actual_qty !== undefined || item.stock_qty !== undefined
 		const shouldValidateStock = !isNonStockItem && (item.is_stock_item || item.is_bundle || hasActualQty)
 
-		if (currentProfile && !autoAdd && settingsStore.shouldEnforceStockValidation() && shouldValidateStock && !item.has_serial_no && !item.has_batch_no) {
+		// Check if item specifically allows negative stock (overrides global setting)
+		const itemAllowsNegativeStock = Boolean(item.allow_negative_stock)
+
+		if (currentProfile && !autoAdd && settingsStore.shouldEnforceStockValidation() && !itemAllowsNegativeStock && shouldValidateStock && !item.has_serial_no && !item.has_batch_no) {
 			const warehouse = item.warehouse || currentProfile.warehouse
 			const actualQty =
 				item.actual_qty !== undefined ? item.actual_qty : item.stock_qty || 0

--- a/POS/src/stores/posUI.js
+++ b/POS/src/stores/posUI.js
@@ -1,4 +1,5 @@
 import { useDialog, useDialogState } from "@/composables/useDialogState"
+import { playErrorSound } from "@/utils/soundFeedback"
 import { defineStore } from "pinia"
 import { computed, ref } from "vue"
 
@@ -86,6 +87,7 @@ export const usePOSUIStore = defineStore("posUI", () => {
 		errorRetryAction.value = retryAction
 		errorRetryActionData.value = retryData
 		showErrorDialog.value = true
+		playErrorSound()
 	}
 
 	function clearError() {

--- a/POS/src/utils/soundFeedback.js
+++ b/POS/src/utils/soundFeedback.js
@@ -1,0 +1,79 @@
+
+let audioContext = null;
+
+function initAudio() {
+	if (!audioContext) {
+		const AudioContext = window.AudioContext || window.webkitAudioContext;
+		if (AudioContext) {
+			audioContext = new AudioContext();
+		}
+	}
+}
+
+export function playSuccessSound() {
+	try {
+		initAudio();
+		if (!audioContext) return;
+
+		if (audioContext.state === 'suspended') {
+			audioContext.resume().catch(() => {});
+		}
+
+		const oscillator = audioContext.createOscillator();
+		const gainNode = audioContext.createGain();
+
+		oscillator.type = 'sine';
+		// A pleasant high pitch beep (e.g. 1000Hz)
+		oscillator.frequency.setValueAtTime(1000, audioContext.currentTime);
+
+		// Envelope to avoid clicking
+		gainNode.gain.setValueAtTime(0, audioContext.currentTime);
+		gainNode.gain.linearRampToValueAtTime(0.1, audioContext.currentTime + 0.01);
+		gainNode.gain.exponentialRampToValueAtTime(0.001, audioContext.currentTime + 0.15);
+
+		oscillator.connect(gainNode);
+		gainNode.connect(audioContext.destination);
+
+		oscillator.start();
+		oscillator.stop(audioContext.currentTime + 0.2);
+	} catch (e) {
+		console.error("Failed to play success sound", e);
+	}
+}
+
+export function playErrorSound() {
+	try {
+		initAudio();
+		if (!audioContext) return;
+
+		if (audioContext.state === 'suspended') {
+			audioContext.resume().catch(() => {});
+		}
+
+		const now = audioContext.currentTime;
+		const oscillator = audioContext.createOscillator();
+		const gainNode = audioContext.createGain();
+
+		// Use sine wave for a smoother, less abrasive sound
+		oscillator.type = 'sine';
+
+		// Play a low "dun-dun" sound
+		oscillator.frequency.setValueAtTime(200, now);
+		oscillator.frequency.setValueAtTime(150, now + 0.15); // Drop pitch for second note
+
+		// Envelope: Pulse twice
+		gainNode.gain.setValueAtTime(0, now);
+		gainNode.gain.linearRampToValueAtTime(0.2, now + 0.05);
+		gainNode.gain.linearRampToValueAtTime(0.05, now + 0.1); // Dip volume
+		gainNode.gain.linearRampToValueAtTime(0.2, now + 0.2);  // Rise again
+		gainNode.gain.exponentialRampToValueAtTime(0.001, now + 0.4);
+
+		oscillator.connect(gainNode);
+		gainNode.connect(audioContext.destination);
+
+		oscillator.start();
+		oscillator.stop(now + 0.45);
+	} catch (e) {
+		console.error("Failed to play error sound", e);
+	}
+}

--- a/pos_next/api/invoices.py
+++ b/pos_next/api/invoices.py
@@ -138,8 +138,16 @@ def _collect_stock_errors(items):
     return errors
 
 
-def _should_block(pos_profile):
+def _should_block(pos_profile, item_code=None):
     """Check if sale should be blocked for insufficient stock."""
+    # If item-specific override allows negative stock, do not block
+    if item_code:
+        item_allow_negative = cint(
+            frappe.db.get_value("Item", item_code, "allow_negative_stock") or 0
+        )
+        if item_allow_negative:
+            return False
+
     # First check global ERPNext Stock Settings
     allow_negative = cint(
         frappe.db.get_single_value("Stock Settings", "allow_negative_stock") or 0
@@ -190,9 +198,16 @@ def _validate_stock_on_invoice(invoice_doc):
     # Check for stock errors
     errors = _collect_stock_errors(items_to_check)
 
+    # Filter out errors for items that allow negative stock or where blocking is disabled
+    final_errors = []
+    if errors:
+        for error in errors:
+            if _should_block(invoice_doc.pos_profile, error.get("item_code")):
+                final_errors.append(error)
+
     # Throw error if stock insufficient and blocking is enabled
-    if errors and _should_block(invoice_doc.pos_profile):
-        frappe.throw(frappe.as_json({"errors": errors}), frappe.ValidationError)
+    if final_errors:
+        frappe.throw(frappe.as_json({"errors": final_errors}), frappe.ValidationError)
 
 
 def _auto_set_return_batches(invoice_doc):
@@ -245,14 +260,16 @@ def validate_cart_items(items, pos_profile=None):
     if pos_profile and not frappe.db.exists("POS Profile", pos_profile):
         pos_profile = None
 
-    if not _should_block(pos_profile):
-        return []
-
     errors = _collect_stock_errors(items)
-    if not errors:
-        return []
 
-    return errors
+    # Filter errors based on blocking logic per item
+    final_errors = []
+    if errors:
+        for error in errors:
+            if _should_block(pos_profile, error.get("item_code")):
+                final_errors.append(error)
+
+    return final_errors
 
 
 @frappe.whitelist()

--- a/pos_next/api/items.py
+++ b/pos_next/api/items.py
@@ -26,6 +26,7 @@ ITEM_RESULT_FIELDS = [
 	"has_variants",
 	"custom_company",
 	"disabled",
+	"allow_negative_stock",
 ]
 
 ITEM_RESULT_COLUMNS = ",\n\t".join(ITEM_RESULT_FIELDS)
@@ -276,10 +277,13 @@ def get_item_detail(item, doc=None, warehouse=None, price_list=None, company=Non
 	res["batch_no_data"] = batch_no_data
 	res["serial_no_data"] = serial_no_data
 
-	# Add item_group and brand for offer eligibility checking
-	item_group, brand = frappe.db.get_value("Item", item_code, ["item_group", "brand"])
-	res["item_group"] = item_group
-	res["brand"] = brand
+	# Add item_group, brand and allow_negative_stock
+	item_values = frappe.db.get_value(
+		"Item", item_code, ["item_group", "brand", "allow_negative_stock"], as_dict=1
+	)
+	res["item_group"] = item_values.item_group
+	res["brand"] = item_values.brand
+	res["allow_negative_stock"] = item_values.allow_negative_stock
 
 	# Add UOMs data
 	uoms = frappe.get_all(
@@ -493,6 +497,7 @@ def get_item_variants(template_item, pos_profile):
 				"item_group",
 				"brand",
 				"custom_company",
+				"allow_negative_stock",
 			],
 		)
 
@@ -1033,6 +1038,7 @@ def get_items(pos_profile, search_term=None, item_group=None, start=0, limit=20)
 					"has_variants",
 					"custom_company",
 					"disabled",
+					"allow_negative_stock",
 				],
 				start=start,
 				page_length=limit,


### PR DESCRIPTION
* feat: allow item-level override for negative stock validation

- Updated `pos_next/api/items.py` to include `allow_negative_stock` in item data responses (`get_items`, `get_item_detail`, etc.).
- Modified `POS/src/stores/posCart.js` to skip stock validation if `item.allow_negative_stock` is true, even when global settings enforce stock checks.
- Ensures items configured to allow negative stock can be added to the cart regardless of global POS profile restrictions.

* feat: backend support for item-level negative stock override

- Updated `pos_next/api/invoices.py` to check for `allow_negative_stock` at the item level in `_should_block`.
- Modified `validate_cart_items` and `_validate_stock_on_invoice` to filter out stock errors for items that allow negative stock.
- Frontend logic in `POS/src/stores/posCart.js` was already updated to support this override.
- This ensures that items configured to allow negative stock can be sold even if the global POS profile restricts it.

* feat: add item-level negative stock override to frontend validation

- Updated `POS/src/components/sale/ItemsSelector.vue` to respect `allow_negative_stock` in `handleItemClick`.
- Ensures items with this override do not trigger the "Allow Negative Stock is disabled" error when added to the cart from the item selector.
- Complements previous changes in `posCart.js` and backend API logic.