### PR TITLE
fix(payment): add mutex protection to prevent duplicate invoice submissions

### DIFF
--- a/POS/src/components/sale/PaymentDialog.vue
+++ b/POS/src/components/sale/PaymentDialog.vue
@@ -493,15 +493,23 @@
 								<!-- Pay on Account Button -->
 								<button
 									@click="addCreditAccountPayment"
+									:disabled="isSubmitting"
 									:class="[
-										'font-semibold rounded-lg bg-orange-500 text-white active:bg-orange-600 flex items-center justify-center',
+										'font-semibold rounded-lg flex items-center justify-center',
+										isSubmitting
+											? 'bg-orange-300 text-white cursor-not-allowed'
+											: 'bg-orange-500 text-white active:bg-orange-600',
 										mobileButtonSize.height, mobileButtonSize.text, mobileButtonSize.gap
 									]"
 								>
-									<svg :class="mobileButtonSize.icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<svg v-if="isSubmitting" :class="mobileButtonSize.icon" class="animate-spin" fill="none" viewBox="0 0 24 24">
+										<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+										<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+									</svg>
+									<svg v-else :class="mobileButtonSize.icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
 									</svg>
-									<span class="truncate">{{ __('On Account') }}</span>
+									<span class="truncate">{{ isSubmitting ? __('Processing...') : __('On Account') }}</span>
 								</button>
 							</div>
 
@@ -509,8 +517,12 @@
 							<button
 								v-else-if="lastSelectedMethod && remainingAmount > 0"
 								@click="addCustomPayment(lastSelectedMethod, remainingAmount)"
+								:disabled="isSubmitting"
 								:class="[
-									'w-full font-bold rounded-lg bg-green-500 text-white active:bg-green-600 flex items-center justify-center',
+									'w-full font-bold rounded-lg flex items-center justify-center',
+									isSubmitting
+										? 'bg-green-300 text-white cursor-not-allowed'
+										: 'bg-green-500 text-white active:bg-green-600',
 									mobileButtonSize.height, mobileButtonSize.text, mobileButtonSize.gap
 								]"
 							>
@@ -524,15 +536,23 @@
 							<button
 								v-if="remainingAmount === 0 && totalPaid > 0"
 								@click="completePayment"
+								:disabled="isSubmitting"
 								:class="[
-									'w-full font-bold rounded-lg bg-blue-500 text-white active:bg-blue-600 flex items-center justify-center',
+									'w-full font-bold rounded-lg flex items-center justify-center',
+									isSubmitting
+										? 'bg-blue-300 text-white cursor-not-allowed'
+										: 'bg-blue-500 text-white active:bg-blue-600',
 									mobileButtonSize.height, mobileButtonSize.text, mobileButtonSize.gap
 								]"
 							>
-								<svg :class="mobileButtonSize.icon" fill="currentColor" viewBox="0 0 20 20">
+								<svg v-if="isSubmitting" :class="mobileButtonSize.icon" class="animate-spin" fill="none" viewBox="0 0 24 24">
+									<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+									<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+								</svg>
+								<svg v-else :class="mobileButtonSize.icon" fill="currentColor" viewBox="0 0 20 20">
 									<path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
 								</svg>
-								<span>{{ __('Complete Payment') }}</span>
+								<span>{{ isSubmitting ? __('Processing...') : __('Complete Payment') }}</span>
 							</button>
 						</div>
 					</div>
@@ -640,37 +660,45 @@
 						<button
 							v-if="allowCreditSale"
 							@click="addCreditAccountPayment"
-							:disabled="paymentEntries.length > 0"
+							:disabled="paymentEntries.length > 0 || isSubmitting"
 							:class="[
 								'flex-1 inline-flex items-center justify-center gap-2 transition-colors focus:outline-none',
 								dynamicButtonHeight, 'text-sm font-semibold px-4 rounded-lg',
-								paymentEntries.length > 0
+								paymentEntries.length > 0 || isSubmitting
 									? 'bg-orange-300 text-white cursor-not-allowed'
 									: 'bg-orange-500 text-white hover:bg-orange-600 active:bg-orange-700 focus-visible:ring-2 focus-visible:ring-orange-400'
 							]"
 						>
-							<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<svg v-if="isSubmitting" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+								<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+								<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+							</svg>
+							<svg v-else class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
 							</svg>
-							<span>{{ __('Pay on Account') }}</span>
+							<span>{{ isSubmitting ? __('Processing...') : __('Pay on Account') }}</span>
 						</button>
 
 						<!-- Complete/Partial Payment Button -->
 						<button
 							@click="completePayment"
-							:disabled="!canComplete"
+							:disabled="!canComplete || isSubmitting"
 							:class="[
 								'flex-1 inline-flex items-center justify-center gap-2 transition-colors focus:outline-none',
 								dynamicButtonHeight, 'text-sm font-semibold px-5 rounded-lg',
-								!canComplete
+								!canComplete || isSubmitting
 									? 'bg-blue-300 text-white cursor-not-allowed'
 									: 'bg-blue-600 text-white hover:bg-blue-700 active:bg-blue-800 focus-visible:ring-2 focus-visible:ring-blue-400'
 							]"
 						>
-							<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+							<svg v-if="isSubmitting" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+								<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+								<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+							</svg>
+							<svg v-else class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
 								<path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
 							</svg>
-							<span>{{ paymentButtonText }}</span>
+							<span>{{ isSubmitting ? __('Processing...') : paymentButtonText }}</span>
 						</button>
 					</div>
 				</div>
@@ -750,6 +778,10 @@ const props = defineProps({
 	targetDoctype: {
 		type: String,
 		default: "Sales Invoice",
+	},
+	isSubmitting: {
+		type: Boolean,
+		default: false,
 	},
 })
 

--- a/POS/src/composables/useInvoice.js
+++ b/POS/src/composables/useInvoice.js
@@ -3,6 +3,9 @@ import { computed, ref, toRaw } from "vue"
 import { isOffline } from "@/utils/offline"
 import { useSerialNumberStore } from "@/stores/serialNumber"
 import { CoalescingMutex } from "@/utils/mutex"
+import { logger } from "@/utils/logger"
+
+const log = logger.create("Invoice")
 
 
 // Shared mutex for invoice submission across all useInvoice instances
@@ -723,7 +726,7 @@ export function useInvoice() {
 		return await submitMutex.withLock(async () => {
 			// Check if already submitting (belt and suspenders with mutex)
 			if (isSubmitting.value) {
-				console.warn("Invoice submission already in progress, skipping duplicate request")
+				log.warn("Invoice submission already in progress, skipping duplicate request")
 				return null
 			}
 

--- a/POS/src/composables/useInvoice.js
+++ b/POS/src/composables/useInvoice.js
@@ -7,10 +7,12 @@ import { logger } from "@/utils/logger"
 
 const log = logger.create("Invoice")
 
-
 // Shared mutex for invoice submission across all useInvoice instances
 // This prevents duplicate invoice creation from rapid clicks or concurrent submissions
-const submitMutex = new CoalescingMutex({ timeout: 60000, name: "InvoiceSubmit" })
+const submitMutex = new CoalescingMutex({
+	timeout: 60000,
+	name: "InvoiceSubmit",
+})
 
 export function useInvoice() {
 	// Serial Number Store for returning serials when items are removed

--- a/POS/src/composables/useInvoice.js
+++ b/POS/src/composables/useInvoice.js
@@ -2,7 +2,12 @@ import { createResource } from "frappe-ui"
 import { computed, ref, toRaw } from "vue"
 import { isOffline } from "@/utils/offline"
 import { useSerialNumberStore } from "@/stores/serialNumber"
+import { CoalescingMutex } from "@/utils/mutex"
 
+
+// Shared mutex for invoice submission across all useInvoice instances
+// This prevents duplicate invoice creation from rapid clicks or concurrent submissions
+const submitMutex = new CoalescingMutex({ timeout: 60000, name: "InvoiceSubmit" })
 
 export function useInvoice() {
 	// Serial Number Store for returning serials when items are removed
@@ -19,6 +24,9 @@ export function useInvoice() {
 	const couponCode = ref(null)
 	const taxRules = ref([]) // Tax rules from POS Profile
 	const taxInclusive = ref(false) // Tax inclusive setting from POS Settings
+
+	// Submission state - prevents duplicate submissions
+	const isSubmitting = ref(false)
 
 	// Performance: Incrementally maintained aggregates (updated on add/remove/change)
 	// This avoids O(n) array reductions on every reactive change
@@ -703,158 +711,175 @@ export function useInvoice() {
 
 	async function submitInvoice(targetDoctype = "Sales Invoice", deliveryDate = null) {
 		/**
-		 * Two-step submission process:
+		 * Two-step submission process with mutex protection:
 		 * 1. Create/update draft invoice
 		 * 2. Validate stock and submit
+		 *
+		 * The mutex prevents duplicate invoice creation from:
+		 * - Rapid double-clicks on payment buttons
+		 * - Concurrent submissions from multiple UI interactions
+		 * - Credit sales where full amount goes on account
 		 */
-		try {
-			// Step 1: Create invoice draft
-			// Use toRaw() to ensure we get current, non-reactive values (prevents stale cached quantities)
-			const rawItems = toRaw(invoiceItems.value)
-			const rawPayments = toRaw(payments.value)
-			const rawSalesTeam = toRaw(salesTeam.value)
-
-			const invoiceData = {
-				doctype: targetDoctype,
-				pos_profile: posProfile.value,
-				posa_pos_opening_shift: posOpeningShift.value,
-				customer: customer.value?.name || customer.value,
-				items: rawItems.map((item) => ({
-					item_code: item.item_code,
-					item_name: item.item_name,
-					qty: item.quantity,
-					// IMPORTANT: Rate calculation depends on tax mode and discounts
-					// Tax-inclusive mode: Send gross amount (price after discount, before tax extraction)
-					//   - With discount: price_list_rate - discount_amount
-					//   - Without discount: price_list_rate
-					//   ERPNext will extract net amount based on included_in_print_rate flag
-					// Tax-exclusive mode: Send net amount (after discount, before tax addition)
-					rate: taxInclusive.value
-						? ((item.price_list_rate || item.rate) - (item.discount_amount || 0) / (item.quantity || 1))
-						: (item.quantity > 0 ? item.amount / item.quantity : item.rate),
-					price_list_rate: item.price_list_rate || item.rate,
-					uom: item.uom,
-					warehouse: item.warehouse,
-					batch_no: item.batch_no,
-					serial_no: item.serial_no,
-					conversion_factor: item.conversion_factor || 1,
-					discount_percentage: item.discount_percentage || 0,
-					discount_amount: item.discount_amount || 0,
-				})),
-				payments: rawPayments.map((p) => ({
-					mode_of_payment: p.mode_of_payment,
-					amount: p.amount,
-					type: p.type,
-				})),
-				discount_amount: additionalDiscount.value || 0,
-				coupon_code: couponCode.value,
-				is_pos: 1,
-				update_stock: 1, // Critical: Ensures stock is updated
+		return await submitMutex.withLock(async () => {
+			// Check if already submitting (belt and suspenders with mutex)
+			if (isSubmitting.value) {
+				console.warn("Invoice submission already in progress, skipping duplicate request")
+				return null
 			}
 
-			if (targetDoctype === "Sales Order" && deliveryDate) {
-				invoiceData.delivery_date = deliveryDate
-			}
-
-			// Add sales_team if provided
-			if (rawSalesTeam && rawSalesTeam.length > 0) {
-				invoiceData.sales_team = rawSalesTeam.map((member) => ({
-					sales_person: member.sales_person,
-					allocated_percentage: member.allocated_percentage || 0,
-				}))
-			}
-
-			const draftInvoice = await updateInvoiceResource.submit({
-				data: invoiceData,
-			})
-
-			let invoiceDoc = draftInvoice
-			if (
-				draftInvoice &&
-				typeof draftInvoice === "object" &&
-				"data" in draftInvoice
-			) {
-				invoiceDoc = draftInvoice.data
-			}
-
-			if (!invoiceDoc || !invoiceDoc.name) {
-				throw new Error(
-					"Failed to create draft invoice - no invoice name returned",
-				)
-			}
-
-			const submitData = {
-				change_amount:
-					remainingAmount.value < 0 ? Math.abs(remainingAmount.value) : 0,
-			}
+			isSubmitting.value = true
 
 			try {
-				const result = await submitInvoiceResource.submit({
-					invoice: invoiceDoc,
-					data: submitData,
+				// Step 1: Create invoice draft
+				// Use toRaw() to ensure we get current, non-reactive values (prevents stale cached quantities)
+				const rawItems = toRaw(invoiceItems.value)
+				const rawPayments = toRaw(payments.value)
+				const rawSalesTeam = toRaw(salesTeam.value)
+
+				const invoiceData = {
+					doctype: targetDoctype,
+					pos_profile: posProfile.value,
+					posa_pos_opening_shift: posOpeningShift.value,
+					customer: customer.value?.name || customer.value,
+					items: rawItems.map((item) => ({
+						item_code: item.item_code,
+						item_name: item.item_name,
+						qty: item.quantity,
+						// IMPORTANT: Rate calculation depends on tax mode and discounts
+						// Tax-inclusive mode: Send gross amount (price after discount, before tax extraction)
+						//   - With discount: price_list_rate - discount_amount
+						//   - Without discount: price_list_rate
+						//   ERPNext will extract net amount based on included_in_print_rate flag
+						// Tax-exclusive mode: Send net amount (after discount, before tax addition)
+						rate: taxInclusive.value
+							? ((item.price_list_rate || item.rate) - (item.discount_amount || 0) / (item.quantity || 1))
+							: (item.quantity > 0 ? item.amount / item.quantity : item.rate),
+						price_list_rate: item.price_list_rate || item.rate,
+						uom: item.uom,
+						warehouse: item.warehouse,
+						batch_no: item.batch_no,
+						serial_no: item.serial_no,
+						conversion_factor: item.conversion_factor || 1,
+						discount_percentage: item.discount_percentage || 0,
+						discount_amount: item.discount_amount || 0,
+					})),
+					payments: rawPayments.map((p) => ({
+						mode_of_payment: p.mode_of_payment,
+						amount: p.amount,
+						type: p.type,
+					})),
+					discount_amount: additionalDiscount.value || 0,
+					coupon_code: couponCode.value,
+					is_pos: 1,
+					update_stock: 1, // Critical: Ensures stock is updated
+				}
+
+				if (targetDoctype === "Sales Order" && deliveryDate) {
+					invoiceData.delivery_date = deliveryDate
+				}
+
+				// Add sales_team if provided
+				if (rawSalesTeam && rawSalesTeam.length > 0) {
+					invoiceData.sales_team = rawSalesTeam.map((member) => ({
+						sales_person: member.sales_person,
+						allocated_percentage: member.allocated_percentage || 0,
+					}))
+				}
+
+				const draftInvoice = await updateInvoiceResource.submit({
+					data: invoiceData,
 				})
 
-				// Check if resource has error (frappe-ui pattern)
-				if (submitInvoiceResource.error) {
-					const resourceError = submitInvoiceResource.error
-					console.error("Submit invoice resource error:", resourceError)
-
-					// Create a detailed error object
-					const detailedError = new Error(
-						resourceError.message || "Invoice submission failed",
-					)
-					detailedError.exc_type = resourceError.exc_type
-					detailedError._server_messages = resourceError._server_messages
-					detailedError.httpStatus = resourceError.httpStatus
-					detailedError.messages = resourceError.messages
-
-					throw detailedError
+				let invoiceDoc = draftInvoice
+				if (
+					draftInvoice &&
+					typeof draftInvoice === "object" &&
+					"data" in draftInvoice
+				) {
+					invoiceDoc = draftInvoice.data
 				}
 
-				resetInvoice()
-				return result
-			} catch (error) {
-				// Preserve original error object with all its properties
-				console.error("Submit invoice error:", error)
-				console.log("submitInvoiceResource.error:", submitInvoiceResource.error)
+				if (!invoiceDoc || !invoiceDoc.name) {
+					throw new Error(
+						"Failed to create draft invoice - no invoice name returned",
+					)
+				}
 
-				// If resource has error data, extract and attach it
-				if (submitInvoiceResource.error) {
-					const resourceError = submitInvoiceResource.error
-					console.log("Resource error details:", {
-						exc_type: resourceError.exc_type,
-						_server_messages: resourceError._server_messages,
-						httpStatus: resourceError.httpStatus,
-						messages: resourceError.messages,
-						messagesContent: JSON.stringify(resourceError.messages),
-						data: resourceError.data,
-						exception: resourceError.exception,
-						keys: Object.keys(resourceError),
+				const submitData = {
+					change_amount:
+						remainingAmount.value < 0 ? Math.abs(remainingAmount.value) : 0,
+				}
+
+				try {
+					const result = await submitInvoiceResource.submit({
+						invoice: invoiceDoc,
+						data: submitData,
 					})
 
-					// The messages array likely contains the detailed error info
-					if (resourceError.messages && resourceError.messages.length > 0) {
-						console.log("First message:", resourceError.messages[0])
+					// Check if resource has error (frappe-ui pattern)
+					if (submitInvoiceResource.error) {
+						const resourceError = submitInvoiceResource.error
+						console.error("Submit invoice resource error:", resourceError)
+
+						// Create a detailed error object
+						const detailedError = new Error(
+							resourceError.message || "Invoice submission failed",
+						)
+						detailedError.exc_type = resourceError.exc_type
+						detailedError._server_messages = resourceError._server_messages
+						detailedError.httpStatus = resourceError.httpStatus
+						detailedError.messages = resourceError.messages
+
+						throw detailedError
 					}
 
-					// Attach all resource error properties to the error
-					error.exc_type = resourceError.exc_type || error.exc_type
-					error._server_messages = resourceError._server_messages
-					error.httpStatus = resourceError.httpStatus
-					error.messages = resourceError.messages
-					error.exception = resourceError.exception
-					error.data = resourceError.data
+					resetInvoice()
+					return result
+				} catch (error) {
+					// Preserve original error object with all its properties
+					console.error("Submit invoice error:", error)
+					console.log("submitInvoiceResource.error:", submitInvoiceResource.error)
 
-					console.log("After attaching, error.messages:", error.messages)
+					// If resource has error data, extract and attach it
+					if (submitInvoiceResource.error) {
+						const resourceError = submitInvoiceResource.error
+						console.log("Resource error details:", {
+							exc_type: resourceError.exc_type,
+							_server_messages: resourceError._server_messages,
+							httpStatus: resourceError.httpStatus,
+							messages: resourceError.messages,
+							messagesContent: JSON.stringify(resourceError.messages),
+							data: resourceError.data,
+							exception: resourceError.exception,
+							keys: Object.keys(resourceError),
+						})
+
+						// The messages array likely contains the detailed error info
+						if (resourceError.messages && resourceError.messages.length > 0) {
+							console.log("First message:", resourceError.messages[0])
+						}
+
+						// Attach all resource error properties to the error
+						error.exc_type = resourceError.exc_type || error.exc_type
+						error._server_messages = resourceError._server_messages
+						error.httpStatus = resourceError.httpStatus
+						error.messages = resourceError.messages
+						error.exception = resourceError.exception
+						error.data = resourceError.data
+
+						console.log("After attaching, error.messages:", error.messages)
+					}
+
+					throw error
 				}
-
+			} catch (error) {
+				// Outer catch to ensure error propagates
+				console.error("Submit invoice outer error:", error)
 				throw error
+			} finally {
+				isSubmitting.value = false
 			}
-		} catch (error) {
-			// Outer catch to ensure error propagates
-			console.error("Submit invoice outer error:", error)
-			throw error
-		}
+		}) // End of submitMutex.withLock
 	}
 
 	/**
@@ -1004,6 +1029,7 @@ export function useInvoice() {
 		couponCode,
 		taxRules,
 		taxInclusive,
+		isSubmitting,
 
 		// Computed
 		subtotal,

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -449,6 +449,7 @@
 			:tax-amount="cartStore.totalTax"
 			:discount-amount="cartStore.totalDiscount"
 			:target-doctype="cartStore.targetDoctype"
+			:is-submitting="cartStore.isSubmitting"
 			@payment-completed="handlePaymentCompleted"
 			@update-additional-discount="handleAdditionalDiscountUpdate"
 		/>

--- a/POS/src/stores/posCart.js
+++ b/POS/src/stores/posCart.js
@@ -92,6 +92,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		salesTeam,
 		additionalDiscount,
 		taxInclusive,
+		isSubmitting,
 		addItem: addItemToInvoice,
 		removeItem,
 		updateItemQuantity,
@@ -1687,6 +1688,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		isEmpty,
 		hasCustomer,
 		isProcessingOffers, // True when any offer operation is in progress
+		isSubmitting, // True when invoice submission is in progress (mutex protected)
 
 		// Actions
 		addItem,


### PR DESCRIPTION
## Summary
- Adds mutex protection to invoice submission to prevent duplicate invoices from rapid clicks or concurrent submissions
- Disables payment buttons and shows loading state during submission
- Replaces console.warn with centralized logger utility

## Test plan
- [ ] Click "Pay on Account" button rapidly multiple times - should only create one invoice
- [ ] Click "Complete Payment" button rapidly - should only submit once
- [ ] Verify loading spinner appears on buttons during submission
- [ ] Verify buttons are disabled during submission
- [ ] Check console logs use the logger utility instead of console.warn