### PR TITLE
fix(items): convert get_stock_availability to Query Builder for Frappe 16

### DIFF
--- a/pos_next/api/items.py
+++ b/pos_next/api/items.py
@@ -40,13 +40,16 @@ def get_stock_availability(item_code, warehouse):
 		# Include all child warehouses when a group warehouse is set
 		warehouses = frappe.db.get_descendants("Warehouse", warehouse) or []
 
-	rows = frappe.get_all(
-		"Bin",
-		fields=["sum(actual_qty) as actual_qty"],
-		filters={"item_code": item_code, "warehouse": ["in", warehouses]},
+	Bin = DocType("Bin")
+	result = (
+		frappe.qb.from_(Bin)
+		.select(fn.Sum(Bin.actual_qty).as_("actual_qty"))
+		.where(Bin.item_code == item_code)
+		.where(Bin.warehouse.isin(warehouses))
+		.run(as_dict=True)
 	)
 
-	return flt(rows[0].actual_qty) if rows else 0.0
+	return flt(result[0].actual_qty) if result and result[0].actual_qty else 0.0
 
 
 def get_item_detail(item, doc=None, warehouse=None, price_list=None, company=None):


### PR DESCRIPTION
## Summary
- Frappe v16 disallows SQL aggregate functions as strings in `get_all()` fields parameter
- Convert `get_stock_availability()` to use Query Builder with `fn.Sum()`
- Resolves barcode scanning errors on Frappe v16

## Test plan
- [x] Simple barcode scanning with auto-add
- [x] Items with multiple UOMs (Kg/Gram barcodes)
- [x] Variant items
- [x] Full invoice creation flow

Closes #109