### PR TITLE
feat: allow user to edit item rate in POS cart

### DIFF
--- a/POS/src/components/sale/EditItemDialog.vue
+++ b/POS/src/components/sale/EditItemDialog.vue
@@ -133,10 +133,18 @@
 																type="number"
 																min="0"
 																step="0.01"
-																readonly
-																class="w-full h-7 border border-gray-300 rounded-lg ps-12 pe-3 text-sm font-semibold bg-gray-50 cursor-not-allowed"
+																:readonly="!canEditRate"
+																:class="canEditRate ? 'bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent' : 'bg-gray-50 cursor-not-allowed'"
+																class="w-full h-7 border border-gray-300 rounded-lg ps-12 pe-3 text-sm font-semibold"
+																:title="rateEditDisabledReason"
+																@input="calculateTotals"
 															/>
 														</div>
+														<!-- Compact warning when rate editing disabled due to pricing rules -->
+														<p v-if="hasPricingRules && settingsStore.allowUserToEditRate" class="mt-1 text-xs text-amber-600 flex items-center gap-1">
+															<FeatherIcon name="lock" class="w-3 h-3" />
+															{{ __('Locked (offer applied)') }}
+														</p>
 													</div>
 												</div>
 
@@ -318,6 +326,7 @@ const isCheckingStock = ref(false)
 const localSerials = ref([]) // List of serial numbers for this item
 const removedSerials = ref([]) // Track serials removed during this edit session
 const originalSerials = ref([]) // Original serials when dialog opened
+const originalPriceListRate = ref(0) // Original price_list_rate when dialog opened (for rate edit validation)
 
 const show = computed({
 	get: () => props.modelValue,
@@ -332,6 +341,30 @@ const availableUoms = computed(() => {
 })
 
 const currencySymbol = computed(() => getCurrencySymbol(props.currency))
+
+// Check if item has pricing rules applied (promotional offers)
+const hasPricingRules = computed(() => {
+	if (!localItem.value) return false
+	return Boolean(localItem.value.pricing_rules) && localItem.value.pricing_rules.length > 0
+})
+
+// Rate editing is allowed only if:
+// 1. POS Settings allows rate editing AND
+// 2. Item does NOT have pricing rules (promotional offers) applied
+const canEditRate = computed(() => {
+	return settingsStore.allowUserToEditRate && !hasPricingRules.value
+})
+
+// Tooltip message for why rate editing is disabled
+const rateEditDisabledReason = computed(() => {
+	if (!settingsStore.allowUserToEditRate) {
+		return __('Rate editing is disabled')
+	}
+	if (hasPricingRules.value) {
+		return __('Locked (offer applied)')
+	}
+	return ''
+})
 
 // Options for SelectInput components
 const uomOptions = computed(() => {
@@ -369,6 +402,8 @@ watch(
 			localQuantity.value = newItem.quantity || 1
 			localUom.value = newItem.uom || newItem.stock_uom || __("Nos")
 			localRate.value = newItem.rate || 0
+			// Store original price_list_rate for rate edit validation
+			originalPriceListRate.value = newItem.price_list_rate || newItem.rate || 0
 			localWarehouse.value =
 				newItem.warehouse || props.warehouses[0]?.name || ""
 
@@ -578,16 +613,52 @@ function formatCurrency(amount) {
 }
 
 function updateItem() {
+	// Check if rate was manually edited
+	const isRateManuallyEdited = localRate.value !== originalPriceListRate.value
+
+	// ========================================================================
+	// RATE EDIT VALIDATION
+	// ========================================================================
+	if (settingsStore.allowUserToEditRate && isRateManuallyEdited) {
+		// Validate rate is positive
+		if (localRate.value <= 0) {
+			showError(__('Rate must be greater than zero'))
+			return
+		}
+
+		// Validate against max discount if rate was reduced
+		const maxDiscount = settingsStore.maxDiscountAllowed
+		if (maxDiscount > 0 && localRate.value < originalPriceListRate.value) {
+			const discountPercent = ((originalPriceListRate.value - localRate.value) / originalPriceListRate.value) * 100
+			const roundedDiscount = Math.round(discountPercent * 100) / 100
+
+			if (roundedDiscount > maxDiscount) {
+				showError(
+					__('Rate reduction of {0}% exceeds maximum allowed discount of {1}%', [
+						roundedDiscount.toFixed(2),
+						maxDiscount
+					])
+				)
+				return
+			}
+		}
+	}
+
 	const updatedItem = {
 		...localItem.value,
 		quantity: localQuantity.value,
 		uom: localUom.value,
 		rate: localRate.value,
+		// Preserve price_list_rate for reference (original price before any manual edits)
+		price_list_rate: originalPriceListRate.value,
 		warehouse: localWarehouse.value,
 		discount_percentage:
 			discountType.value === "percentage" ? discountValue.value : 0,
 		discount_amount:
 			discountType.value === "amount" ? discountValue.value : 0,
+		// Track manual rate edits for audit logging
+		is_rate_manually_edited: isRateManuallyEdited ? 1 : 0,
+		original_rate: isRateManuallyEdited ? originalPriceListRate.value : null,
 	}
 
 	// Update serial numbers if item has serials

--- a/POS/src/components/settings/POSSettings.vue
+++ b/POS/src/components/settings/POSSettings.vue
@@ -317,6 +317,11 @@
 												:description="__('Enable item-level discount in edit dialog')"
 											/>
 											<CheckboxField
+												v-model="settings.allow_user_to_edit_rate"
+												:label="__('Allow User To Edit Rate')"
+												:description="__('Allow editing item rate in cart. Disabled when offers are applied.')"
+											/>
+											<CheckboxField
 												v-model="settings.disable_rounded_total"
 												:label="__('Disable Rounded Total')"
 												:description="__('Show exact totals without rounding')"
@@ -426,6 +431,7 @@ const settings = ref({
 	use_percentage_discount: 0,
 	allow_user_to_edit_additional_discount: 0,
 	allow_user_to_edit_item_discount: 1,
+	allow_user_to_edit_rate: 0,
 	disable_rounded_total: 1,
 	allow_credit_sale: 0,
 	allow_return: 0,

--- a/POS/src/composables/useInvoice.js
+++ b/POS/src/composables/useInvoice.js
@@ -643,7 +643,11 @@ export function useInvoice() {
 
 		// Update item fields with rounded values
 		item.tax_amount = taxAmount
-		item.rate = priceListRate // Preserve original price for display
+		// For manually edited rates, preserve the edited rate; otherwise use price_list_rate
+		if (!isManuallyEdited) {
+			item.rate = effectiveRate // Preserve original price for display
+		}
+		// If manually edited, item.rate is already set to the edited value
 		item.amount = netAmount // Net amount for backend calculations
 	}
 

--- a/POS/src/composables/useInvoice.js
+++ b/POS/src/composables/useInvoice.js
@@ -277,10 +277,11 @@ export function useInvoice() {
 
 		if (itemToRemove) {
 			// Update cache incrementally (subtract removed item values)
-			// Use rounded price_list_rate for subtotal to match ERPNext
-			const priceListRate = itemToRemove.price_list_rate || itemToRemove.rate
+			// Use effective rate (manually edited rate or price_list_rate)
+			const isManuallyEdited = itemToRemove.is_rate_manually_edited === 1
+			const effectiveRate = isManuallyEdited ? itemToRemove.rate : (itemToRemove.price_list_rate || itemToRemove.rate)
 			_cachedSubtotal.value -= roundCurrency(
-				itemToRemove.quantity * roundCurrency(priceListRate),
+				itemToRemove.quantity * roundCurrency(effectiveRate),
 			)
 			_cachedTotalTax.value -= itemToRemove.tax_amount || 0
 			_cachedTotalDiscount.value -= itemToRemove.discount_amount || 0
@@ -322,11 +323,11 @@ export function useInvoice() {
 
 		if (item) {
 			// Store old values before update for incremental cache adjustment
-			// Use price_list_rate for subtotal calculations (before discount)
-			// IMPORTANT: Calculate oldAmount using same rounding as cache to ensure consistency
-			const oldPriceListRate = item.price_list_rate || item.rate
+			// Use effective rate (manually edited rate or price_list_rate)
+			const isManuallyEdited = item.is_rate_manually_edited === 1
+			const effectiveRate = isManuallyEdited ? item.rate : (item.price_list_rate || item.rate)
 			const oldAmount = roundCurrency(
-				item.quantity * roundCurrency(oldPriceListRate),
+				item.quantity * roundCurrency(effectiveRate),
 			)
 			const oldTax = item.tax_amount || 0
 			const oldDiscount = item.discount_amount || 0
@@ -356,36 +357,49 @@ export function useInvoice() {
 			recalculateItem(item)
 
 			// Update cache incrementally (new values - old values)
-			// Use rounded price_list_rate for subtotal to match ERPNext
-			const priceListRate = item.price_list_rate || item.rate
+			// Use effective rate for manually edited items
 			_cachedSubtotal.value +=
-				roundCurrency(item.quantity * roundCurrency(priceListRate)) - oldAmount
+				roundCurrency(item.quantity * roundCurrency(effectiveRate)) - oldAmount
 			_cachedTotalTax.value += (item.tax_amount || 0) - oldTax
 			_cachedTotalDiscount.value += (item.discount_amount || 0) - oldDiscount
 		}
 	}
 
-	function updateItemRate(itemCode, rate) {
+	function updateItemRate(itemCode, rate, isManualEdit = false) {
 		const item = invoiceItems.value.find((i) => i.item_code === itemCode)
 		if (item) {
 			// Store old values before update for incremental cache adjustment
-			// Use price_list_rate for subtotal calculations (before discount)
-			// IMPORTANT: Calculate oldAmount using same rounding as cache to ensure consistency
-			const oldPriceListRate = item.price_list_rate || item.rate
+			// Use effective rate (manually edited rate or price_list_rate)
+			const wasManuallyEdited = item.is_rate_manually_edited === 1
+			const oldEffectiveRate = wasManuallyEdited ? item.rate : (item.price_list_rate || item.rate)
 			const oldAmount = roundCurrency(
-				item.quantity * roundCurrency(oldPriceListRate),
+				item.quantity * roundCurrency(oldEffectiveRate),
 			)
 			const oldTax = item.tax_amount || 0
 			const oldDiscount = item.discount_amount || 0
 
-			item.rate = Number.parseFloat(rate) || 0
+			const newRate = Number.parseFloat(rate) || 0
+
+			// Update rate but PRESERVE price_list_rate (original catalog price)
+			// This maintains auditability - we can always see the original price
+			item.rate = newRate
+			// price_list_rate is NOT updated - it remains the original catalog price
+
+			// Track manual rate edits for audit purposes
+			const originalPriceListRate = item.price_list_rate || oldEffectiveRate
+			if (isManualEdit && newRate !== originalPriceListRate) {
+				item.is_rate_manually_edited = 1
+				item.original_rate = originalPriceListRate
+			}
+
 			recalculateItem(item)
 
 			// Update cache incrementally (new values - old values)
-			// Use rounded price_list_rate for subtotal to match ERPNext
-			const priceListRate = item.price_list_rate || item.rate
+			// Use the new rate for manually edited items
+			const isNowManuallyEdited = item.is_rate_manually_edited === 1
+			const newEffectiveRate = isNowManuallyEdited ? item.rate : (item.price_list_rate || item.rate)
 			_cachedSubtotal.value +=
-				roundCurrency(item.quantity * roundCurrency(priceListRate)) - oldAmount
+				roundCurrency(item.quantity * roundCurrency(newEffectiveRate)) - oldAmount
 			_cachedTotalTax.value += (item.tax_amount || 0) - oldTax
 			_cachedTotalDiscount.value += (item.discount_amount || 0) - oldDiscount
 		}
@@ -400,11 +414,11 @@ export function useInvoice() {
 			if (validDiscount > 100) validDiscount = 100
 
 			// Store old values before update for incremental cache adjustment
-			// Use price_list_rate for subtotal calculations (before discount)
-			// IMPORTANT: Calculate oldAmount using same rounding as cache to ensure consistency
-			const oldPriceListRate = item.price_list_rate || item.rate
+			// Use effective rate (manually edited rate or price_list_rate)
+			const isManuallyEdited = item.is_rate_manually_edited === 1
+			const effectiveRate = isManuallyEdited ? item.rate : (item.price_list_rate || item.rate)
 			const oldAmount = roundCurrency(
-				item.quantity * roundCurrency(oldPriceListRate),
+				item.quantity * roundCurrency(effectiveRate),
 			)
 			const oldTax = item.tax_amount || 0
 			const oldDiscount = item.discount_amount || 0
@@ -414,10 +428,9 @@ export function useInvoice() {
 			recalculateItem(item)
 
 			// Update cache incrementally (new values - old values)
-			// Use rounded price_list_rate for subtotal to match ERPNext
-			const priceListRate = item.price_list_rate || item.rate
+			// Use effective rate for manually edited items
 			_cachedSubtotal.value +=
-				roundCurrency(item.quantity * roundCurrency(priceListRate)) - oldAmount
+				roundCurrency(item.quantity * roundCurrency(effectiveRate)) - oldAmount
 			_cachedTotalTax.value += (item.tax_amount || 0) - oldTax
 			_cachedTotalDiscount.value += (item.discount_amount || 0) - oldDiscount
 		}
@@ -548,10 +561,11 @@ export function useInvoice() {
 		_cachedTotalDiscount.value = 0
 
 		for (const item of invoiceItems.value) {
-			// Use rounded price_list_rate for subtotal to match ERPNext
-			const priceListRate = item.price_list_rate || item.rate
+			// Use manually edited rate if set, otherwise use price_list_rate
+			const isManuallyEdited = item.is_rate_manually_edited === 1
+			const effectiveRate = isManuallyEdited ? item.rate : (item.price_list_rate || item.rate)
 			_cachedSubtotal.value += roundCurrency(
-				item.quantity * roundCurrency(priceListRate),
+				item.quantity * roundCurrency(effectiveRate),
 			)
 			_cachedTotalTax.value += item.tax_amount || 0
 			_cachedTotalDiscount.value += item.discount_amount || 0
@@ -589,10 +603,11 @@ export function useInvoice() {
 	 * @param {Object} item - Invoice item object with quantity, rates, and discount fields
 	 */
 	function recalculateItem(item) {
-		// Determine the base unit price (original list price)
-		// IMPORTANT: Round rate to currency precision FIRST to match ERPNext behavior
-		const priceListRate = item.price_list_rate || item.rate
-		const roundedRate = roundCurrency(priceListRate)
+		// Determine the base unit price
+		// If rate was manually edited, use the edited rate; otherwise use price_list_rate
+		const isManuallyEdited = item.is_rate_manually_edited === 1
+		const effectiveRate = isManuallyEdited ? item.rate : (item.price_list_rate || item.rate)
+		const roundedRate = roundCurrency(effectiveRate)
 		const baseAmount = roundCurrency(item.quantity * roundedRate)
 
 		// Calculate discount from either percentage or fixed amount
@@ -682,6 +697,9 @@ export function useInvoice() {
 			discount_percentage: roundCurrency(item.discount_percentage || 0),
 			discount_amount: roundCurrency(item.discount_amount || 0),
 			pricing_rules: stringifyPricingRules(item.pricing_rules),
+			// Manual rate edit tracking for audit logging
+			is_rate_manually_edited: item.is_rate_manually_edited || 0,
+			original_rate: item.original_rate || null,
 		}))
 	}
 

--- a/POS/src/stores/posCart.js
+++ b/POS/src/stores/posCart.js
@@ -1348,8 +1348,12 @@ export const usePOSCartStore = defineStore("posCart", () => {
 			if (updates.warehouse !== undefined) cartItem.warehouse = updates.warehouse
 			if (updates.discount_percentage !== undefined) cartItem.discount_percentage = updates.discount_percentage
 			if (updates.discount_amount !== undefined) cartItem.discount_amount = updates.discount_amount
+			if (updates.rate !== undefined) cartItem.rate = updates.rate
 			if (updates.price_list_rate !== undefined) cartItem.price_list_rate = updates.price_list_rate
 			if (updates.serial_no !== undefined) cartItem.serial_no = updates.serial_no
+			// Track manual rate edits for audit purposes
+			if (updates.is_rate_manually_edited !== undefined) cartItem.is_rate_manually_edited = updates.is_rate_manually_edited
+			if (updates.original_rate !== undefined) cartItem.original_rate = updates.original_rate
 
 			recalculateItem(cartItem)
 			rebuildIncrementalCache()

--- a/POS/src/stores/posEvents.js
+++ b/POS/src/stores/posEvents.js
@@ -243,6 +243,7 @@ export const usePOSEventsStore = defineStore('posEvents', () => {
 			'use_percentage_discount',
 			'allow_user_to_edit_additional_discount',
 			'allow_user_to_edit_item_discount',
+			'allow_user_to_edit_rate',
 			'disable_rounded_total',
 			'tax_inclusive'
 		]

--- a/POS/src/stores/posSettings.js
+++ b/POS/src/stores/posSettings.js
@@ -372,7 +372,8 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 		isLoading.value = true
 
 		try {
-			await settingsResource.reload()
+			// Use submit with pos_profile to ensure proper reload
+			await settingsResource.submit({ pos_profile: settings.value.pos_profile })
 			return true
 		} catch {
 			return false

--- a/POS/src/stores/posSettings.js
+++ b/POS/src/stores/posSettings.js
@@ -19,6 +19,7 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 		use_percentage_discount: 0,
 		allow_user_to_edit_additional_discount: 0,
 		allow_user_to_edit_item_discount: 1, // Allow item-level discounts
+		allow_user_to_edit_rate: 0, // Allow rate editing in edit dialog
 		disable_rounded_total: 1, // Disable rounding for accurate totals
 		allow_credit_sale: 0,
 		allow_customer_credit_payment: 0,
@@ -98,6 +99,9 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 	)
 	const allowItemDiscount = computed(() =>
 		Boolean(settings.value.allow_user_to_edit_item_discount),
+	)
+	const allowUserToEditRate = computed(() =>
+		Boolean(settings.value.allow_user_to_edit_rate),
 	)
 	const disableRoundedTotal = computed(() =>
 		Boolean(settings.value.disable_rounded_total),
@@ -286,6 +290,7 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 			use_percentage_discount: 0,
 			allow_user_to_edit_additional_discount: 0,
 			allow_user_to_edit_item_discount: 1,
+			allow_user_to_edit_rate: 0,
 			disable_rounded_total: 1,
 			allow_credit_sale: 0,
 			allow_customer_credit_payment: 0,
@@ -393,6 +398,7 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 		usePercentageDiscount,
 		allowAdditionalDiscount,
 		allowItemDiscount,
+		allowUserToEditRate,
 		disableRoundedTotal,
 		allowCreditSale,
 		allowCustomerCreditPayment,

--- a/pos_next/api/constants.py
+++ b/pos_next/api/constants.py
@@ -21,6 +21,7 @@ POS_SETTINGS_FIELDS = [
 	"tax_inclusive",
 	"allow_user_to_edit_additional_discount",
 	"allow_user_to_edit_item_discount",
+	"allow_user_to_edit_rate",
 	"use_percentage_discount",
 	"max_discount_allowed",
 	"allow_credit_sale",
@@ -44,6 +45,7 @@ DEFAULT_POS_SETTINGS = {
 	"tax_inclusive": 0,
 	"allow_user_to_edit_additional_discount": 0,
 	"allow_user_to_edit_item_discount": 1,
+	"allow_user_to_edit_rate": 0,
 	"use_percentage_discount": 0,
 	"max_discount_allowed": 0,
 	"disable_rounded_total": 0,  # Derived from POS Profile

--- a/pos_next/api/invoices.py
+++ b/pos_next/api/invoices.py
@@ -10,6 +10,28 @@ from frappe.utils import flt, cint, nowdate, nowtime, get_datetime, cstr
 from erpnext.stock.doctype.batch.batch import get_batch_qty, get_batch_no
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import get_bank_cash_account
 
+
+# ==========================================
+# Constants for field names (avoid typos and enable refactoring)
+# ==========================================
+FIELD_IS_RATE_MANUALLY_EDITED = "is_rate_manually_edited"
+FIELD_ORIGINAL_RATE = "original_rate"
+FIELD_PRICE_LIST_RATE = "price_list_rate"
+FIELD_RATE = "rate"
+FIELD_ITEM_CODE = "item_code"
+FIELD_DISCOUNT_PERCENTAGE = "discount_percentage"
+FIELD_ALLOW_USER_TO_EDIT_RATE = "allow_user_to_edit_rate"
+FIELD_MAX_DISCOUNT_ALLOWED = "max_discount_allowed"
+FIELD_DISABLE_ROUNDED_TOTAL = "disable_rounded_total"
+FIELD_ALLOW_NEGATIVE_STOCK = "allow_negative_stock"
+
+# Doctypes
+DOCTYPE_SALES_INVOICE = "Sales Invoice"
+DOCTYPE_POS_SETTINGS = "POS Settings"
+DOCTYPE_POS_PROFILE = "POS Profile"
+DOCTYPE_COMMENT = "Comment"
+
+
 try:
     from erpnext.accounts.doctype.pricing_rule.pricing_rule import (
         apply_pricing_rule as erpnext_apply_pricing_rule,
@@ -25,6 +47,176 @@ except Exception:  # pragma: no cover - ERPNext not installed in some environmen
 # ==========================================
 # Helper Functions
 # ==========================================
+
+
+def calculate_price_list_rate(item_rate, discount_pct, current_price_list_rate):
+    """
+    Calculate price_list_rate from discounted rate and discount percentage.
+
+    Formula: rate = price_list_rate * (1 - discount_percentage/100)
+    Reverse: price_list_rate = rate / (1 - discount_percentage/100)
+
+    Args:
+        item_rate: The current item rate (after discount)
+        discount_pct: The discount percentage (0-100)
+        current_price_list_rate: The existing price_list_rate if any
+
+    Returns:
+        float: The calculated price_list_rate
+    """
+    # Early exit: no discount applied
+    if discount_pct <= 0 or discount_pct >= 100:
+        return current_price_list_rate if current_price_list_rate else item_rate
+
+    # Reverse-calculate price_list_rate from discounted rate
+    if item_rate > 0:
+        discount_multiplier = 1 - discount_pct / 100
+        return item_rate / discount_multiplier
+
+    return current_price_list_rate if current_price_list_rate else item_rate
+
+
+def validate_manual_rate_edit(item, pos_profile=None, pos_settings_cache=None):
+    """
+    Validate manually edited item rates against POS Settings business rules.
+
+    This function enforces:
+    1. Rate must be positive
+    2. Rate editing must be enabled in POS Settings
+    3. Rate reduction must not exceed max_discount_allowed (if configured)
+
+    Args:
+        item: The item dict/object with rate information. Must contain:
+            - is_rate_manually_edited: Flag indicating manual edit (1 or 0)
+            - item_code: The item code for error messages
+            - rate: The edited rate
+            - original_rate or price_list_rate: The original catalog price
+        pos_profile: POS Profile name for settings lookup. Required for manual edits.
+        pos_settings_cache: Optional pre-fetched POS Settings dict to avoid repeated DB queries.
+            Should contain: allow_user_to_edit_rate, max_discount_allowed
+
+    Returns:
+        dict with 'valid' boolean and 'message' string if invalid
+    """
+    is_manual_edit = cint(item.get(FIELD_IS_RATE_MANUALLY_EDITED) or 0)
+
+    # Skip validation if not a manual edit
+    if not is_manual_edit:
+        return {"valid": True}
+
+    item_code = item.get(FIELD_ITEM_CODE)
+    item_rate = flt(item.get(FIELD_RATE) or 0)
+    original_rate = flt(item.get(FIELD_ORIGINAL_RATE) or item.get(FIELD_PRICE_LIST_RATE) or 0)
+
+    # Validate rate is positive
+    if item_rate <= 0:
+        return {
+            "valid": False,
+            "message": _("Rate for item {0} must be greater than zero").format(item_code)
+        }
+
+    # POS Profile is required for manual rate edit validation
+    if not pos_profile:
+        return {
+            "valid": False,
+            "message": _("POS Profile is required to validate rate edit for item {0}").format(item_code)
+        }
+
+    # Use cached POS Settings if provided, otherwise fetch from DB
+    pos_settings = pos_settings_cache
+    if pos_settings is None:
+        pos_settings = frappe.db.get_value(
+            DOCTYPE_POS_SETTINGS,
+            {"pos_profile": pos_profile},
+            [FIELD_ALLOW_USER_TO_EDIT_RATE, FIELD_MAX_DISCOUNT_ALLOWED],
+            as_dict=True
+        )
+
+    # Check if POS Settings exists
+    if not pos_settings:
+        return {
+            "valid": False,
+            "message": _("POS Settings not found for profile {0}. Cannot validate rate edit.").format(pos_profile)
+        }
+
+    # Check if rate editing is allowed
+    if not cint(pos_settings.get(FIELD_ALLOW_USER_TO_EDIT_RATE)):
+        return {
+            "valid": False,
+            "message": _("Rate editing is not allowed for this POS Profile")
+        }
+
+    # Validate against max discount if configured and rate is reduced
+    max_discount = flt(pos_settings.get(FIELD_MAX_DISCOUNT_ALLOWED) or 0)
+    if max_discount > 0 and original_rate > 0 and item_rate < original_rate:
+        # Calculate effective discount percentage
+        discount_pct = round(((original_rate - item_rate) / original_rate) * 100, 2)
+        if discount_pct > max_discount:
+            return {
+                "valid": False,
+                "message": _("Rate reduction for item {0} is {1}% which exceeds the maximum allowed discount of {2}%").format(
+                    item_code, discount_pct, max_discount
+                )
+            }
+
+    return {"valid": True}
+
+
+def log_manual_rate_edit(item, invoice_name, user=None):
+    """
+    Create an audit log entry for manual rate edits.
+
+    This function creates a Comment on the Sales Invoice documenting the rate change.
+    It should only be called ONCE per item, after the invoice is successfully submitted.
+
+    Args:
+        item: The item dict/object with rate information. Must contain:
+            - is_rate_manually_edited: Flag indicating manual edit (1 or 0)
+            - item_code: The item code
+            - rate: The new/edited rate
+            - original_rate: The original price before edit (or price_list_rate as fallback)
+        invoice_name: The Sales Invoice document name
+        user: Optional user who made the edit (defaults to session user)
+
+    Returns:
+        None
+    """
+    # Only log if rate was manually edited
+    if not cint(item.get(FIELD_IS_RATE_MANUALLY_EDITED)):
+        return
+
+    user = user or frappe.session.user
+    item_code = item.get(FIELD_ITEM_CODE)
+    original_rate = flt(item.get(FIELD_ORIGINAL_RATE) or item.get(FIELD_PRICE_LIST_RATE) or 0)
+    new_rate = flt(item.get(FIELD_RATE) or 0)
+
+    # Skip logging if rates are the same (no actual change)
+    if original_rate == new_rate:
+        return
+
+    # Calculate discount/markup percentage for logging
+    change_pct = 0
+    change_type = "reduction"
+    if original_rate > 0:
+        change_pct = round(abs((original_rate - new_rate) / original_rate) * 100, 2)
+        if new_rate > original_rate:
+            change_type = "increase"
+
+    # Create audit comment on the invoice
+    frappe.get_doc({
+        "doctype": DOCTYPE_COMMENT,
+        "comment_type": "Comment",
+        "reference_doctype": DOCTYPE_SALES_INVOICE,
+        "reference_name": invoice_name,
+        "content": _("Manual rate edit by {user}: Item {item_code} rate changed from {original} to {new} ({change_pct}% {change_type})").format(
+            user=user,
+            item_code=item_code,
+            original=frappe.format_value(original_rate, {"fieldtype": "Currency"}),
+            new=frappe.format_value(new_rate, {"fieldtype": "Currency"}),
+            change_pct=change_pct,
+            change_type=change_type
+        )
+    }).insert(ignore_permissions=True)
 
 
 def standardize_pricing_rules(items):
@@ -513,6 +705,24 @@ def update_invoice(data):
         invoice_doc.flags.ignore_pricing_rule = True
 
         # ========================================================================
+        # OPTIMIZATION: Cache POS Settings to avoid repeated DB queries
+        # Fetch all needed settings in a single query at the start
+        # ========================================================================
+        pos_settings_cache = None
+        if pos_profile:
+            pos_settings_cache = frappe.db.get_value(
+                DOCTYPE_POS_SETTINGS,
+                {"pos_profile": pos_profile},
+                [
+                    FIELD_ALLOW_USER_TO_EDIT_RATE,
+                    FIELD_MAX_DISCOUNT_ALLOWED,
+                    FIELD_DISABLE_ROUNDED_TOTAL,
+                    FIELD_ALLOW_NEGATIVE_STOCK
+                ],
+                as_dict=True
+            )
+
+        # ========================================================================
         # DISCOUNT CALCULATION - CRITICAL LOGIC
         # ========================================================================
         # Frontend sends: rate (discounted), price_list_rate (original), discount_percentage
@@ -526,20 +736,34 @@ def update_invoice(data):
             item_rate = flt(item.rate or 0)
             discount_pct = flt(item.discount_percentage or 0)
             frontend_price_list_rate = flt(item.get("price_list_rate") or 0)
+            is_manual_edit = cint(item.get(FIELD_IS_RATE_MANUALLY_EDITED) or 0)
 
-            # Trust frontend's price_list_rate if provided and valid
-            if frontend_price_list_rate > 0:
-                item.price_list_rate = frontend_price_list_rate
-            # Fallback: reverse-calculate if discount exists but no price_list_rate
-            elif discount_pct > 0 and discount_pct < 100 and item_rate > 0:
-                item.price_list_rate = flt(item_rate / (1 - discount_pct / 100), 2)
+            if is_manual_edit:
+                # MANUAL RATE EDIT: preserve original price_list_rate for audit
+                original_rate = flt(item.get(FIELD_ORIGINAL_RATE) or item.get(FIELD_PRICE_LIST_RATE) or 0)
+                if original_rate > 0:
+                    item.price_list_rate = original_rate
+
+                # Validate manual rate edit against business rules (uses cached settings)
+                validation = validate_manual_rate_edit(item, pos_profile, pos_settings_cache)
+                if not validation.get("valid"):
+                    frappe.throw(validation.get("message"))
             else:
-                # No discount or price_list_rate - use rate as is
-                item.price_list_rate = item_rate
+                # NORMAL FLOW: Trust frontend's price_list_rate if provided and valid
+                if frontend_price_list_rate > 0:
+                    item.price_list_rate = frontend_price_list_rate
+                # Fallback: reverse-calculate if discount exists but no price_list_rate
+                elif discount_pct > 0 and discount_pct < 100 and item_rate > 0:
+                    item.price_list_rate = calculate_price_list_rate(
+                        item_rate, discount_pct, frontend_price_list_rate
+                    )
+                else:
+                    # No discount or price_list_rate - use rate as is
+                    item.price_list_rate = item_rate
 
-            # Ensure price_list_rate is never less than rate (data integrity)
-            if flt(item.price_list_rate) < item_rate:
-                item.price_list_rate = item_rate
+                # Ensure price_list_rate is never less than rate (data integrity)
+                if flt(item.price_list_rate) < item_rate:
+                    item.price_list_rate = item_rate
 
             # IMPORTANT: Keep the rate from frontend (do NOT set to 0)
             # ERPNext will recalculate if needed, but preserving frontend rate
@@ -569,24 +793,14 @@ def update_invoice(data):
         # ========================================================================
         # ROUNDING CONFIGURATION
         # ========================================================================
-        # Load rounding preference from POS Settings
+        # Load rounding preference from POS Settings (use cached value)
         # When disabled (0): ERPNext rounds to nearest whole number
         # When enabled (1): Shows exact amount without rounding
         # ========================================================================
         disable_rounded = 1  # Default: disable rounding for POS (show exact amounts)
 
-        if pos_profile:
-            try:
-                pos_settings_value = frappe.db.get_value(
-                    "POS Settings",
-                    {"pos_profile": pos_profile},
-                    "disable_rounded_total"
-                )
-                if pos_settings_value is not None:
-                    disable_rounded = cint(pos_settings_value)
-            except Exception as e:
-                # Log error but continue with default
-                frappe.log_error(f"Error loading rounding setting: {str(e)}", "POS Invoice Creation")
+        if pos_settings_cache and pos_settings_cache.get(FIELD_DISABLE_ROUNDED_TOTAL) is not None:
+            disable_rounded = cint(pos_settings_cache.get(FIELD_DISABLE_ROUNDED_TOTAL))
 
         invoice_doc.disable_rounded_total = disable_rounded
 
@@ -1118,6 +1332,19 @@ def submit_invoice(invoice=None, data=None):
                     alert=True,
                     indicator="orange"
                 )
+
+        # Log manual rate edits for audit trail (only after successful submission)
+        if doctype == DOCTYPE_SALES_INVOICE:
+            incoming_items = invoice.get("items") or []
+            for item in incoming_items:
+                if cint(item.get(FIELD_IS_RATE_MANUALLY_EDITED)):
+                    log_manual_rate_edit({
+                        FIELD_ITEM_CODE: item.get(FIELD_ITEM_CODE),
+                        "item_name": item.get("item_name"),
+                        FIELD_RATE: flt(item.get(FIELD_RATE)),
+                        FIELD_ORIGINAL_RATE: flt(item.get(FIELD_ORIGINAL_RATE) or item.get(FIELD_PRICE_LIST_RATE)),
+                        FIELD_IS_RATE_MANUALLY_EDITED: 1
+                    }, invoice_doc.name)
 
         # Return complete invoice details
         result = {

--- a/pos_next/pos_next/doctype/pos_settings/pos_settings.json
+++ b/pos_next/pos_next/doctype/pos_settings/pos_settings.json
@@ -18,6 +18,7 @@
   "section_break_general",
   "allow_user_to_edit_additional_discount",
   "allow_user_to_edit_item_discount",
+  "allow_user_to_edit_rate",
   "use_percentage_discount",
   "max_discount_allowed",
   "column_break_general",
@@ -169,6 +170,13 @@
    "fieldname": "allow_user_to_edit_item_discount",
    "fieldtype": "Check",
    "label": "Allow Item Discount"
+  },
+  {
+   "default": "0",
+   "description": "Allow user to edit item rate in cart. Rate editing is automatically disabled when promotional offers are applied to an item.",
+   "fieldname": "allow_user_to_edit_rate",
+   "fieldtype": "Check",
+   "label": "Allow User To Edit Rate"
   },
   {
    "default": "0",


### PR DESCRIPTION
## Summary
- Adds a new **Allow User To Edit Rate** setting in POS Settings that lets cashiers manually edit item rates directly in the Edit Item dialog
- Automatically **locks rate editing when promotional offers** (pricing rules) are applied to an item, preventing accidental override of promotional prices
- Enforces **max discount validation** on the frontend and backend — rate reductions that exceed the configured `max_discount_allowed` are blocked
- Adds **backend validation** (`validate_manual_rate_edit`) and **audit logging** (`log_manual_rate_edit`) — every manual rate change is recorded as a Comment on the Sales Invoice after submission
- Tracks `is_rate_manually_edited` and `original_rate` throughout the invoice lifecycle (cart, recalculation, submission) so calculations use the correct effective rate
- Caches POS Settings in `update_invoice()` to avoid repeated DB queries

## Changes
- **POS Settings doctype**: New `allow_user_to_edit_rate` Check field
- **Backend** (`constants.py`, `invoices.py`): Validation, audit logging, settings caching, price_list_rate handling for manual edits
- **Frontend** (`EditItemDialog.vue`): Conditionally editable rate input with tooltip and lock indicator for offer-applied items
- **Stores** (`posSettings.js`, `posCart.js`, `posEvents.js`): New setting, rate tracking fields, change detection
- **Composable** (`useInvoice.js`): Effective rate logic across all cache calculations (add, remove, update quantity, update discount, rebuild cache, recalculate, format for submission)

## Test plan
- [ ] Enable "Allow User To Edit Rate" in POS Settings
- [ ] Edit an item's rate in the Edit Item dialog — verify the new rate is reflected in totals
- [ ] Reduce rate beyond max discount allowed — verify validation error appears
- [ ] Add an item with a pricing rule (offer) — verify rate input is locked with amber "Locked (offer applied)" indicator
- [ ] Submit an invoice with a manually edited rate — verify audit Comment is created on the Sales Invoice
- [ ] Disable the setting — verify rate input is readonly again
- [ ] Test with no pricing rules and no manual edits — verify existing behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)