### PR TITLE
fix: deduplicate free items and normalize styling

### DIFF
--- a/POS/src/components/sale/PaymentDialog.vue
+++ b/POS/src/components/sale/PaymentDialog.vue
@@ -276,12 +276,12 @@
 							<div
 								v-for="(item, index) in items"
 								:key="index"
-								class="px-3 py-2 hover:bg-gray-50 flex flex-col gap-1"
+								:class="['px-3 py-2 flex flex-col gap-1', item.is_free_item ? 'bg-green-50' : 'hover:bg-gray-50']"
 							>
 								<!-- Main Item -->
-								<div :class="['flex items-start justify-between gap-2', item.is_free_item ? 'bg-green-50 px-2 py-1 rounded border border-green-100' : '']">
+								<div class="flex items-start justify-between gap-2">
 									<div class="flex-1 min-w-0 text-start">
-										<div :class="['font-medium text-sm truncate', item.is_free_item ? 'text-green-700' : 'text-gray-900']">{{ item.item_name || item.item_code }}<span v-if="item.is_free_item" class="text-[10px] font-bold"> ({{ __('Free') }})</span></div>
+										<div :class="['font-medium text-sm truncate', item.is_free_item ? 'text-green-700' : 'text-gray-900']">{{ item.item_name || item.item_code }}<span v-if="item.is_free_item" class="text-xs font-bold"> ({{ __('Free') }})</span></div>
 										<div class="text-xs text-gray-500 mt-0.5">
 											{{ formatCurrency(item.rate || item.price_list_rate) }} × {{ item.qty || item.quantity }}
 										</div>

--- a/pos_next/api/invoices.py
+++ b/pos_next/api/invoices.py
@@ -2654,7 +2654,12 @@ def apply_offers(invoice_data, selected_offers=None):
             return {"items": items}
 
         applied_rules = set()
-        free_items = []
+        # Deduplicate free items using a dict keyed by (item_code, pricing_rule).
+        # ERPNext's apply_pricing_rule() returns one result per cart item and for
+        # mixed_conditions rules attaches the same free_item_data to every matching
+        # item's result. ERPNext's own apply_pricing_rule_for_free_items() deduplicates
+        # the same way: {(item_code, pricing_rules): data for data in free_item_data}.
+        free_items_map = {}
 
         for result, item_index in zip(pricing_results, index_map):
             if not result:
@@ -2770,11 +2775,11 @@ def apply_offers(invoice_data, selected_offers=None):
                 free_item_doc.applied_promotional_scheme = rule_map[
                     rule_name
                 ].promotional_scheme
-                free_items.append(free_item_doc)
+                free_items_map[(free_item.get("item_code"), rule_name)] = free_item_doc
 
         return {
             "items": [dict(item) for item in prepared_items],
-            "free_items": [dict(item) for item in free_items],
+            "free_items": [dict(item) for item in free_items_map.values()],
             "applied_pricing_rules": sorted(applied_rules),
         }
     except Exception as e:


### PR DESCRIPTION
## Summary
- **Backend**: Deduplicate free items in `apply_offers()` using a dict keyed by `(item_code, pricing_rule)`, matching ERPNext's own dedup pattern. Fixes duplicate free item rows when mixed_conditions pricing rules match multiple cart items.
- **Frontend**: Normalize free item row sizing in payment dialog — same padding as regular items with green background instead of a smaller inset box.

## Test plan
- [ ] Add 2+ items that trigger a mixed_conditions promotional scheme with a different-product free item
- [ ] Verify only 1 free item row appears in the cart and payment dialog
- [ ] Verify free item row in payment dialog is the same size as regular items with green background