### PR TITLE
feat: Add Show Variants as Items POS setting

### DIFF
--- a/POS/src/components/sale/ItemsSelector.vue
+++ b/POS/src/components/sale/ItemsSelector.vue
@@ -379,6 +379,9 @@
 							<h3 class="text-[10px] sm:text-xs font-semibold text-gray-900 truncate mb-0.5 leading-tight">
 								{{ item.item_name }}
 							</h3>
+							<p v-if="item.attributes" class="text-[8px] sm:text-[9px] text-gray-400 truncate leading-tight">
+								{{ Object.values(item.attributes).join(' / ') }}
+							</p>
 							<p class="text-[9px] sm:text-[10px] text-gray-500 leading-tight">
 									<span class="font-semibold text-blue-600">{{ formatCurrency(item.rate || item.price_list_rate || 0) }}</span>
 									<span class="text-gray-400">/ {{ item.uom || item.stock_uom || __('Nos', null, 'UOM') }}</span>
@@ -544,6 +547,9 @@
 							<td class="px-2 sm:px-3 py-2 max-w-[120px] sm:max-w-[180px] md:max-w-[200px]">
 								<div class="text-xs sm:text-sm font-medium text-gray-900 truncate" :title="item.item_name">
 									{{ item.item_name }}
+								</div>
+								<div v-if="item.attributes" class="text-[8px] sm:text-[9px] text-gray-400 truncate leading-tight">
+									{{ Object.values(item.attributes).join(' / ') }}
 								</div>
 							</td>
 							<td class="hidden sm:table-cell px-2 sm:px-3 py-2 whitespace-nowrap sm:max-w-[150px]">
@@ -1076,7 +1082,7 @@ function clearLongPress() {
 function selectItem(item, autoAdd = false) {
 	if (!item) return false
 
-	// Skip stock validation for: variants (template), serial items, batch items (they have own validation)
+	// Skip stock validation for: template items (no stock), serial items, batch items (they have own validation)
 	const skipValidation = item.has_variants || item.has_serial_no || item.has_batch_no
 	const isStockTracked = item.is_stock_item || item.is_bundle
 	const qty = Math.floor(item.actual_qty ?? item.stock_qty ?? 0)

--- a/POS/src/stores/itemSearch.js
+++ b/POS/src/stores/itemSearch.js
@@ -1,79 +1,18 @@
 import { call } from "@/utils/apiWrapper"
 import { isOffline } from "@/utils/offline"
 import { offlineWorker } from "@/utils/offline/workerClient"
-import { cacheItems, getCachedVariants, updateItemBatchSerialData } from "@/utils/offline/items"
+import { updateItemBatchSerialData } from "@/utils/offline/items"
 import { performanceConfig } from "@/utils/performanceConfig"
 import { logger } from "@/utils/logger"
 import { createResource } from "frappe-ui"
 import { defineStore } from "pinia"
-import { computed, ref } from "vue"
+import { computed, ref, watch } from "vue"
 import { useStockStore } from "./stock"
+import { usePOSSettingsStore } from "./posSettings"
 import { usePOSShiftStore } from "./posShift"
 import { useRealtimePosProfile } from "@/composables/useRealtimePosProfile"
 
 const log = logger.create('ItemSearch')
-
-/**
- * Fetch and cache variants for all template items
- * This ensures variants are available for offline use
- * @param {Array} items - Items array to check for templates
- * @param {string} posProfile - POS Profile name
- */
-async function cacheVariantsForTemplates(items, posProfile) {
-	if (!items || items.length === 0 || !posProfile) return
-
-	// Find template items (items with has_variants = 1)
-	const templateItems = items.filter(item => item.has_variants)
-
-	if (templateItems.length === 0) {
-		log.debug("No template items found - skipping variant caching")
-		return
-	}
-
-	log.info(`Caching variants for ${templateItems.length} template items`)
-
-	// Fetch variants for each template in parallel (with concurrency limit)
-	const CONCURRENCY_LIMIT = 3
-	const allVariants = []
-
-	for (let i = 0; i < templateItems.length; i += CONCURRENCY_LIMIT) {
-		const batch = templateItems.slice(i, i + CONCURRENCY_LIMIT)
-
-		const batchPromises = batch.map(async (template) => {
-			try {
-				const response = await call("pos_next.api.items.get_item_variants", {
-					template_item: template.item_code,
-					pos_profile: posProfile,
-				})
-				const variants = response?.message || response || []
-
-				if (variants.length > 0) {
-					log.debug(`Fetched ${variants.length} variants for ${template.item_code}`)
-					return variants
-				}
-				return []
-			} catch (error) {
-				log.warn(`Failed to fetch variants for ${template.item_code}:`, error.message)
-				return []
-			}
-		})
-
-		const batchResults = await Promise.all(batchPromises)
-		for (const variants of batchResults) {
-			allVariants.push(...variants)
-		}
-	}
-
-	// Cache all variants in IndexedDB
-	if (allVariants.length > 0) {
-		try {
-			await cacheItems(allVariants)
-			log.success(`Cached ${allVariants.length} variants for offline use`)
-		} catch (error) {
-			log.error("Failed to cache variants:", error)
-		}
-	}
-}
 
 /**
  * Fetch and cache batch/serial data for items with batch or serial tracking
@@ -126,6 +65,15 @@ async function cacheBatchSerialForItems(items, warehouse) {
 export const useItemSearchStore = defineStore("itemSearch", () => {
 	// Get stock store instance
 	const stockStore = useStockStore()
+
+	// Get POS settings store for dynamic show_variants_as_items flag
+	const posSettingsStore = usePOSSettingsStore()
+	const getShowVariantsFlag = () => posSettingsStore.showVariantsAsItems ? 1 : 0
+
+	// Sync show_variants_as_items setting to worker whenever it changes
+	watch(() => posSettingsStore.showVariantsAsItems, (newVal) => {
+		offlineWorker.setShowVariantsAsItems(newVal)
+	}, { immediate: true })
 
 	// Get shift store for warehouse info (for batch/serial caching)
 	const shiftStore = usePOSShiftStore()
@@ -776,6 +724,7 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 			// Skip when offline — count can't be fetched without network
 			const countPromise = !offline ? call("pos_next.api.items.get_items_count", {
 				pos_profile: profile,
+				show_variants_as_items: getShowVariantsFlag(),
 			}).then(r => r?.message ?? r ?? 0).catch(countErr => {
 				log.warn("Could not fetch item count:", countErr.message)
 				return 0
@@ -824,28 +773,6 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 							totalServerItems.value = cacheStats.value?.totalServerItems || stats.items
 							hasMore.value = cached.length >= limit
 							log.success(`Loaded ${cached.length} items from cache (offline, total: ${stats.items})`)
-
-							// Eager variant verification: Check if template items have cached variants
-							const templateItems = cached.filter(item => item.has_variants)
-							if (templateItems.length > 0) {
-								log.info(`Verifying variants for ${templateItems.length} template items`)
-								const missingVariants = []
-
-								for (const template of templateItems) {
-									const variants = await getCachedVariants(template.item_code)
-									if (!variants || variants.length === 0) {
-										missingVariants.push(template.item_code)
-									} else {
-										log.debug(`Template ${template.item_code} has ${variants.length} cached variants`)
-									}
-								}
-
-								if (missingVariants.length > 0) {
-									log.warn(`${missingVariants.length} template items missing variants in offline cache:`, missingVariants)
-								} else {
-									log.success(`All ${templateItems.length} template items have variants cached`)
-								}
-							}
 						} else {
 							replaceAllItems([])
 							log.warn("No items in cache")
@@ -946,11 +873,6 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 
 					log.success(`Loaded ${fetchedItems.length} items (server-side filtering)`)
 
-					// Background caching - limit to prevent overloading IndexedDB
-					cacheVariantsForTemplates(fetchedItems.slice(0, 50), profile).catch(err => {
-						log.warn("Background variant caching failed:", err.message)
-					})
-
 					// Cache batch/serial data for offline use
 					if (shiftStore.profileWarehouse) {
 						cacheBatchSerialForItems(fetchedItems, shiftStore.profileWarehouse).catch(err => {
@@ -984,6 +906,7 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 					item_group: null, // No filter - get items from all groups
 					start: 0,
 					limit: unfilteredLimit,
+					show_variants_as_items: getShowVariantsFlag(),
 				})
 				const list = response?.message || response || []
 
@@ -1005,12 +928,6 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 					serverDataFresh.value = true
 
 					log.success(`Loaded ${list.length} items from server`)
-
-					// Cache variants for template items (for offline use)
-					// Run in background to not block UI
-					cacheVariantsForTemplates(list, profile).catch(err => {
-						log.warn("Background variant caching failed:", err.message)
-					})
 
 					// Cache batch/serial data for offline use
 					if (shiftStore.profileWarehouse) {
@@ -1072,6 +989,7 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 				item_group: firstGroup, // Server-side filter via DB index
 				start: 0,
 				limit: effectiveLimit,
+				show_variants_as_items: getShowVariantsFlag(),
 			})
 			const items = response?.message || response || []
 			log.info(`Fetched ${items.length} items from ${firstGroup}`)
@@ -1107,6 +1025,7 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 					item_groups: JSON.stringify(groupsToFetch),
 					start: start,
 					limit: effectiveLimit,
+					show_variants_as_items: getShowVariantsFlag(),
 				})
 				return response?.message || response || []
 			} else {
@@ -1116,6 +1035,7 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 					item_group: itemGroup,
 					start: start,
 					limit: effectiveLimit,
+					show_variants_as_items: getShowVariantsFlag(),
 				})
 				return response?.message || response || []
 			}
@@ -1188,6 +1108,7 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 					item_group: null,
 					start: start,
 					limit: pageSize,
+					show_variants_as_items: getShowVariantsFlag(),
 				})
 				items = response?.message || response || []
 			}
@@ -1277,6 +1198,7 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 					item_group: null,
 					start: currentOffset.value,
 					limit: itemsPerPage.value,
+					show_variants_as_items: getShowVariantsFlag(),
 				})
 				list = response?.message || response || []
 			}
@@ -1418,7 +1340,8 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 							item_groups: JSON.stringify([currentGroup]),
 							start: groupOffset,
 							limit: batchSize,
-							include_variants: 1,
+							show_variants_as_items: getShowVariantsFlag(),
+							include_variants: 1, // Always cache variants for offline barcode scanning
 						})
 						if (myGeneration !== syncGeneration) return
 						const list = response?.message || response || []
@@ -1467,7 +1390,8 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 									pos_profile: profile,
 									start: offset,
 									limit: batchSize,
-									include_variants: 1,
+									show_variants_as_items: getShowVariantsFlag(),
+									include_variants: 1, // Always cache variants for offline barcode scanning
 								}).then(r => r?.message || r || [])
 								.catch(err => {
 									log.warn(`Parallel batch at offset ${offset} failed:`, err.message)
@@ -1627,6 +1551,7 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 						item_group: selectedItemGroup.value,
 						start: 0,
 						limit: searchLimit, // Dynamically adjusted based on device performance
+						show_variants_as_items: getShowVariantsFlag(),
 					})
 					const serverResults = response?.message || response || []
 
@@ -1856,6 +1781,7 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 				const countPromise = call("pos_next.api.items.get_items_count", {
 					pos_profile: posProfile.value,
 					item_group: group || undefined,
+					show_variants_as_items: getShowVariantsFlag(),
 				}).catch(err => {
 					log.warn("Could not fetch item count:", err.message)
 					return 0
@@ -1874,6 +1800,7 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 						item_group: null,
 						start: 0,
 						limit: pageSize,
+						show_variants_as_items: getShowVariantsFlag(),
 					})
 					items = response?.message || response || []
 					log.info(`Loaded ${items.length} items for "All Items" tab`)

--- a/POS/src/stores/posSettings.js
+++ b/POS/src/stores/posSettings.js
@@ -34,6 +34,7 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 		hide_expected_amount: 0,
 		display_discount_percentage: 0,
 		display_discount_amount: 0,
+		show_variants_as_items: 0,
 		// Operations
 		allow_sales_order: 0,
 		allow_select_sales_order: 0,
@@ -141,6 +142,9 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 	)
 	const displayDiscountAmount = computed(() =>
 		Boolean(settings.value.display_discount_amount),
+	)
+	const showVariantsAsItems = computed(() =>
+		Boolean(settings.value.show_variants_as_items),
 	)
 
 	// Computed - Operations
@@ -304,6 +308,7 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 			hide_expected_amount: 0,
 			display_discount_percentage: 0,
 			display_discount_amount: 0,
+			show_variants_as_items: 0,
 			allow_sales_order: 0,
 			allow_select_sales_order: 0,
 			create_only_sales_order: 0,
@@ -415,6 +420,7 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 		hideExpectedAmount,
 		displayDiscountPercentage,
 		displayDiscountAmount,
+		showVariantsAsItems,
 
 		// Computed - Operations
 		allowSalesOrder,

--- a/POS/src/utils/offline/db.js
+++ b/POS/src/utils/offline/db.js
@@ -44,7 +44,7 @@ const CURRENT_SCHEMA = {
 
 	// Items cache with searchable fields
 	// variant_of index allows querying variants by their template item
-	items: "&item_code, item_name, item_group, variant_of, *barcodes",
+	items: "&item_code, item_name, item_group, variant_of, has_variants, *barcodes",
 
 	// Customers cache
 	customers: "&name, customer_name, mobile_no, email_id",

--- a/POS/src/utils/offline/workerClient.js
+++ b/POS/src/utils/offline/workerClient.js
@@ -464,6 +464,10 @@ class OfflineWorkerClient {
 		return this.sendMessage("SET_CSRF_TOKEN", { token })
 	}
 
+	async setShowVariantsAsItems(value) {
+		return this.sendMessage("SET_SHOW_VARIANTS_AS_ITEMS", { value: Boolean(value) })
+	}
+
 	async updateStockQuantities(stockUpdates) {
 		return this.sendMessage("UPDATE_STOCK_QUANTITIES", { stockUpdates })
 	}

--- a/POS/src/workers/offline.worker.js
+++ b/POS/src/workers/offline.worker.js
@@ -168,6 +168,11 @@ let serverOnline = true
 let manualOffline = false
 let csrfToken = null // CSRF token passed from main thread
 
+// Display mode: controlled by POS Settings "Show Variants as Items" (default: off)
+// true = variants shown directly, templates hidden
+// false = templates shown, variants hidden from browse (but still cached for barcode scan)
+let showVariantsAsItems = false
+
 // Periodic stock sync state
 let stockSyncInterval = null
 let stockSyncEnabled = false
@@ -467,6 +472,17 @@ async function updateLocalStock(items) {
 }
 
 /**
+ * Check if an item should be displayed in the grid based on display mode.
+ * @param {Object} item - Item to check
+ * @returns {boolean} True if item should be shown
+ */
+function shouldShowItem(item) {
+	if (item.disabled) return false
+	if (showVariantsAsItems) return !item.has_variants
+	return !item.variant_of
+}
+
+/**
  * Search cached items with intelligent query optimization
  * - Query result caching (5x faster for repeated searches)
  * - Index-based search (O(log n) for single-word queries)
@@ -491,11 +507,11 @@ async function searchCachedItems(searchTerm = "", limit = 50, offset = 0) {
 		const db = await initDB()
 
 		// Empty search - return top N items sorted alphabetically
-		// Exclude disabled and variant items (variants are shown via template selector, not in grid)
+		// Exclude disabled and template items (templates are not shown in grid, variants are)
 		if (!searchTerm || searchTerm.trim().length === 0) {
 			const results = await db.table("items")
 				.orderBy("item_name")
-				.filter(item => !item.disabled && !item.variant_of)
+				.filter(item => shouldShowItem(item))
 				.offset(offset)
 				.limit(limit)
 				.toArray()
@@ -621,13 +637,13 @@ async function searchCachedItemsByGroup(itemGroups = [], limit = 50, offset = 0)
 		const db = await initDB()
 
 		// Use item_group index for efficient lookup
-		// Exclude variant items (variant_of is set) — only show templates + regular items
+		// Exclude template items (has_variants is set) — only show variants + regular items
 		let allResults = []
 		for (const group of itemGroups) {
 			const items = await db.table("items")
 				.where("item_group")
 				.equals(group)
-				.filter(item => !item.disabled && !item.variant_of)
+				.filter(item => shouldShowItem(item))
 				.toArray()
 			allResults.push(...items)
 		}
@@ -664,7 +680,7 @@ async function countCachedItemsByGroup(itemGroups = []) {
 		const db = await initDB()
 
 		if (!itemGroups || itemGroups.length === 0) {
-			return await db.table("items").filter(item => !item.disabled && !item.variant_of).count()
+			return await db.table("items").filter(item => shouldShowItem(item)).count()
 		}
 
 		let total = 0
@@ -672,7 +688,7 @@ async function countCachedItemsByGroup(itemGroups = []) {
 			total += await db.table("items")
 				.where("item_group")
 				.equals(group)
-				.filter(item => !item.disabled && !item.variant_of)
+				.filter(item => shouldShowItem(item))
 				.count()
 		}
 		return total
@@ -1209,17 +1225,21 @@ async function getCacheStats() {
 	try {
 		const db = await initDB()
 
-		const [totalCount, variantCount, customerCount, queuedInvoices, lastSyncSetting] =
+		const [totalCount, hiddenCount, customerCount, queuedInvoices, lastSyncSetting] =
 			await Promise.all([
 				db.table("items").count(),
-				// Count variant items (have non-empty variant_of field)
-				db.table("items").where("variant_of").notEqual("").count(),
+				// Count items hidden from display based on current mode:
+				// showVariantsAsItems=true: hide templates (has_variants)
+				// showVariantsAsItems=false: hide variants (variant_of)
+				showVariantsAsItems
+					? db.table("items").filter(item => !!item.has_variants).count()
+					: db.table("items").filter(item => !!item.variant_of).count(),
 				db.table("customers").count(),
 				getOfflineInvoiceCount(),
 				db.table("settings").get("items_last_sync"),
 			])
-		// Exclude variants from display count (they're cached for template item lookups)
-		const itemCount = totalCount - variantCount
+		// Exclude hidden items from display count
+		const itemCount = totalCount - hiddenCount
 
 		return {
 			items: itemCount,
@@ -1610,6 +1630,15 @@ self.onmessage = async (event) => {
 
 			case "DELETE_INVOICE":
 				result = await deleteOfflineInvoice(payload.id)
+				break
+
+			case "SET_SHOW_VARIANTS_AS_ITEMS":
+				showVariantsAsItems = Boolean(payload.value)
+				// Invalidate query cache since display filters changed
+				invalidateCache('search:')
+				invalidateCache('group:')
+				log.info(`Display mode updated: showVariantsAsItems=${showVariantsAsItems}`)
+				result = { success: true, showVariantsAsItems }
 				break
 
 			case "SET_MANUAL_OFFLINE":

--- a/pos_next/api/constants.py
+++ b/pos_next/api/constants.py
@@ -36,6 +36,7 @@ POS_SETTINGS_FIELDS = [
 	"allow_sales_order",
 	"allow_select_sales_order",
 	"create_only_sales_order",
+	"show_variants_as_items",
 ]
 
 # Default POS Settings values
@@ -62,4 +63,5 @@ DEFAULT_POS_SETTINGS = {
 	"allow_sales_order": 0,
 	"allow_select_sales_order": 0,
 	"create_only_sales_order": 0,
+	"show_variants_as_items": 0,
 }

--- a/pos_next/api/items.py
+++ b/pos_next/api/items.py
@@ -696,7 +696,7 @@ def _get_item_group_with_descendants(item_group):
 	return [item_group] + list(descendants)
 
 
-def _build_item_base_conditions(pos_profile_doc, item_group=None, exclude_variants=True, hide_unavailable=False, warehouse=None):
+def _build_item_base_conditions(pos_profile_doc, item_group=None, exclude_variants=True, exclude_templates=False, hide_unavailable=False, warehouse=None):
 	"""Build base SQL conditions for POS item search with hierarchical item group support.
 
 	Returns:
@@ -711,6 +711,8 @@ def _build_item_base_conditions(pos_profile_doc, item_group=None, exclude_varian
 	]
 	if exclude_variants:
 		conditions.append("IFNULL(i.variant_of, '') = ''")
+	if exclude_templates:
+		conditions.append("i.has_variants = 0")
 
 	where_params = []
 
@@ -735,7 +737,7 @@ def _build_item_base_conditions(pos_profile_doc, item_group=None, exclude_varian
 		wh_placeholders = ", ".join(["%s"] * len(warehouses))
 		extra_joins = f"LEFT JOIN `tabBin` bin ON bin.item_code = i.name AND bin.warehouse IN ({wh_placeholders})"
 		join_params.extend(warehouses)
-		conditions.append("(i.is_stock_item = 0 OR bin.actual_qty > 0)")
+		conditions.append("(i.is_stock_item = 0 OR i.has_variants = 1 OR bin.actual_qty > 0)")
 
 	# Merge: join params come before WHERE params to match SQL placeholder order
 	return conditions, join_params + where_params, extra_joins
@@ -1065,7 +1067,7 @@ def _get_bundle_warehouse_availability_bulk(bundle_codes, warehouses):
 
 
 @frappe.whitelist()
-def get_items(pos_profile, search_term=None, item_group=None, start=0, limit=20, include_variants=0):
+def get_items(pos_profile, search_term=None, item_group=None, start=0, limit=20, include_variants=0, show_variants_as_items=0):
 	"""Get items for POS with stock, price, and tax details"""
 	try:
 		pos_profile_doc = frappe.get_cached_doc("POS Profile", pos_profile)
@@ -1080,20 +1082,22 @@ def get_items(pos_profile, search_term=None, item_group=None, start=0, limit=20,
 				# Use the extracted item barcode for searching
 				effective_search_term = resolved_barcode_data["item_barcode"]
 
-		# IMPORTANT: Filtering logic explained:
-		# - Template items (has_variants=1) are shown → users select variants via dialog
-		# - Regular items (has_variants=0, variant_of is null) are shown → direct add to cart
-		# - Variant items (has_variants=0, variant_of is not null) are HIDDEN from main list
-		#   UNLESS include_variants=1 (used by background sync to cache variants for offline)
-
-		# Add company filter - show items for specific company + global items (empty company)
-		# Global items (custom_company is empty) are available to all companies
+		# FILTERING LOGIC:
+		# When show_variants_as_items=1: Variants shown directly in grid, templates excluded
+		# When show_variants_as_items=0 (default): Templates shown, variants hidden from browse
 
 		# Build base conditions
-		exclude_variants = not int(include_variants)
+		show_variants_mode = int(show_variants_as_items)
+		if show_variants_mode:
+			exclude_variants = False
+			exclude_templates = True
+		else:
+			exclude_variants = not int(include_variants)
+			exclude_templates = False
 		hide_unavailable = getattr(pos_profile_doc, "hide_unavailable_items", 0)
 		conditions, params, extra_joins = _build_item_base_conditions(
 			pos_profile_doc, item_group, exclude_variants=exclude_variants,
+			exclude_templates=exclude_templates,
 			hide_unavailable=hide_unavailable, warehouse=pos_profile_doc.warehouse,
 		)
 
@@ -1420,7 +1424,7 @@ def get_items(pos_profile, search_term=None, item_group=None, start=0, limit=20,
 
 
 @frappe.whitelist()
-def get_items_bulk(pos_profile, item_groups=None, start=0, limit=2000, include_variants=0):
+def get_items_bulk(pos_profile, item_groups=None, start=0, limit=2000, include_variants=0, show_variants_as_items=0):
 	"""
 	Fetch items from multiple item groups in a SINGLE query.
 	Eliminates N+1 problem where frontend was making one API call per group.
@@ -1431,6 +1435,7 @@ def get_items_bulk(pos_profile, item_groups=None, start=0, limit=2000, include_v
 		start: Offset for pagination (default 0)
 		limit: Max items to return (default 2000)
 		include_variants: If 1, include variant items (for offline caching)
+		show_variants_as_items: If 1, show variants directly and exclude templates
 	"""
 	try:
 		if isinstance(item_groups, str):
@@ -1439,10 +1444,17 @@ def get_items_bulk(pos_profile, item_groups=None, start=0, limit=2000, include_v
 		pos_profile_doc = frappe.get_cached_doc("POS Profile", pos_profile)
 
 		# Build base conditions using shared helper
-		exclude_variants = not int(include_variants)
+		show_variants_mode = int(show_variants_as_items)
+		if show_variants_mode:
+			exclude_variants = False
+			exclude_templates = True
+		else:
+			exclude_variants = not int(include_variants)
+			exclude_templates = False
 		hide_unavailable = getattr(pos_profile_doc, "hide_unavailable_items", 0)
 		conditions, params, extra_joins = _build_item_base_conditions(
 			pos_profile_doc, exclude_variants=exclude_variants,
+			exclude_templates=exclude_templates,
 			hide_unavailable=hide_unavailable, warehouse=pos_profile_doc.warehouse,
 		)
 
@@ -1557,9 +1569,9 @@ def get_items_bulk(pos_profile, item_groups=None, start=0, limit=2000, include_v
 			item_code = item["item_code"]
 			stock_uom = item.get("stock_uom")
 
-			# Price
+			# Price: prefer stock_uom, then None/empty UOM (Item Price without UOM)
 			prices = uom_prices_map.get(item_code, {})
-			item["rate"] = prices.get(stock_uom, 0)
+			item["rate"] = flt(prices.get(stock_uom) or prices.get(None) or prices.get("") or 0)
 			item["price_list_rate"] = item["rate"]
 			item["uom"] = stock_uom
 			item["price_uom"] = stock_uom
@@ -1601,7 +1613,7 @@ def get_items_bulk(pos_profile, item_groups=None, start=0, limit=2000, include_v
 
 
 @frappe.whitelist()
-def get_items_count(pos_profile, item_group=None, include_variants=0):
+def get_items_count(pos_profile, item_group=None, include_variants=0, show_variants_as_items=0):
 	"""
 	Get total count of POS-eligible items for progress tracking and smart pagination.
 
@@ -1612,16 +1624,24 @@ def get_items_count(pos_profile, item_group=None, include_variants=0):
 		pos_profile: POS Profile name
 		item_group: Optional item group filter (expands to descendants)
 		include_variants: If 1, include variant items in the count
+		show_variants_as_items: If 1, count variants directly and exclude templates
 
 	Returns:
 		int: Total count of distinct matching items
 	"""
 	try:
 		pos_profile_doc = frappe.get_cached_doc("POS Profile", pos_profile)
-		exclude_variants = not int(include_variants)
+		show_variants_mode = int(show_variants_as_items)
+		if show_variants_mode:
+			exclude_variants = False
+			exclude_templates = True
+		else:
+			exclude_variants = not int(include_variants)
+			exclude_templates = False
 		hide_unavailable = getattr(pos_profile_doc, "hide_unavailable_items", 0)
 		conditions, params, extra_joins = _build_item_base_conditions(
 			pos_profile_doc, item_group, exclude_variants=exclude_variants,
+			exclude_templates=exclude_templates,
 			hide_unavailable=hide_unavailable, warehouse=pos_profile_doc.warehouse,
 		)
 

--- a/pos_next/pos_next/doctype/pos_settings/pos_settings.json
+++ b/pos_next/pos_next/doctype/pos_settings/pos_settings.json
@@ -36,6 +36,7 @@
   "hide_expected_amount",
   "display_discount_percentage",
   "display_discount_amount",
+  "show_variants_as_items",
   "section_break_operations",
   "allow_sales_order",
   "allow_select_sales_order",
@@ -291,6 +292,13 @@
    "fieldname": "display_discount_amount",
    "fieldtype": "Check",
    "label": "Display Discount Amount"
+  },
+  {
+   "default": "0",
+   "description": "Show item variants directly in the item grid instead of their template items. When disabled, template items are shown and variants are selected via a variant selector.",
+   "fieldname": "show_variants_as_items",
+   "fieldtype": "Check",
+   "label": "Show Variants as Items"
   },
   {
    "collapsible": 1,


### PR DESCRIPTION
## Summary
- Adds a new **Show Variants as Items** checkbox in POS Settings that displays individual variant items directly in the item grid instead of template items
- When enabled, variants appear with their attribute labels (e.g. "Red / Large") and correct prices; template items are hidden from the grid
- When disabled (default), existing behavior is preserved — templates are shown and variants are selected via the variant selector dialog

## Changes
- **POS Settings doctype**: New `show_variants_as_items` Check field
- **Backend (`items.py`)**: `get_items`, `get_items_bulk`, `get_items_count` accept `show_variants_as_items` param; `_build_item_base_conditions` gains `exclude_templates` filter; fixed pricing fallback for items with NULL UOM price
- **Frontend (`itemSearch.js`)**: Passes `show_variants_as_items` flag to all API calls; removed old per-template variant fetching (`cacheVariantsForTemplates`) in favor of unified bulk caching
- **Web Worker (`offline.worker.js`)**: New `shouldShowItem()` display filter; `SET_SHOW_VARIANTS_AS_ITEMS` message handler with cache invalidation
- **Worker Client**: New `setShowVariantsAsItems()` method
- **IndexedDB schema**: Added `has_variants` index for efficient template filtering
- **ItemsSelector.vue**: Renders variant attribute labels below item name

## Test plan
- [ ] Enable "Show Variants as Items" in POS Settings → verify variants appear in grid with attribute labels, templates are hidden
- [ ] Disable the setting → verify templates appear, variants are hidden from browse
- [ ] Test offline mode in both modes — items should load correctly from cache
- [ ] Verify barcode scanning still finds variant items regardless of setting
- [ ] Check that item prices display correctly for variants (including items with NULL UOM prices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)