### PR TITLE
fix: POS reports double-counting and Payments report redesign

### DIFF
--- a/pos_next/pos_next/report/cashier_performance_report/cashier_performance_report.py
+++ b/pos_next/pos_next/report/cashier_performance_report/cashier_performance_report.py
@@ -34,24 +34,24 @@ def get_columns():
 
 
 def get_data(filters):
-	"""Get cashier performance data"""
+	"""Get cashier performance data.
+
+	Uses two separate queries to avoid cartesian-product inflation:
+	1. Invoice aggregates grouped by cashier (owner)
+	2. Shift count from POS Closing Shift via Sales Invoice Reference
+	"""
 	conditions = get_conditions(filters)
 
+	# Query 1: Invoice aggregates — no JOIN to shifts, so no duplication
 	query = """
 		SELECT
 			si.owner as cashier,
-			COUNT(DISTINCT pcs.name) as shifts_worked,
 			COALESCE(SUM(CASE WHEN si.is_return = 0 THEN si.grand_total ELSE 0 END), 0) as total_sales,
 			COUNT(CASE WHEN si.is_return = 0 THEN si.name END) as invoice_count,
 			COALESCE(SUM(CASE WHEN si.is_return = 0 THEN si.discount_amount ELSE 0 END), 0) as total_discounts,
 			COUNT(CASE WHEN si.is_return = 1 THEN si.name END) as return_count,
 			COALESCE(SUM(CASE WHEN si.is_return = 1 THEN ABS(si.grand_total) ELSE 0 END), 0) as return_amount
 		FROM `tabSales Invoice` si
-		LEFT JOIN `tabPOS Closing Shift` pcs ON (
-			pcs.user = si.owner
-			AND pcs.pos_profile = si.pos_profile
-			AND pcs.docstatus = 1
-		)
 		WHERE si.docstatus = 1
 		AND si.is_pos = 1
 		{conditions}
@@ -61,8 +61,25 @@ def get_data(filters):
 
 	data = frappe.db.sql(query, filters, as_dict=1)
 
+	# Query 2: Shifts worked per cashier via Sales Invoice Reference
+	# Count distinct closing shifts that contain at least one invoice owned by this cashier
+	shift_conditions = _build_shift_conditions(filters)
+	shift_query = """
+		SELECT
+			pcs.user as cashier,
+			COUNT(DISTINCT pcs.name) as shifts_worked
+		FROM `tabPOS Closing Shift` pcs
+		WHERE pcs.docstatus = 1
+		{conditions}
+		GROUP BY pcs.user
+	""".format(conditions=shift_conditions)
+
+	shift_data = frappe.db.sql(shift_query, filters, as_dict=1)
+	shift_map = {row.cashier: row.shifts_worked for row in shift_data}
+
 	# Get cashier names and calculate derived metrics
 	for row in data:
+		row.shifts_worked = shift_map.get(row.cashier, 0)
 		row.cashier_name = frappe.db.get_value("User", row.cashier, "full_name")
 
 		# Calculate derived metrics
@@ -134,7 +151,7 @@ def get_data(filters):
 
 
 def get_conditions(filters):
-	"""Build WHERE conditions from filters"""
+	"""Build WHERE conditions for the invoice query"""
 	conditions = []
 
 	if filters.get("from_date"):
@@ -148,6 +165,35 @@ def get_conditions(filters):
 
 	if filters.get("cashier"):
 		conditions.append("si.owner = %(cashier)s")
+
+	if filters.get("shift"):
+		conditions.append("""
+			EXISTS (
+				SELECT 1 FROM `tabSales Invoice Reference` sir
+				WHERE sir.sales_invoice = si.name
+				AND sir.parent = %(shift)s
+				AND sir.parenttype = 'POS Closing Shift'
+			)
+		""")
+
+	return "AND " + " AND ".join(conditions) if conditions else ""
+
+
+def _build_shift_conditions(filters):
+	"""Build WHERE conditions for the shift count query"""
+	conditions = []
+
+	if filters.get("from_date"):
+		conditions.append("pcs.period_start_date >= %(from_date)s")
+
+	if filters.get("to_date"):
+		conditions.append("pcs.period_end_date <= %(to_date)s")
+
+	if filters.get("pos_profile"):
+		conditions.append("pcs.pos_profile = %(pos_profile)s")
+
+	if filters.get("cashier"):
+		conditions.append("pcs.user = %(cashier)s")
 
 	if filters.get("shift"):
 		conditions.append("pcs.name = %(shift)s")

--- a/pos_next/pos_next/report/inventory_impact_and_fast_movers_report/inventory_impact_and_fast_movers_report.py
+++ b/pos_next/pos_next/report/inventory_impact_and_fast_movers_report/inventory_impact_and_fast_movers_report.py
@@ -94,7 +94,11 @@ def get_columns():
 
 
 def get_data(filters):
-	"""Get inventory impact and fast movers data"""
+	"""Get inventory impact and fast movers data.
+
+	Stock is read from the POS Profile's warehouse so that depletion
+	metrics reflect the actual location that serves this POS counter.
+	"""
 	conditions = get_conditions(filters)
 
 	# Get warehouse from POS Profile if provided
@@ -141,22 +145,15 @@ def get_data(filters):
 
 	data = frappe.db.sql(query, filters, as_dict=1)
 
-	# Get current stock levels and calculate metrics
+	if not data:
+		return []
+
+	# Batch-fetch current stock levels (single query instead of N+1)
+	item_codes = [row.item_code for row in data]
+	stock_map = _get_stock_map(item_codes, warehouse)
+
 	for row in data:
-		# Get current stock
-		if warehouse:
-			row.current_stock = flt(frappe.db.get_value(
-				"Bin",
-				{"item_code": row.item_code, "warehouse": warehouse},
-				"actual_qty"
-			) or 0, 2)
-		else:
-			# Sum across all warehouses if no specific warehouse
-			row.current_stock = flt(frappe.db.sql("""
-				SELECT SUM(actual_qty)
-				FROM `tabBin`
-				WHERE item_code = %s
-			""", row.item_code)[0][0] or 0, 2)
+		row.current_stock = flt(stock_map.get(row.item_code, 0), 2)
 
 		# Calculate stock depletion rate (qty sold per day)
 		row.stock_depletion_rate = flt(row.qty_sold / date_range_days, 2)
@@ -203,6 +200,36 @@ def get_data(filters):
 	return sorted_data
 
 
+def _get_stock_map(item_codes, warehouse=None):
+	"""Fetch current stock for all items in a single query.
+
+	Returns dict {item_code: actual_qty}.
+	When warehouse is specified, returns stock for that warehouse only.
+	Otherwise sums across all warehouses.
+	"""
+	if not item_codes:
+		return {}
+
+	placeholders = ", ".join(["%s"] * len(item_codes))
+
+	if warehouse:
+		rows = frappe.db.sql("""
+			SELECT item_code, actual_qty
+			FROM `tabBin`
+			WHERE item_code IN ({placeholders})
+			AND warehouse = %s
+		""".format(placeholders=placeholders), item_codes + [warehouse], as_dict=1)
+	else:
+		rows = frappe.db.sql("""
+			SELECT item_code, SUM(actual_qty) as actual_qty
+			FROM `tabBin`
+			WHERE item_code IN ({placeholders})
+			GROUP BY item_code
+		""".format(placeholders=placeholders), item_codes, as_dict=1)
+
+	return {row.item_code: flt(row.actual_qty) for row in rows}
+
+
 def get_conditions(filters):
 	"""Build WHERE conditions"""
 	conditions = []
@@ -219,12 +246,10 @@ def get_conditions(filters):
 	if filters.get("shift"):
 		conditions.append("""
 			EXISTS (
-				SELECT 1 FROM `tabPOS Closing Shift` pcs
-				WHERE pcs.name = %(shift)s
-				AND si.owner = pcs.user
-				AND si.pos_profile = pcs.pos_profile
-				AND si.posting_date >= DATE(pcs.period_start_date)
-				AND si.posting_date <= DATE(pcs.period_end_date)
+				SELECT 1 FROM `tabSales Invoice Reference` sir
+				WHERE sir.sales_invoice = si.name
+				AND sir.parent = %(shift)s
+				AND sir.parenttype = 'POS Closing Shift'
 			)
 		""")
 

--- a/pos_next/pos_next/report/payments_and_cash_control_report/payments_and_cash_control_report.py
+++ b/pos_next/pos_next/report/payments_and_cash_control_report/payments_and_cash_control_report.py
@@ -136,24 +136,24 @@ def get_data(filters):
 			row.status = "↓ Short"
 
 		# Get transaction count for this payment method in this shift
+		# Uses the Sales Invoice Reference child table (pos_transactions) as the
+		# authoritative link between closing shift and its invoices
+		shift_invoices = frappe.get_all(
+			"Sales Invoice Reference",
+			filters={
+				"parent": row.shift,
+				"parenttype": "POS Closing Shift"
+			},
+			pluck="sales_invoice"
+		)
 		row.transaction_count = frappe.db.count(
 			"Sales Invoice Payment",
 			filters={
 				"parenttype": "Sales Invoice",
 				"mode_of_payment": row.payment_method,
-				"parent": ["in", frappe.get_all(
-					"Sales Invoice",
-					filters={
-						"pos_profile": row.pos_profile,
-						"owner": row.cashier,
-						"posting_date": row.posting_date,
-						"docstatus": 1,
-						"is_pos": 1
-					},
-					pluck="name"
-				)]
+				"parent": ["in", shift_invoices]
 			}
-		)
+		) if shift_invoices else 0
 
 	return data
 

--- a/pos_next/pos_next/report/payments_and_cash_control_report/payments_and_cash_control_report.py
+++ b/pos_next/pos_next/report/payments_and_cash_control_report/payments_and_cash_control_report.py
@@ -3,19 +3,22 @@
 
 import frappe
 from frappe import _
-from frappe.utils import flt
+from frappe.utils import flt, time_diff_in_hours, get_datetime
 
 
 def execute(filters=None):
-	columns = get_columns()
-	data = get_data(filters)
-	chart = get_chart_data(data)
+	data, payment_methods = get_data(filters)
+	columns = get_columns(payment_methods)
+	chart = get_chart_data(data, payment_methods)
 	return columns, data, None, chart
 
 
-def get_columns():
-	"""Return columns for the report"""
-	return [
+def get_columns(payment_methods):
+	"""Return columns for the report.
+
+	Generates dynamic columns per payment method found in the data.
+	"""
+	columns = [
 		{
 			"fieldname": "shift",
 			"label": _("Shift"),
@@ -44,52 +47,87 @@ def get_columns():
 			"width": 100
 		},
 		{
-			"fieldname": "payment_method",
-			"label": _("Payment Method"),
-			"fieldtype": "Data",
-			"width": 130
-		},
-		{
-			"fieldname": "expected_amount",
-			"label": _("Expected Amount"),
-			"fieldtype": "Currency",
-			"width": 140
-		},
-		{
-			"fieldname": "actual_amount",
-			"label": _("Actual Amount"),
-			"fieldtype": "Currency",
-			"width": 130
-		},
-		{
-			"fieldname": "difference",
-			"label": _("Difference"),
-			"fieldtype": "Currency",
-			"width": 120
-		},
-		{
-			"fieldname": "variance_percentage",
-			"label": _("Variance %"),
-			"fieldtype": "Percent",
+			"fieldname": "shift_start",
+			"label": _("Shift Start"),
+			"fieldtype": "Time",
 			"width": 100
+		},
+		{
+			"fieldname": "shift_end",
+			"label": _("Shift End"),
+			"fieldtype": "Time",
+			"width": 100
+		},
+		{
+			"fieldname": "shift_hours",
+			"label": _("Shift Hours"),
+			"fieldtype": "Float",
+			"width": 90
+		},
+		{
+			"fieldname": "total_transactions",
+			"label": _("Transactions"),
+			"fieldtype": "Int",
+			"width": 100
+		},
+	]
+
+	# Dynamic columns per payment method
+	for method in payment_methods:
+		safe = method.lower().replace(" ", "_")
+		columns.extend([
+			{
+				"fieldname": f"{safe}_expected",
+				"label": _(f"{method} Expected"),
+				"fieldtype": "Currency",
+				"width": 130
+			},
+			{
+				"fieldname": f"{safe}_closing",
+				"label": _(f"{method} Closing"),
+				"fieldtype": "Currency",
+				"width": 130
+			},
+			{
+				"fieldname": f"{safe}_diff",
+				"label": _(f"{method} Diff"),
+				"fieldtype": "Currency",
+				"width": 110
+			},
+		])
+
+	columns.extend([
+		{
+			"fieldname": "total_expected",
+			"label": _("Total Expected"),
+			"fieldtype": "Currency",
+			"width": 130
+		},
+		{
+			"fieldname": "total_closing",
+			"label": _("Total Closing"),
+			"fieldtype": "Currency",
+			"width": 130
+		},
+		{
+			"fieldname": "total_difference",
+			"label": _("Total Difference"),
+			"fieldtype": "Currency",
+			"width": 130
 		},
 		{
 			"fieldname": "status",
 			"label": _("Status"),
 			"fieldtype": "Data",
-			"width": 100
+			"width": 120
 		},
-		{
-			"fieldname": "transaction_count",
-			"label": _("Transactions"),
-			"fieldtype": "Int",
-			"width": 110
-		}
-	]
+	])
+
+	return columns
 
 
 def get_data(filters):
-	"""Get payment reconciliation data"""
+	"""Get payment reconciliation data — one row per shift."""
 	conditions = get_conditions(filters)
 
 	# Get payment reconciliation details from closing shifts
@@ -99,9 +137,14 @@ def get_data(filters):
 			pcs.pos_profile,
 			pcs.user as cashier,
 			DATE(pcs.period_end_date) as posting_date,
+			TIME(pcs.period_start_date) as shift_start,
+			TIME(pcs.period_end_date) as shift_end,
+			pcs.period_start_date as _shift_start_dt,
+			pcs.period_end_date as _shift_end_dt,
 			pr.mode_of_payment as payment_method,
+			pr.opening_amount,
 			pr.expected_amount,
-			pr.closing_amount as actual_amount,
+			pr.closing_amount,
 			pr.difference
 		FROM
 			`tabPOS Closing Shift` pcs
@@ -114,48 +157,102 @@ def get_data(filters):
 			pcs.period_end_date DESC, pr.mode_of_payment
 	""".format(conditions=conditions)
 
-	data = frappe.db.sql(query, filters, as_dict=1)
+	raw = frappe.db.sql(query, filters, as_dict=1)
 
-	# Calculate variance and status for each payment method
-	for row in data:
-		# Calculate variance percentage
-		if row.expected_amount > 0:
-			row.variance_percentage = flt((row.difference / row.expected_amount) * 100, 2)
-		else:
-			row.variance_percentage = 0
+	if not raw:
+		return [], []
 
-		# Determine status
-		abs_difference = abs(row.difference)
-		if abs_difference == 0:
-			row.status = "✓ Balanced"
-		elif abs_difference <= 10:  # Within 10 currency units
-			row.status = "~ Minor Variance"
-		elif row.difference > 0:
-			row.status = "↑ Over"
-		else:
-			row.status = "↓ Short"
+	# Discover payment methods (ordered by first appearance)
+	payment_methods = list(dict.fromkeys(r.payment_method for r in raw))
 
-		# Get transaction count for this payment method in this shift
-		# Uses the Sales Invoice Reference child table (pos_transactions) as the
-		# authoritative link between closing shift and its invoices
-		shift_invoices = frappe.get_all(
-			"Sales Invoice Reference",
-			filters={
-				"parent": row.shift,
-				"parenttype": "POS Closing Shift"
-			},
-			pluck="sales_invoice"
-		)
-		row.transaction_count = frappe.db.count(
-			"Sales Invoice Payment",
-			filters={
-				"parenttype": "Sales Invoice",
-				"mode_of_payment": row.payment_method,
-				"parent": ["in", shift_invoices]
+	# Batch-fetch transaction counts per shift (total, not per method)
+	transaction_map = _get_transaction_counts(raw)
+
+	# Pivot: group rows by shift into one row each
+	shifts = {}
+	shift_order = []
+	for r in raw:
+		if r.shift not in shifts:
+			shift_order.append(r.shift)
+			# Calculate shift hours
+			if r._shift_start_dt and r._shift_end_dt:
+				shift_hours = flt(time_diff_in_hours(
+					get_datetime(r._shift_end_dt),
+					get_datetime(r._shift_start_dt)
+				), 1)
+			else:
+				shift_hours = 0
+
+			shifts[r.shift] = {
+				"shift": r.shift,
+				"pos_profile": r.pos_profile,
+				"cashier": r.cashier,
+				"posting_date": r.posting_date,
+				"shift_start": r.shift_start,
+				"shift_end": r.shift_end,
+				"shift_hours": shift_hours,
+				"total_transactions": transaction_map.get(r.shift, 0),
+				"total_expected": 0,
+				"total_closing": 0,
+				"total_difference": 0,
 			}
-		) if shift_invoices else 0
 
-	return data
+		row = shifts[r.shift]
+		safe = r.payment_method.lower().replace(" ", "_")
+		row[f"{safe}_expected"] = flt(r.expected_amount, 2)
+		row[f"{safe}_closing"] = flt(r.closing_amount, 2)
+		row[f"{safe}_diff"] = flt(r.difference, 2)
+
+		row["total_expected"] += flt(r.expected_amount, 2)
+		row["total_closing"] += flt(r.closing_amount, 2)
+		row["total_difference"] += flt(r.difference, 2)
+
+	# Build final data list and determine status
+	data = []
+	for shift_name in shift_order:
+		row = shifts[shift_name]
+		row["total_expected"] = flt(row["total_expected"], 2)
+		row["total_closing"] = flt(row["total_closing"], 2)
+		row["total_difference"] = flt(row["total_difference"], 2)
+
+		# Determine status based on total difference
+		abs_diff = abs(row["total_difference"])
+		if abs_diff == 0:
+			row["status"] = "✓ Balanced"
+		elif abs_diff <= 10:
+			row["status"] = "~ Minor Variance"
+		elif row["total_difference"] > 0:
+			row["status"] = "↑ Over"
+		else:
+			row["status"] = "↓ Short"
+
+		data.append(row)
+
+	return data, payment_methods
+
+
+def _get_transaction_counts(data):
+	"""Batch-fetch total transaction counts per shift.
+
+	Counts distinct Sales Invoices in each shift.
+	"""
+	shift_names = list({row.shift for row in data})
+	if not shift_names:
+		return {}
+
+	placeholders = ", ".join(["%s"] * len(shift_names))
+
+	rows = frappe.db.sql("""
+		SELECT
+			sir.parent as shift,
+			COUNT(DISTINCT sir.sales_invoice) as cnt
+		FROM `tabSales Invoice Reference` sir
+		WHERE sir.parenttype = 'POS Closing Shift'
+		AND sir.parent IN ({placeholders})
+		GROUP BY sir.parent
+	""".format(placeholders=placeholders), shift_names, as_dict=1)
+
+	return {r.shift: r.cnt for r in rows}
 
 
 def get_conditions(filters):
@@ -180,28 +277,26 @@ def get_conditions(filters):
 	return " AND " + " AND ".join(conditions) if conditions else ""
 
 
-def get_chart_data(data):
+def get_chart_data(data, payment_methods):
 	"""Generate chart showing payment method breakdown"""
-	if not data:
+	if not data or not payment_methods:
 		return None
 
-	# Aggregate by payment method
-	payment_summary = {}
-	for row in data:
-		method = row.payment_method
-		if method not in payment_summary:
-			payment_summary[method] = 0
-		payment_summary[method] += row.expected_amount
+	# Aggregate expected amounts by payment method across all shifts
+	datasets = []
+	for method in payment_methods:
+		safe = method.lower().replace(" ", "_")
+		values = [flt(row.get(f"{safe}_expected", 0)) for row in data]
+		datasets.append({
+			"name": method,
+			"values": values
+		})
 
 	return {
 		"data": {
-			"labels": list(payment_summary.keys()),
-			"datasets": [
-				{
-					"name": "Total Amount",
-					"values": list(payment_summary.values())
-				}
-			]
+			"labels": [row.get("shift") for row in data],
+			"datasets": datasets
 		},
-		"type": "pie"
+		"type": "bar",
+		"barOptions": {"stacked": True}
 	}

--- a/pos_next/pos_next/report/sales_vs_shifts_report/sales_vs_shifts_report.js
+++ b/pos_next/pos_next/report/sales_vs_shifts_report/sales_vs_shifts_report.js
@@ -150,16 +150,9 @@ frappe.query_reports["Sales vs Shifts Report"] = {
 	// INVOICE MATCHING LOGIC
 	// -------------------------------------------------------------------------
 	//
-	// Invoices are matched to a shift using OR logic:
-	//   1. posa_pos_opening_shift matches the shift's opening reference
-	//   OR
-	//   2. ALL of these match:
-	//      - pos_profile matches
-	//      - owner (cashier) matches
-	//      - posting_date is within shift period
-	//
-	// This ensures invoices are captured even if the opening shift link is
-	// missing, as long as the profile, cashier, and date align.
+	// Invoices are linked to shifts via the Sales Invoice Reference child table
+	// (pos_transactions) on POS Closing Shift. This is the explicit list stored
+	// at shift-close time — the authoritative source, no fuzzy matching.
 	//
 	// =========================================================================
 

--- a/pos_next/pos_next/report/sales_vs_shifts_report/sales_vs_shifts_report.py
+++ b/pos_next/pos_next/report/sales_vs_shifts_report/sales_vs_shifts_report.py
@@ -71,10 +71,9 @@ RATING LABELS
 
 INVOICE MATCHING
 ----------------
-Invoices match a shift when:
-  1. posa_pos_opening_shift = shift.pos_opening_shift
-  OR
-  2. pos_profile AND owner AND posting_date all match the shift
+Invoices are linked to shifts via the `Sales Invoice Reference` child table
+(pos_transactions) on `POS Closing Shift`. This is the explicit list of invoices
+stored at shift-close time — the authoritative source, no fuzzy matching.
 """
 
 import frappe
@@ -638,7 +637,12 @@ def get_shift_data(filters):
 
 
 def fetch_shifts_with_invoices(filters):
-	"""Fetch shifts with aggregated invoice data in a single query"""
+	"""Fetch shifts with aggregated invoice data in a single query.
+
+	Uses the `Sales Invoice Reference` child table (pos_transactions) on POS Closing Shift
+	as the authoritative link between shifts and invoices. This is the explicit list stored
+	at shift-close time — no fuzzy matching by date/user/profile.
+	"""
 
 	conditions = build_conditions(filters)
 
@@ -661,17 +665,10 @@ def fetch_shifts_with_invoices(filters):
 			COUNT(DISTINCT CASE WHEN si.is_return = 0 THEN si.customer END) AS customers
 
 		FROM `tabPOS Closing Shift` pcs
-		LEFT JOIN `tabSales Invoice` si ON
-			si.docstatus = 1
-			AND si.is_pos = 1
-			AND (
-				si.posa_pos_opening_shift = pcs.pos_opening_shift
-				OR (
-					si.pos_profile = pcs.pos_profile
-					AND si.owner = pcs.user
-					AND si.posting_date BETWEEN DATE(pcs.period_start_date) AND DATE(pcs.period_end_date)
-				)
-			)
+		LEFT JOIN `tabSales Invoice Reference` sir ON sir.parent = pcs.name
+			AND sir.parenttype = 'POS Closing Shift'
+		LEFT JOIN `tabSales Invoice` si ON si.name = sir.sales_invoice
+			AND si.docstatus = 1
 		WHERE pcs.docstatus = 1
 		{conditions}
 		GROUP BY pcs.name
@@ -704,31 +701,10 @@ def build_conditions(filters):
 # =============================================================================
 
 def fetch_payment_data_batch(shifts):
-	"""Fetch payment breakdown for all shifts in one query"""
+	"""Fetch payment breakdown for all shifts"""
 	if not shifts:
 		return {}
 
-	# Build conditions for all shifts
-	shift_conditions = []
-	params = {}
-
-	for i, shift in enumerate(shifts):
-		param_prefix = f"s{i}_"
-		shift_conditions.append(f"""(
-			si.posa_pos_opening_shift = %({param_prefix}pos_opening)s
-			OR (
-				si.pos_profile = %({param_prefix}profile)s
-				AND si.owner = %({param_prefix}cashier)s
-				AND si.posting_date BETWEEN DATE(%({param_prefix}start)s) AND DATE(%({param_prefix}end)s)
-			)
-		)""")
-		params[f"{param_prefix}pos_opening"] = shift.pos_opening_shift
-		params[f"{param_prefix}profile"] = shift.pos_profile
-		params[f"{param_prefix}cashier"] = shift.cashier_id
-		params[f"{param_prefix}start"] = shift.period_start_date
-		params[f"{param_prefix}end"] = shift.period_end_date
-
-	# For simplicity, fetch per-shift (batch would be complex with OR conditions)
 	result = {}
 	for shift in shifts:
 		result[shift.shift_id] = fetch_payment_data_single(shift)
@@ -737,31 +713,22 @@ def fetch_payment_data_batch(shifts):
 
 
 def fetch_payment_data_single(shift):
-	"""Fetch payment data for a single shift"""
+	"""Fetch payment data for a single shift via pos_transactions child table"""
 	query = """
 		SELECT
 			LOWER(sip.mode_of_payment) AS mode,
 			SUM(sip.amount) AS amount
 		FROM `tabSales Invoice Payment` sip
 		INNER JOIN `tabSales Invoice` si ON si.name = sip.parent
-		WHERE si.docstatus = 1 AND si.is_pos = 1 AND si.is_return = 0
-		AND (
-			si.posa_pos_opening_shift = %(pos_opening)s
-			OR (
-				si.pos_profile = %(profile)s
-				AND si.owner = %(cashier)s
-				AND si.posting_date BETWEEN DATE(%(start)s) AND DATE(%(end)s)
-			)
-		)
+		INNER JOIN `tabSales Invoice Reference` sir ON sir.sales_invoice = si.name
+			AND sir.parent = %(shift)s
+			AND sir.parenttype = 'POS Closing Shift'
+		WHERE si.docstatus = 1 AND si.is_return = 0
 		GROUP BY LOWER(sip.mode_of_payment)
 	"""
 
 	payments = frappe.db.sql(query, {
-		"pos_opening": shift.pos_opening_shift,
-		"profile": shift.pos_profile,
-		"cashier": shift.cashier_id,
-		"start": shift.period_start_date,
-		"end": shift.period_end_date
+		"shift": shift.shift_id,
 	}, as_dict=True)
 
 	cash = 0
@@ -784,32 +751,23 @@ def fetch_salesperson_data_batch(shifts):
 
 
 def fetch_salesperson_data_single(shift):
-	"""Fetch sales person data for a single shift"""
+	"""Fetch sales person data for a single shift via pos_transactions child table"""
 	query = """
 		SELECT
 			st.sales_person,
 			SUM(st.allocated_amount) AS contribution
 		FROM `tabSales Team` st
 		INNER JOIN `tabSales Invoice` si ON si.name = st.parent
-		WHERE si.docstatus = 1 AND si.is_pos = 1 AND si.is_return = 0
-		AND (
-			si.posa_pos_opening_shift = %(pos_opening)s
-			OR (
-				si.pos_profile = %(profile)s
-				AND si.owner = %(cashier)s
-				AND si.posting_date BETWEEN DATE(%(start)s) AND DATE(%(end)s)
-			)
-		)
+		INNER JOIN `tabSales Invoice Reference` sir ON sir.sales_invoice = si.name
+			AND sir.parent = %(shift)s
+			AND sir.parenttype = 'POS Closing Shift'
+		WHERE si.docstatus = 1 AND si.is_return = 0
 		GROUP BY st.sales_person
 		ORDER BY contribution DESC
 	"""
 
 	sales_persons = frappe.db.sql(query, {
-		"pos_opening": shift.pos_opening_shift,
-		"profile": shift.pos_profile,
-		"cashier": shift.cashier_id,
-		"start": shift.period_start_date,
-		"end": shift.period_end_date
+		"shift": shift.shift_id,
 	}, as_dict=True)
 
 	if not sales_persons:
@@ -843,30 +801,21 @@ def fetch_peak_hours_batch(shifts):
 
 
 def fetch_peak_hour_single(shift):
-	"""Fetch peak hour for a single shift"""
+	"""Fetch peak hour for a single shift via pos_transactions child table"""
 	query = """
 		SELECT HOUR(si.posting_time) AS hour, SUM(si.grand_total) AS total
 		FROM `tabSales Invoice` si
-		WHERE si.docstatus = 1 AND si.is_pos = 1 AND si.is_return = 0
-		AND (
-			si.posa_pos_opening_shift = %(pos_opening)s
-			OR (
-				si.pos_profile = %(profile)s
-				AND si.owner = %(cashier)s
-				AND si.posting_date BETWEEN DATE(%(start)s) AND DATE(%(end)s)
-			)
-		)
+		INNER JOIN `tabSales Invoice Reference` sir ON sir.sales_invoice = si.name
+			AND sir.parent = %(shift)s
+			AND sir.parenttype = 'POS Closing Shift'
+		WHERE si.docstatus = 1 AND si.is_return = 0
 		GROUP BY HOUR(si.posting_time)
 		ORDER BY total DESC
 		LIMIT 1
 	"""
 
 	result = frappe.db.sql(query, {
-		"pos_opening": shift.pos_opening_shift,
-		"profile": shift.pos_profile,
-		"cashier": shift.cashier_id,
-		"start": shift.period_start_date,
-		"end": shift.period_end_date
+		"shift": shift.shift_id,
 	}, as_dict=True)
 
 	if result and result[0].hour is not None:


### PR DESCRIPTION
## Summary
- **Fix double-counting in all POS reports** by replacing cartesian-product JOINs with `Sales Invoice Reference` child table as the authoritative link between shifts and invoices
- **Redesign Payments and Cash Control Report** to show one row per shift with dynamic payment method columns (Expected/Closing/Diff per method), shift time, and totals
- **Fix N+1 query patterns** in Inventory and Payments reports with batch queries

## Reports Fixed
- **Cashier Performance Report** — split into two independent queries (invoices + shifts) to eliminate cartesian product inflation
- **Sales vs Shifts Report** — replaced OR-based LEFT JOIN with Sales Invoice Reference lookup
- **Inventory Impact & Fast Movers Report** — batch stock query replaces per-item N+1 calls
- **Payments and Cash Control Report** — pivoted from one-row-per-payment-method to one-row-per-shift with dynamic columns; added Shift Start/End time, Shift Hours, transaction counts

## Files Changed
- `cashier_performance_report.py` — two-query approach, shift conditions builder
- `inventory_impact_and_fast_movers_report.py` — `_get_stock_map()` batch function
- `payments_and_cash_control_report.py` — full redesign with dynamic columns, batch transaction counts
- `sales_vs_shifts_report.py` / `.js` — Sales Invoice Reference based shift filter

## Test plan
- [ ] Verify Cashier Performance Report shows correct sales totals (no inflation from multiple shifts)
- [ ] Verify Payments report shows one row per shift with correct per-method breakdowns
- [ ] Verify Inventory report stock levels match actual warehouse bins
- [ ] Verify Sales vs Shifts report invoice counts are accurate
- [ ] Confirm all reports load without errors on both local and production sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)