### PR TITLE
refactor(settings): replace warehouse-changed emit with event bus

### DIFF
--- a/POS/src/components/settings/POSSettings.vue
+++ b/POS/src/components/settings/POSSettings.vue
@@ -485,7 +485,7 @@ const props = defineProps({
 	currentWarehouse: String,
 })
 
-const emit = defineEmits(["update:modelValue", "warehouse-changed"])
+const emit = defineEmits(["update:modelValue"])
 
 const show = ref(props.modelValue)
 
@@ -727,10 +727,8 @@ async function saveSettings() {
 
 			if (warehouseResult && warehouseResult.success) {
 				// Add warehouse to new settings for change detection
+				// (detectSettingsChanges below will emit settings:warehouse-changed via event bus)
 				settings.value.warehouse = selectedWarehouse.value
-
-				// Emit event to parent to reload stock with new warehouse
-				emit("warehouse-changed", selectedWarehouse.value)
 			}
 		}
 

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -600,7 +600,6 @@
 				v-model="showPOSSettings"
 				:pos-profile="shiftStore.profileName"
 				:current-warehouse="shiftStore.profileWarehouse"
-				@warehouse-changed="handleWarehouseChanged"
 			/>
 
 			<!-- Stock Lookup Dialog (Products Menu) -->


### PR DESCRIPTION
## Summary
- Removed the `warehouse-changed` emit from `POSSettings.vue` in favor of the existing event bus mechanism
- Removed the corresponding `@warehouse-changed` listener from `POSSale.vue`
- Simplifies parent-child coupling by using the event bus that `detectSettingsChanges` already triggers

## Test plan
- [ ] Change warehouse in POS Settings and verify stock data reloads correctly
- [ ] Verify no console errors when saving settings with a new warehouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)