### PR TITLE
fix: handle free items that are different products in promotional sch…

### DIFF
--- a/POS/src/components/sale/InvoiceCart.vue
+++ b/POS/src/components/sale/InvoiceCart.vue
@@ -743,9 +743,14 @@
 			<div v-else class="flex flex-col gap-0.5 sm:gap-1">
 				<div
 					v-for="(item, index) in sortedItems"
-					:key="item.item_code + '-' + (item.uom || '')"
-					@click="openEditDialog(item)"
-					class="bg-white border border-gray-200 rounded-md p-1.5 sm:p-2 hover:border-blue-300 hover:shadow-md transition-all duration-200 active:scale-[0.99] cursor-pointer group"
+					:key="item.item_code + '-' + (item.uom || '') + (item.is_free_item ? '-free' : '')"
+					@click="item.is_free_item ? null : openEditDialog(item)"
+					:class="[
+						'border rounded-md p-1.5 sm:p-2 transition-all duration-200',
+						item.is_free_item
+							? 'bg-green-50 border-green-300 cursor-default'
+							: 'bg-white border-gray-200 hover:border-blue-300 hover:shadow-md active:scale-[0.99] cursor-pointer group'
+					]"
 				>
 					<div class="flex gap-1.5 sm:gap-2">
 						<!-- Item Image Thumbnail -->
@@ -792,7 +797,7 @@
 									<span
 										v-if="item.free_qty && item.free_qty > 0"
 										class="inline-flex items-center px-1.5 py-0.5 bg-green-600 text-white rounded-full text-[9px] font-bold flex-shrink-0"
-										:title="__('{0} free item(s) included', [item.free_qty])"
+										:title="item.is_free_item ? __('Free item') : __('{0} free item(s) included', [item.free_qty])"
 									>
 										<svg
 											class="w-2.5 h-2.5 me-0.5"
@@ -805,7 +810,7 @@
 												clip-rule="evenodd"
 											/>
 										</svg>
-										{{ __("+{0} FREE", [item.free_qty]) }}
+										{{ item.is_free_item ? __("FREE") : __("+{0} FREE", [item.free_qty]) }}
 									</span>
 									<!-- Discount Badge -->
 									<div
@@ -831,6 +836,7 @@
 									</div>
 								</div>
 								<button
+									v-if="!item.is_free_item"
 									type="button"
 									@click.stop="$emit('remove-item', item.item_code, item.uom)"
 									class="text-gray-400 hover:text-red-600 active:text-red-700 transition-colors flex-shrink-0 p-0.5 -m-0.5 touch-manipulation active:scale-90"
@@ -857,9 +863,16 @@
 							<div class="flex items-center justify-between gap-1.5">
 								<div class="flex items-center gap-1.5">
 									<!-- Quantity Counter -->
+									<!-- For free items, show static quantity badge -->
+									<div
+										v-if="item.is_free_item"
+										class="flex items-center bg-green-100 border border-green-300 rounded px-2 h-6 sm:h-7"
+									>
+										<span class="text-xs sm:text-sm font-bold text-green-700">{{ item.quantity }}</span>
+									</div>
 									<!-- For serial items, show serial badge with edit button -->
 									<div
-										v-if="item.has_serial_no && item.serial_no"
+										v-else-if="item.has_serial_no && item.serial_no"
 										class="flex items-center gap-1"
 										@click.stop
 									>
@@ -1541,7 +1554,8 @@ watch(customerResults, () => {
 const totalQuantity = computed(() => {
 	return props.items.reduce((sum, item) => {
 		const qty = item.quantity || 0;
-		const freeQty = item.free_qty || 0;
+		// For dedicated free item rows, quantity IS the free qty — don't double-count
+		const freeQty = item.is_free_item ? 0 : (item.free_qty || 0);
 		return sum + qty + freeQty;
 	}, 0);
 });

--- a/POS/src/components/sale/PaymentDialog.vue
+++ b/POS/src/components/sale/PaymentDialog.vue
@@ -279,9 +279,9 @@
 								class="px-3 py-2 hover:bg-gray-50 flex flex-col gap-1"
 							>
 								<!-- Main Item -->
-								<div class="flex items-start justify-between gap-2">
+								<div :class="['flex items-start justify-between gap-2', item.is_free_item ? 'bg-green-50 px-2 py-1 rounded border border-green-100' : '']">
 									<div class="flex-1 min-w-0 text-start">
-										<div class="font-medium text-sm text-gray-900 truncate">{{ item.item_name || item.item_code }}</div>
+										<div :class="['font-medium text-sm truncate', item.is_free_item ? 'text-green-700' : 'text-gray-900']">{{ item.item_name || item.item_code }}<span v-if="item.is_free_item" class="text-[10px] font-bold"> ({{ __('Free') }})</span></div>
 										<div class="text-xs text-gray-500 mt-0.5">
 											{{ formatCurrency(item.rate || item.price_list_rate) }} × {{ item.qty || item.quantity }}
 										</div>
@@ -291,8 +291,8 @@
 									</div>
 								</div>
 
-								<!-- Free Item -->
-								<div v-if="item?.free_qty > 0" class="flex justify-between items-center gap-2 bg-green-50 px-2 py-1 rounded border border-green-100">
+								<!-- Free Item (same-item case: free qty attached to a paid item) -->
+								<div v-if="!item.is_free_item && item?.free_qty > 0" class="flex justify-between items-center gap-2 bg-green-50 px-2 py-1 rounded border border-green-100">
 									<div class="flex-1 min-w-0 text-start">
 										<div class="font-medium text-xs text-green-700 truncate flex items-center gap-1">
 											<svg class="w-3 h-3 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">

--- a/POS/src/composables/useInvoice.js
+++ b/POS/src/composables/useInvoice.js
@@ -737,8 +737,8 @@ export function useInvoice() {
 			item_code: item.item_code,
 			item_name: item.item_name,
 			qty: item.quantity || item.qty || 1,
-			rate: computeBackendRate(item),
-			price_list_rate: roundCurrency(item.price_list_rate || item.rate),
+			rate: item.is_free_item ? 0 : computeBackendRate(item),
+			price_list_rate: item.is_free_item ? 0 : roundCurrency(item.price_list_rate || item.rate),
 			uom: item.uom,
 			warehouse: item.warehouse,
 			batch_no: item.batch_no,
@@ -750,6 +750,7 @@ export function useInvoice() {
 			// Manual rate edit tracking for audit logging
 			is_rate_manually_edited: item.is_rate_manually_edited || 0,
 			original_rate: item.original_rate || null,
+			is_free_item: item.is_free_item || 0,
 		}))
 	}
 

--- a/POS/src/stores/posCart.js
+++ b/POS/src/stores/posCart.js
@@ -376,42 +376,73 @@ export const usePOSCartStore = defineStore("posCart", () => {
 	}
 
 	/**
-	 * Parses the backend offer response and applies free item quantities to cart items
+	 * Processes free items from backend offer response.
 	 *
-	 * @param {Array} freeItems - Array of free items from backend (e.g., [{item_code, qty, uom}])
+	 * Two cases:
+	 * 1. Same item (free item matches an existing cart item) → sets free_qty on that item
+	 * 2. Different product (free item not in cart) → adds a dedicated free item row
+	 *    with is_free_item=1, rate=0, non-editable in UI
+	 *
+	 * @param {Array} freeItems - Array of free items from backend (e.g., [{item_code, qty, uom, item_name}])
 	 * @returns {void}
-	 *
-	 * @example
-	 * // Backend returns: [{ item_code: "SKU001", qty: 1, uom: "Nos" }]
-	 * // Cart has: [{ item_code: "SKU001", quantity: 2, uom: "Nos" }]
-	 * // Result: Cart item gets free_qty = 1 (shown as "2 items + 1 FREE")
 	 */
 	function processFreeItems(freeItems) {
-		// Reset all free quantities
+		// Reset free_qty on all non-free items
 		invoiceItems.value.forEach(item => {
-			item.free_qty = 0
+			if (!item.is_free_item) {
+				item.free_qty = 0
+			}
 		})
+
+		// Remove previously-added free item rows (they'll be re-added below if still valid)
+		invoiceItems.value = invoiceItems.value.filter(item => !item.is_free_item)
 
 		// Early return if no free items
 		if (!Array.isArray(freeItems) || freeItems.length === 0) {
+			rebuildIncrementalCache()
 			return
 		}
 
-		// Match free items to cart items and set free_qty
 		for (const freeItem of freeItems) {
 			const freeQty = Number.parseFloat(freeItem.qty) || 0
 			if (freeQty <= 0) continue
 
-			// Find matching cart item by item_code and uom
+			const freeUom = freeItem.uom || freeItem.stock_uom
+
+			// Check if this free item matches an existing (non-free) cart item
 			const cartItem = invoiceItems.value.find(
-				item => item.item_code === freeItem.item_code &&
-					(item.uom || item.stock_uom) === (freeItem.uom || freeItem.stock_uom)
+				item => !item.is_free_item &&
+					item.item_code === freeItem.item_code &&
+					(item.uom || item.stock_uom) === freeUom
 			)
 
 			if (cartItem) {
+				// Same item is already in cart — just annotate with free_qty
 				cartItem.free_qty = freeQty
+			} else {
+				// Different product — add a dedicated free item row
+				invoiceItems.value.push({
+					item_code: freeItem.item_code,
+					item_name: freeItem.item_name || freeItem.item_code,
+					rate: 0,
+					price_list_rate: 0,
+					quantity: freeQty,
+					discount_amount: 0,
+					discount_percentage: 0,
+					tax_amount: 0,
+					amount: 0,
+					stock_qty: 0,
+					uom: freeUom,
+					stock_uom: freeItem.stock_uom || freeUom,
+					conversion_factor: freeItem.conversion_factor || 1,
+					is_free_item: 1,
+					free_qty: freeQty,
+					pricing_rules: freeItem.pricing_rules || null,
+				})
 			}
 		}
+
+		rebuildIncrementalCache()
 	}
 
 	/**


### PR DESCRIPTION
…emes

processFreeItems() only matched free items against existing cart items, silently dropping free items when the promotional scheme gives a different product (same_item=0). Now adds dedicated free item rows with is_free_item=1 and rate=0, with proper UI treatment (green styling, non-editable) and correct submission payload including is_free_item flag.