### PR TITLE
feat: require manual entry of actual closing amounts

### DIFF
--- a/POS/src/components/ShiftClosingDialog.vue
+++ b/POS/src/components/ShiftClosingDialog.vue
@@ -595,9 +595,9 @@ async function loadClosingData() {
 			data.payment_reconciliation = data.payment_reconciliation.map((payment) =>
 				reactive({
 					...payment,
-					closing_amount:
-						payment.closing_amount ?? payment.expected_amount ?? 0,
+					closing_amount: payment.closing_amount ?? null,
 					difference: 0,
+					_touched: false,
 				}),
 			)
 
@@ -628,6 +628,7 @@ function calculateDifference(payment) {
 // New function to handle closing amount updates with proper reactivity
 function updateClosingAmount(payment, value) {
 	payment.closing_amount = value
+	payment._touched = true
 	calculateDifference(payment)
 }
 
@@ -635,9 +636,10 @@ const canSubmit = computed(() => {
 	if (!closingData.value || !closingData.value.payment_reconciliation)
 		return false
 
-	// Check if all closing amounts are filled
+	// Check if all closing amounts have been manually entered
 	return closingData.value.payment_reconciliation.every(
 		(payment) =>
+			payment._touched &&
 			payment.closing_amount !== null &&
 			payment.closing_amount !== undefined &&
 			payment.closing_amount !== "",


### PR DESCRIPTION
## Summary
- Closing amounts are no longer pre-filled with expected values when closing a POS shift
- Cashiers must manually enter the actual counted amount for each payment method
- The "Close Shift" button stays disabled until all amounts are entered

Closes #156

## Test plan
- [ ] Open POS, start a shift, make a sale, then click Close Shift
- [ ] Verify all "Actual Amount" fields are empty (not pre-filled)
- [ ] Verify the "Close Shift" button is disabled with "Please enter all closing amounts" warning
- [ ] Enter amounts for all payment methods and verify the button becomes enabled
- [ ] Submit and verify the shift closes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)