### PR TITLE
fixing issue with wallet balance in return invoices with this solution:

### DIFF
--- a/pos_next/api/invoices.py
+++ b/pos_next/api/invoices.py
@@ -1317,7 +1317,23 @@ def submit_invoice(invoice=None, data=None):
         # Submit invoice
         invoice_doc.submit()
         invoice_submitted = True
-
+        # Handle wallet transaction reversal for returns
+        if invoice_doc.get("is_return") and invoice_doc.get("return_against"):
+            try:
+                from pos_next.pos_next.doctype.wallet_transaction.wallet_transaction import reverse_wallet_transactions_for_return
+                reverse_wallet_transactions_for_return(
+                    original_invoice=invoice_doc.return_against,
+                    return_invoice=invoice_doc.name
+                )
+            except Exception as wallet_error:
+                frappe.log_error(
+                    title="Wallet Reversal on Return Error",
+                    message=f"Return Invoice: {invoice_doc.name}, Error: {str(wallet_error)}\n{frappe.get_traceback()}"
+                )
+                frappe.msgprint(
+                    _("Return submitted but wallet reversal failed. Please check manually."),
+                    alert=True, indicator="orange"
+                )
         # Complete the offline sync record
         if sync_record_name:
             _complete_offline_sync(sync_record_name, invoice_doc.name)

--- a/pos_next/pos_next/doctype/wallet_transaction/wallet_transaction.py
+++ b/pos_next/pos_next/doctype/wallet_transaction/wallet_transaction.py
@@ -52,6 +52,10 @@ class WalletTransaction(AccountsController):
 
 	def on_cancel(self):
 		"""Reverse GL entries on cancel"""
+		self.ignore_linked_doctypes = (
+        "GL Entry",
+		"Payment Ledger Entry"
+    	)
 		self.make_gl_entries(cancel=True)
 		self.update_wallet_balance()
 
@@ -287,3 +291,107 @@ def credit_loyalty_points_to_wallet(customer, company, loyalty_points, conversio
 	)
 
 	return transaction
+
+@frappe.whitelist()
+def reverse_wallet_transactions_for_return(original_invoice, return_invoice):
+    """
+    Reverse wallet transactions linked to the original invoice when a return is made.
+    
+    For full returns: Cancel the linked Wallet Transaction(s)
+    For partial returns: Create a proportional Debit transaction to reverse the credit
+    
+    Args:
+        original_invoice: Original Sales Invoice name
+        return_invoice: Return Sales Invoice name (is_return=1)
+    """
+    # Get the return invoice to calculate return ratio
+    return_doc = frappe.get_doc("Sales Invoice", return_invoice)
+    original_doc = frappe.get_doc("Sales Invoice", original_invoice)
+    
+    if not return_doc.is_return or return_doc.return_against != original_invoice:
+        return
+    
+    # Find all submitted Wallet Transactions linked to the original invoice
+    wallet_transactions = frappe.get_all(
+        "Wallet Transaction",
+        filters={
+            "reference_doctype": "Sales Invoice",
+            "reference_name": original_invoice,
+            "docstatus": 1,
+            "transaction_type": ["in", ["Credit", "Loyalty Credit"]]
+        },
+        fields=["name", "wallet", "amount", "transaction_type", "source_type",
+                "source_account", "company", "customer"]
+    )
+    
+    if not wallet_transactions:
+        return
+    
+    # Calculate return ratio based on grand_total
+    # return grand_total is negative, original is positive
+    original_total = abs(flt(original_doc.grand_total))
+    return_total = abs(flt(return_doc.grand_total))
+    
+    if original_total <= 0:
+        return
+    
+    # Check if this is a full return (all items returned)
+    return_ratio = flt(return_total / original_total, 2)
+    is_full_return = return_ratio >= 0.999  # Allow small rounding tolerance
+    
+    for wt in wallet_transactions:
+        if is_full_return:
+            # Full return - cancel the wallet transaction
+            try:
+                wt_doc = frappe.get_doc("Wallet Transaction", wt.name)
+                wt_doc.flags.ignore_permissions = True
+                wt_doc.cancel()
+                frappe.msgprint(
+                    _("Cancelled Wallet Transaction {0} due to full return").format(wt.name),
+                    alert=True, indicator="blue"
+                )
+            except Exception as e:
+                frappe.log_error(
+                    title="Wallet Transaction Cancel on Return Error",
+                    message=f"WT: {wt.name}, Return: {return_invoice}, Error: {str(e)}\n{frappe.get_traceback()}"
+                )
+        else:
+            # Partial return - create a proportional debit (reverse) transaction
+            reverse_amount = flt(wt.amount * return_ratio, 2)
+            
+            if reverse_amount <= 0:
+                continue
+            
+            try:
+                reverse_wt = frappe.get_doc({
+                    "doctype": "Wallet Transaction",
+                    "transaction_type": "Debit",
+                    "wallet": wt.wallet,
+                    "company": wt.company,
+                    "posting_date": today(),
+                    "amount": reverse_amount,
+                    "source_type": "Refund",
+                    "source_account": wt.source_account,
+                    "reference_doctype": "Sales Invoice",
+                    "reference_name": return_invoice,
+                    "remarks": _("Wallet reversal for return {0} against {1} (ratio: {2}%)").format(
+                        return_invoice, original_invoice, round(return_ratio * 100, 1)
+                    )
+                })
+                reverse_wt.flags.ignore_permissions = True
+                reverse_wt.insert()
+                reverse_wt.submit()
+                
+                frappe.msgprint(
+                    _("Created wallet debit of {0} for partial return {1}").format(
+                        frappe.format_value(reverse_amount, {"fieldtype": "Currency"}),
+                        return_invoice
+                    ),
+                    alert=True, indicator="blue"
+                )
+            except Exception as e:
+                frappe.log_error(
+                    title="Wallet Reversal on Partial Return Error",
+                    message=f"Original WT: {wt.name}, Return: {return_invoice}, "
+                            f"Amount: {reverse_amount}, Error: {str(e)}\n{frappe.get_traceback()}"
+                )


### PR DESCRIPTION
first we can't simply cancel the original Wallet Transaction for a partial return (cancelling reverses the full amount). Instead, we have 2 options to handle this:
1- For full returns: Cancel the linked Wallet Transaction(s)
2- For partial returns: Create a new reverse Wallet Transaction (Debit) for the proportional amount we added this logic in the submit_invoice function in invoices.py, right after the return invoice is successfully submitted.
also add ignore_linked_doctypes to the wallet transaction to ignore the GL Entry and Payment Ledger Entry.