### PR TITLE
fix: initialize default customer and state on shift reopen

### DIFF
--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -1666,14 +1666,39 @@ onUnmounted(() => {
 // Handlers
 async function handleShiftOpened() {
 	uiStore.showOpenShiftDialog = false;
-	if (shiftStore.currentProfile) {
-		cartStore.posProfile = shiftStore.profileName;
-		cartStore.posOpeningShift = shiftStore.currentShift?.name;
-		// Load POS Settings first to get tax_inclusive setting
-		await posSettingsStore.loadSettings(shiftStore.profileName);
-		// Load tax rules with tax_inclusive setting
-		await cartStore.loadTaxRules(shiftStore.profileName, posSettingsStore.settings);
+	if (!shiftStore.currentProfile) return;
+
+	cartStore.posProfile = shiftStore.profileName;
+	cartStore.posOpeningShift = shiftStore.currentShift?.name;
+
+	// Set warehouse context early (synchronous, no API call)
+	if (shiftStore.profileWarehouse) {
+		stockStore.setWarehouse(shiftStore.profileWarehouse);
 	}
+
+	// Mirror initPOS: fire independent operations in parallel while settings load
+	const settingsPromise = posSettingsStore.loadSettings(shiftStore.profileName);
+
+	const backgroundOps = Promise.allSettled([
+		cartStore.setDefaultCustomer(),
+		offlineStore.isOffline
+			? offlineStore.checkOfflineCacheAvailability()
+			: offlineStore.preloadDataForOffline(shiftStore.currentProfile),
+		draftsStore.updateDraftsCount(),
+	]);
+
+	// Wait for settings (required for tax rules) + all background ops
+	const [settingsResult] = await Promise.allSettled([settingsPromise, backgroundOps]);
+
+	if (settingsResult.status === "rejected") {
+		log.error("Failed to load POS settings:", settingsResult.reason);
+		return;
+	}
+
+	// Load tax rules (depends on settings being loaded)
+	await cartStore.loadTaxRules(shiftStore.profileName, posSettingsStore.settings);
+
+	_initializedProfile = shiftStore.profileName;
 	showSuccess(__("You can now start making sales"));
 }
 


### PR DESCRIPTION
## Summary
- Fixed bug where closing a shift and opening a new one without page reload caused the default customer not to load and the app to keep loading
- `handleShiftOpened()` now mirrors the `initPOS()` parallel execution pattern — loads settings, default customer, warehouse, offline cache, and drafts count concurrently
- Added error handling for settings load failure and profile tracking via `_initializedProfile`

## Test plan
- [ ] Open POS, close the shift via the Close Shift dialog
- [ ] Open a new shift without reloading the page
- [ ] Verify "Walk-In Customer" (default customer) appears in the cart
- [ ] Verify items load correctly and the app is fully functional
- [ ] Verify offline cache is preloaded for the new shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)