### PR TITLE
fix(pos): use tax-inclusive rate in return invoice when included_in_p…

### DIFF
--- a/pos_next/api/invoices.py
+++ b/pos_next/api/invoices.py
@@ -2104,7 +2104,7 @@ def prepare_return_invoice(invoice_name, pos_opening_shift=None):
 
         # Get rate breakdown for display - use 3 decimal precision for rates
         price_list_rate = flt(item.get("price_list_rate") or item.get("rate"), 3)
-        net_rate = flt(item.get("net_rate") or item.get("rate"), 3)
+        net_rate = flt(item.get("rate") or item.get("net_rate"), 3)
         discount_per_unit = flt(price_list_rate - net_rate, 3)
         tax_per_unit = flt(item_tax_map.get(item.get("item_code"), 0) / original_qty, 3) if original_qty else 0
 


### PR DESCRIPTION
…rint_rate

fix(pos): use tax-inclusive rate in return invoice when included_in_print_rate  
  
When creating POS returns with inclusive taxes, use the original tax-inclusive    rate instead of net_rate to prevent incorrect tax recalculation and display.

Fixes POS return invoices showing incorrect item rates (price_list_rate and rate) when taxes are marked as included_in_print_rate=1. The return was displaying the pre-tax rate (net_rate) instead of the tax-inclusive rate (rate), causing tax recalculation while keeping totals correct.

Bug Details
Original Invoice: rate=21.00 (tax-inclusive), net_rate=18.26 (pre-tax)
Return Before Fix: rate=18.26, net_rate=15.88 (after recalculation)
Return After Fix: rate=21.00, net_rate=18.26 (matches original)
Root Cause
In prepare_return_invoice, the process_return_item function incorrectly assigns net_rate to the rate field:

"rate": net_rate,  # Problem: uses pre-tax rate
When included_in_print_rate=1, the tax engine treats rate as tax-inclusive and back-calculates taxes, leading to incorrect display values.