### PR TITLE
fix: enforce stock validation across all cart entry paths

### DIFF
--- a/POS/src/components/sale/ItemsSelector.vue
+++ b/POS/src/components/sale/ItemsSelector.vue
@@ -734,6 +734,7 @@ import {
 	runWhenIdle
 } from "@/utils/lowEndOptimizations"
 import { performanceConfig } from "@/utils/performanceConfig"
+import { shouldValidateItemStock } from "@/utils/stockValidator"
 
 const props = defineProps({
 	posProfile: String,
@@ -1082,16 +1083,13 @@ function clearLongPress() {
 function selectItem(item, autoAdd = false) {
 	if (!item) return false
 
-	// Skip stock validation for: template items (no stock), serial items, batch items (they have own validation)
-	const skipValidation = item.has_variants || item.has_serial_no || item.has_batch_no
-	const isStockTracked = item.is_stock_item || item.is_bundle
-	const qty = Math.floor(item.actual_qty ?? item.stock_qty ?? 0)
-
-	if (!skipValidation && isStockTracked && qty <= 0 && settingsStore.shouldEnforceStockValidation()) {
-		showError(item.is_bundle
-			? __('"{0}" cannot be added to cart. Bundle is out of stock. Allow Negative Stock is disabled.', [item.item_name])
-			: __('"{0}" cannot be added to cart. Item is out of stock. Allow Negative Stock is disabled.', [item.item_name]))
-		return false
+	// Early out-of-stock guard — full qty validation happens in cartStore.addItem()
+	if (!item.has_variants && settingsStore.shouldEnforceStockValidation() && shouldValidateItemStock(item)) {
+		const qty = item.actual_qty ?? item.stock_qty ?? 0
+		if (qty <= 0) {
+			showError(__('"{0}" is out of stock in warehouse "{1}".', [item.item_name, item.warehouse || '']))
+			return false
+		}
 	}
 
 	emit("item-selected", item, autoAdd)

--- a/POS/src/composables/useInvoice.js
+++ b/POS/src/composables/useInvoice.js
@@ -288,6 +288,11 @@ export function useInvoice() {
 				brand: item.brand,
 				// Resolved barcode flag - prevents editing qty/uom/rate for weighted/priced barcodes
 				is_resolved_barcode: item.is_resolved_barcode || false,
+				// Stock validation fields — needed for qty increase checks in cart
+				actual_qty: item.actual_qty ?? 0,
+				is_stock_item: item.is_stock_item ?? 1,
+				is_bundle: item.is_bundle || false,
+				allow_negative_stock: item.allow_negative_stock || 0,
 			}
 			invoiceItems.value.push(newItem)
 			// Recalculate the newly added item to apply taxes

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -1021,6 +1021,7 @@ import { usePOSShiftStore } from "@/stores/posShift";
 import { usePOSSyncStore } from "@/stores/posSync";
 import { usePOSUIStore } from "@/stores/posUI";
 import { logger } from "@/utils/logger";
+import { shouldValidateItemStock } from "@/utils/stockValidator";
 
 // Initialize stores
 const cartStore = usePOSCartStore();
@@ -1808,31 +1809,18 @@ function handleItemSelected(item, autoAdd = false) {
 		return;
 	}
 
-	// Check stock availability first (before any dialogs)
-	// Skip validation for:
-	// - batch/serial items (they have their own validation in the dialog)
-	// - template items with variants (variants carry their own stock)
-	// Product Bundles have calculated stock based on component availability
-	if (
-		settingsStore.shouldEnforceStockValidation() &&
-		(item.is_stock_item || item.is_bundle) &&
-		!item.has_serial_no &&
-		!item.has_batch_no &&
-		!item.has_variants
-	) {
-		const actualQty = Math.floor(item.actual_qty ?? item.stock_qty ?? 0);
-
+	// Early out-of-stock guard — prevent opening dialogs for zero-stock items
+	// Full qty validation happens in cartStore.addItem()
+	if (!item.has_variants && settingsStore.shouldEnforceStockValidation() && shouldValidateItemStock(item)) {
+		const actualQty = item.actual_qty ?? item.stock_qty ?? 0;
 		if (actualQty <= 0) {
-			showError(
-				item.is_bundle
-					? __(
-							'"{0}" cannot be added to cart. Bundle is out of stock. Allow Negative Stock is disabled.',
-							[item.item_name]
-					  )
-					: __(
-							'"{0}" cannot be added to cart. Item is out of stock. Allow Negative Stock is disabled.',
-							[item.item_name]
-					  )
+			uiStore.showError(
+				__("Insufficient Stock"),
+				__('"{0}" is out of stock in warehouse "{1}".', [
+					item.item_name,
+					item.warehouse || shiftStore.profileWarehouse,
+				]),
+				__("Item: {0}", [item.item_code])
 			);
 			return;
 		}
@@ -2116,17 +2104,18 @@ async function handleOptionSelected(option) {
 		if (option.type === "variant") {
 			const variant = option.data;
 
-			// Stock validation for variants (same as regular items)
-			if (
-				settingsStore.shouldEnforceStockValidation() &&
-				variant.is_stock_item &&
-				!variant.has_serial_no &&
-				!variant.has_batch_no
-			) {
-				const actualQty = Math.floor(variant.actual_qty ?? 0);
+			// Early out-of-stock guard for variants
+			// Full qty validation happens in cartStore.addItem()
+			if (settingsStore.shouldEnforceStockValidation() && shouldValidateItemStock(variant)) {
+				const actualQty = variant.actual_qty ?? 0;
 				if (actualQty <= 0) {
-					showError(
-						__('"{0}" cannot be added to cart. Item is out of stock. Allow Negative Stock is disabled.', [variant.item_name])
+					uiStore.showError(
+						__("Insufficient Stock"),
+						__('"{0}" is out of stock in warehouse "{1}".', [
+							variant.item_name,
+							variant.warehouse || shiftStore.profileWarehouse,
+						]),
+						__("Item: {0}", [variant.item_code])
 					);
 					return;
 				}

--- a/POS/src/stores/posCart.js
+++ b/POS/src/stores/posCart.js
@@ -3,8 +3,8 @@ import { usePOSOffersStore } from "@/stores/posOffers"
 import { usePOSSettingsStore } from "@/stores/posSettings"
 import { parseError } from "@/utils/errorHandler"
 import {
+	shouldValidateItemStock,
 	checkStockAvailability,
-	formatStockError,
 } from "@/utils/stockValidator"
 import { offlineState } from "@/utils/offline/offlineState"
 import { useToast } from "@/composables/useToast"
@@ -95,7 +95,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		isSubmitting,
 		addItem: addItemToInvoice,
 		removeItem,
-		updateItemQuantity,
+		updateItemQuantity: baseUpdateItemQuantity,
 		submitInvoice: baseSubmitInvoice,
 		clearCart: clearInvoiceCart,
 		loadTaxRules,
@@ -172,48 +172,49 @@ export const usePOSCartStore = defineStore("posCart", () => {
 	const hasCustomer = computed(() => !!customer.value)
 
 	// Actions
-	function addItem(item, qty = 1, autoAdd = false, currentProfile = null) {
-		// Check stock availability before adding to cart
-		// Skip validation for batch/serial items - they have their own validation in the dialog
-		// Check for stock items AND Product Bundles (bundles now have calculated stock)
-		// Also check items with actual_qty defined (catches misconfigured items)
-
-		// Determine if this item should be validated for stock
-		// Include: stock items, bundles, OR items with actual_qty defined (catches misconfigured items)
-		// CRITICAL: If is_stock_item is explicitly false/0, we must skip validation even if actual_qty exists
-		const isNonStockItem = item.is_stock_item === 0 || item.is_stock_item === false
-		const hasActualQty = item.actual_qty !== undefined || item.stock_qty !== undefined
-		const shouldValidateStock = !isNonStockItem && (item.is_stock_item || item.is_bundle || hasActualQty)
-
-		if (currentProfile && !autoAdd && settingsStore.shouldEnforceStockValidation() && shouldValidateStock && !item.has_serial_no && !item.has_batch_no) {
+	function addItem(item, qty = 1, _autoAdd = false, currentProfile = null) {
+		if (currentProfile && settingsStore.shouldEnforceStockValidation() && shouldValidateItemStock(item)) {
+			// Account for quantity already in the cart for this item
+			const itemUom = item.uom || item.stock_uom
+			const existing = invoiceItems.value.find(
+				(i) => i.item_code === item.item_code && i.uom === itemUom,
+			)
+			const totalQty = (existing ? existing.quantity : 0) + qty
 			const warehouse = item.warehouse || currentProfile.warehouse
-			const actualQty =
-				item.actual_qty !== undefined ? item.actual_qty : item.stock_qty || 0
 
-			if (warehouse && actualQty !== undefined && actualQty !== null) {
-				const stockCheck = checkStockAvailability({
-					itemCode: item.item_code,
-					qty: qty,
-					warehouse: warehouse,
-					actualQty: actualQty,
-				})
-
-				if (!stockCheck.available) {
-					const itemType = item.is_bundle ? "Bundle" : "Item"
-					const errorMsg = formatStockError(
-						item.item_name,
-						qty,
-						stockCheck.actualQty,
-						warehouse,
-					)
-
-					throw new Error(errorMsg.replace("Item", itemType))
-				}
+			const check = checkStockAvailability(item, totalQty, warehouse)
+			if (!check.available) {
+				throw new Error(check.error)
 			}
 		}
 
-		// Add item to cart - no toast notification for performance
 		addItemToInvoice(item, qty)
+	}
+
+	/**
+	 * Update item quantity with stock validation.
+	 * Wraps useInvoice.updateItemQuantity to enforce stock limits
+	 * when the user clicks +/- or types a new quantity.
+	 */
+	function updateItemQuantity(itemCode, quantity, uom = null) {
+		const item = uom
+			? invoiceItems.value.find((i) => i.item_code === itemCode && i.uom === uom)
+			: invoiceItems.value.find((i) => i.item_code === itemCode)
+
+		if (!item) return baseUpdateItemQuantity(itemCode, quantity, uom)
+
+		const newQty = Number.parseFloat(quantity) || 1
+
+		// Only validate when quantity is increasing
+		if (newQty > item.quantity && settingsStore.shouldEnforceStockValidation() && shouldValidateItemStock(item)) {
+			const check = checkStockAvailability(item, newQty)
+			if (!check.available) {
+				showWarning(check.error)
+				return
+			}
+		}
+
+		baseUpdateItemQuantity(itemCode, quantity, uom)
 	}
 
 	function clearCart() {
@@ -1246,6 +1247,15 @@ export const usePOSCartStore = defineStore("posCart", () => {
 				} catch {
 					// Fallback: just change UOM without rate update
 					cartItem.uom = updates.uom
+				}
+			}
+
+			// Validate stock if quantity is being increased
+			if (updates.quantity !== undefined && updates.quantity > cartItem.quantity
+				&& settingsStore.shouldEnforceStockValidation() && shouldValidateItemStock(cartItem)) {
+				const check = checkStockAvailability(cartItem, updates.quantity)
+				if (!check.available) {
+					throw new Error(check.error)
 				}
 			}
 

--- a/POS/src/utils/stockValidator.js
+++ b/POS/src/utils/stockValidator.js
@@ -1,39 +1,54 @@
 /**
  * Stock Validation Utility
- * Checks item stock availability before adding to cart
+ * Single source of truth for stock availability checks.
  */
 
 import { call } from "frappe-ui"
 
 /**
- * Check if item has sufficient stock
- * @param {Object} params - Validation parameters
- * @param {string} params.itemCode - Item code to check
- * @param {number} params.qty - Quantity requested
- * @param {string} params.warehouse - Warehouse to check
- * @param {number} params.actualQty - Actual available quantity from item
- * @returns {Object} - { available: boolean, actualQty: number }
+ * Determine whether an item requires stock validation.
+ * Centralises the skip-logic so every call site uses the same rules.
+ *
+ * @param {Object} item - Item object (from search API or cart)
+ * @returns {boolean} true when stock should be enforced for this item
  */
-export function checkStockAvailability({
-	itemCode,
-	qty,
-	warehouse,
-	actualQty = null,
-}) {
-	// If actual quantity is provided (from item data), use it
-	if (actualQty !== null && actualQty !== undefined) {
-		const available = actualQty >= qty
-		return {
-			available,
-			actualQty: actualQty,
-		}
+export function shouldValidateItemStock(item) {
+	if (!item) return false
+
+	// Non-stock items are never validated
+	if (item.is_stock_item === 0 || item.is_stock_item === false) return false
+
+	// Item-level allow_negative_stock bypasses validation
+	if (item.allow_negative_stock === 1 || item.allow_negative_stock === true) return false
+
+	// Batch / serial items have their own dialog-level validation
+	if (item.has_serial_no || item.has_batch_no) return false
+
+	// Must be a stock item or bundle (or have stock data)
+	const hasStockData = item.actual_qty !== undefined || item.stock_qty !== undefined
+	return !!(item.is_stock_item || item.is_bundle || hasStockData)
+}
+
+/**
+ * Check if the requested quantity exceeds available stock.
+ *
+ * @param {Object}  item       - Item with actual_qty / stock_qty
+ * @param {number}  requestedQty - Total quantity to validate against
+ * @param {string}  [warehouse]  - Warehouse name (for error message)
+ * @returns {{ available: boolean, actualQty: number, error: string|null }}
+ */
+export function checkStockAvailability(item, requestedQty, warehouse) {
+	const actualQty = item.actual_qty ?? item.stock_qty ?? 0
+	const wh = warehouse || item.warehouse || ''
+
+	if (actualQty >= requestedQty) {
+		return { available: true, actualQty, error: null }
 	}
 
-	// If no stock data available, allow the transaction
-	// Backend will validate on submit anyway
 	return {
-		available: true,
-		actualQty: qty,
+		available: false,
+		actualQty,
+		error: formatStockError(item.item_name, requestedQty, actualQty, wh),
 	}
 }
 
@@ -70,52 +85,11 @@ export async function getItemStock(itemCode, warehouse) {
  * @returns {string} - Formatted error message
  */
 export function formatStockError(itemName, requested, available, warehouse) {
+	if (available <= 0) {
+		return `"${itemName}" is out of stock in warehouse "${warehouse}".`
+	}
+
 	const unit = requested === 1 ? "unit" : "units"
 	const availableUnit = available === 1 ? "unit" : "units"
-
-	if (available === 0) {
-		return `"${itemName}" is out of stock in warehouse "${warehouse}".\n\nPlease check another warehouse or restock this item.`
-	}
-
-	return `Not enough stock for "${itemName}".\n\nYou requested ${requested} ${unit}, but only ${available} ${availableUnit} available in "${warehouse}".\n\nPlease reduce the quantity or check another warehouse.`
-}
-
-/**
- * Validate cart items stock before submission
- * @param {Array} items - Cart items
- * @param {string} warehouse - Warehouse to check
- * @returns {Promise<Object>} - { valid: boolean, errors: Array }
- */
-export async function validateCartStock(items, warehouse) {
-	const errors = []
-
-	for (const item of items) {
-		const result = await checkStockAvailability({
-			itemCode: item.item_code,
-			qty: item.quantity,
-			warehouse: item.warehouse || warehouse,
-			uom: item.uom,
-		})
-
-		if (!result.available) {
-			errors.push({
-				itemCode: item.item_code,
-				itemName: item.item_name,
-				requested: item.quantity,
-				available: result.actualQty,
-				warehouse: item.warehouse || warehouse,
-				message: formatStockError(
-					item.item_name,
-					item.quantity,
-					result.actualQty,
-					item.warehouse || warehouse,
-				),
-			})
-		}
-	}
-
-	return {
-		valid: errors.length === 0,
-		errors,
-	}
+	return `Not enough stock for "${itemName}".\n\nYou requested ${requested} ${unit}, but only ${available} ${availableUnit} available in "${warehouse}".`
 }

--- a/pos_next/api/invoices.py
+++ b/pos_next/api/invoices.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 import json
+from functools import lru_cache
 import frappe
 from frappe import _
 from frappe.utils import flt, cint, nowdate, nowtime, get_datetime, cstr
@@ -361,7 +362,11 @@ def _get_available_stock(item):
 
 
 def _collect_stock_errors(items):
-    """Return list of items exceeding available stock."""
+    """Return list of items exceeding available stock.
+
+    Respects per-item allow_negative_stock if the field exists on Item.
+    """
+    allowed_items = _get_item_negative_stock_allow_set(items)
     errors = []
     for d in items:
         if flt(d.get("qty")) < 0:
@@ -374,6 +379,8 @@ def _collect_stock_errors(items):
         )
 
         if requested > available:
+            if d.get("item_code") in allowed_items:
+                continue
             errors.append(
                 {
                     "item_code": d.get("item_code"),
@@ -384,6 +391,31 @@ def _collect_stock_errors(items):
             )
 
     return errors
+
+
+@lru_cache(maxsize=1)
+def _item_has_allow_negative_stock_field():
+    """Check whether Item doctype has an allow_negative_stock field."""
+    try:
+        return frappe.get_meta("Item").has_field("allow_negative_stock")
+    except Exception:
+        return False
+
+
+def _get_item_negative_stock_allow_set(items):
+    """Return set of item codes that allow negative stock at Item level."""
+    if not items or not _item_has_allow_negative_stock_field():
+        return set()
+
+    item_codes = list({d.get("item_code") for d in items if d.get("item_code")})
+    if not item_codes:
+        return set()
+
+    return set(frappe.get_all(
+        "Item",
+        filters={"name": ["in", item_codes], "allow_negative_stock": 1},
+        pluck="name",
+    ) or [])
 
 
 def _should_block(pos_profile):
@@ -875,6 +907,26 @@ def update_invoice(data):
                 # Store coupon code on invoice for tracking
                 invoice_doc.coupon_code = coupon_code
 
+        # Validate stock availability before saving draft
+        # is_stock_item may not be set on unsaved doc items (frontend doesn't send it),
+        # so look it up from Item master
+        if not invoice_doc.get("is_return") and _should_block(pos_profile):
+            item_codes = list({d.item_code for d in invoice_doc.items if d.get("item_code")})
+            if item_codes:
+                stock_item_set = set(frappe.get_all(
+                    "Item",
+                    filters={"name": ["in", item_codes], "is_stock_item": 1},
+                    pluck="name"
+                ))
+                stock_items = [
+                    d.as_dict() for d in invoice_doc.items
+                    if d.get("item_code") in stock_item_set
+                ]
+                if stock_items:
+                    errors = _collect_stock_errors(stock_items)
+                    if errors:
+                        frappe.throw(frappe.as_json({"errors": errors}), frappe.ValidationError)
+
         # Save as draft
         invoice_doc.flags.ignore_permissions = True
         frappe.flags.ignore_account_permission = True
@@ -1296,20 +1348,10 @@ def submit_invoice(invoice=None, data=None):
                         "POS Write-Off Error"
                     )
 
-        # Check if POS Settings allows negative stock
-        pos_settings_allow_negative = False
-        if pos_profile:
-            pos_settings_allow_negative = cint(
-                frappe.db.get_value(
-                    "POS Settings",
-                    {"pos_profile": pos_profile},
-                    "allow_negative_stock"
-                ) or 0
-            )
-
-        # Validate stock availability only if negative stock is not allowed
-        if not pos_settings_allow_negative:
-            _validate_stock_on_invoice(invoice_doc)
+        # Validate stock availability before submission
+        # _validate_stock_on_invoice checks _should_block internally
+        # (global Stock Settings, POS Settings, and POS Profile flags)
+        _validate_stock_on_invoice(invoice_doc)
 
         # Save before submit
         invoice_doc.flags.ignore_permissions = True


### PR DESCRIPTION
## Summary

- **Fixed barcode scan bypassing stock validation** — the `!autoAdd` condition in `posCart.addItem()` was skipping stock checks entirely when items were added via barcode scan
- **Added cart quantity accumulation** — stock validation now checks `existingQty + newQty` against available stock, preventing incremental bypass
- **Centralized stock skip-logic** into `shouldValidateItemStock()` utility — single source of truth used by all frontend validation points (grid click, barcode scan, qty buttons, edit dialog)
- **Added backend defense-in-depth** — draft save (`update_invoice`) now validates stock before persisting, and submit validates per-item `allow_negative_stock` overrides
- **Preserved correct behavior** for non-stock items, serial/batch items (dialog-level validation), and items with `allow_negative_stock` flag

## Changes

| File | What changed |
|------|-------------|
| `POS/src/utils/stockValidator.js` | Added `shouldValidateItemStock()`, simplified `checkStockAvailability()`, removed dead `validateCartStock()` |
| `POS/src/stores/posCart.js` | Removed `!autoAdd` bypass, added cart accumulation logic, new `updateItemQuantity()` with stock check |
| `POS/src/pages/POSSale.vue` | Replaced inline 12-line conditions with `shouldValidateItemStock()` calls |
| `POS/src/components/sale/ItemsSelector.vue` | Replaced inline 8-line condition with `shouldValidateItemStock()` call |
| `POS/src/composables/useInvoice.js` | Added stock fields (`actual_qty`, `is_stock_item`, `allow_negative_stock`) to cart item object |
| `pos_next/api/invoices.py` | Added draft-save stock validation, per-item `allow_negative_stock` support in submit validation |

## Test Plan

Tested manually on live POS (`http://localhost:8080/pos/`) with site `nexus.local`:

- [x] **Regular stock item** — grid click blocked when qty exceeds stock
- [x] **Qty increase via +/- buttons** — blocked at stock limit with error
- [x] **Barcode scan** — blocked with "Insufficient Stock" dialog when cart already at max
- [x] **Cart accumulation** — existing 5 in cart + 1 scan = 6 > 5 available → blocked
- [x] **Non-stock item** (Gift Card) — added to cart without stock error
- [x] **Serial item** (Smartphone Pro 128GB) — opens serial number dialog, no false stock error
- [x] **Batch item** (Orange Juice 250ml) — opens batch number dialog, no false stock error

🤖 Generated with [Claude Code](https://claude.com/claude-code)