### PR TITLE
fix: remap foreign payment modes on cross-branch return invoices

### DIFF
--- a/POS/src/components/sale/ReturnInvoiceDialog.vue
+++ b/POS/src/components/sale/ReturnInvoiceDialog.vue
@@ -899,6 +899,16 @@ const loadPaymentMethodsResource = createResource({
 	onSuccess(data) {
 		if (data && data.payments) {
 			paymentMethods.value = data.payments
+			// Re-initialize refund payments now that we know the current
+			// profile's modes. initializePaymentsFromInvoice() may have
+			// already run (from fetchInvoiceResource.onSuccess) before
+			// paymentMethods were loaded — in that case it skipped the
+			// foreign mode remap. Now that modes are available, re-run
+			// to validate and remap any foreign modes from cross-branch
+			// returns. See initializePaymentsFromInvoice() JSDoc for details.
+			if (originalInvoice.value) {
+				initializePaymentsFromInvoice()
+			}
 		}
 	},
 	onError(error) {
@@ -1415,22 +1425,55 @@ function removePaymentRow(paymentIndex) {
 	refundPayments.value.splice(paymentIndex, 1)
 }
 
+/**
+ * Cross-branch return — frontend safety net (Layer 2).
+ *
+ * Pre-fills refund payment rows from the original invoice's payments.
+ * The backend (prepare_return_invoice) already remaps foreign payment modes
+ * by type (Cash→Cash, Bank→Bank) via _remap_foreign_payment_modes. This
+ * function provides a second line of defense: if a mode in the original
+ * invoice doesn't exist in the current POS profile's paymentMethods, it
+ * falls back to the profile's default (first) mode.
+ *
+ * Timing:
+ *   - Called from fetchInvoiceResource.onSuccess (may run before
+ *     paymentMethods are loaded from the async profile fetch).
+ *   - If paymentMethods is empty, we skip the remap and trust the
+ *     backend's remapped values. loadPaymentMethodsResource.onSuccess
+ *     will re-call this function once methods are available.
+ *
+ * The payment mode dropdown (<select>) only shows modes from the current
+ * profile's paymentMethods. A foreign mode would appear as an unselectable
+ * value, so this remap also ensures the dropdown works correctly.
+ */
 function initializePaymentsFromInvoice() {
 	if (isOriginalCreditSale.value) {
 		refundPayments.value = []
 		return
 	}
 
+	const defaultMode = paymentMethods.value[0]?.mode_of_payment || ""
+
 	const invoicePayments = originalInvoice.value?.payments
 	if (invoicePayments?.length) {
+		// Only remap when paymentMethods are loaded. When null (not yet loaded),
+		// the backend has already remapped via _remap_foreign_payment_modes,
+		// so the modes are safe to use as-is.
+		const currentModes = paymentMethods.value.length
+			? new Set(paymentMethods.value.map((m) => m.mode_of_payment))
+			: null
+
 		refundPayments.value = invoicePayments.map((payment) => ({
-			mode_of_payment: payment.mode_of_payment,
+			mode_of_payment:
+				currentModes && !currentModes.has(payment.mode_of_payment)
+					? defaultMode
+					: payment.mode_of_payment,
 			amount: isPartiallyPaid.value ? 0 : Math.abs(payment.amount),
 		}))
 	} else {
 		refundPayments.value = [
 			{
-				mode_of_payment: paymentMethods.value[0]?.mode_of_payment || "",
+				mode_of_payment: defaultMode,
 				amount: 0,
 			},
 		]

--- a/pos_next/api/invoices.py
+++ b/pos_next/api/invoices.py
@@ -1985,6 +1985,134 @@ def _build_item_tax_map(taxes: list) -> dict:
     return dict(tax_map)
 
 
+def _remap_foreign_payment_modes(payments_data, current_profile, original_profile):
+    """Remap payment modes that don't belong to the current POS profile.
+
+    Cross-branch returns problem:
+        Each POS branch has its own cash Mode of Payment that maps to a
+        dedicated GL cash account (e.g. "Boulaq Cash" -> account 12114,
+        "Cash lebanon" -> account 12123). When a customer returns an invoice
+        that was originally sold at a different branch, ERPNext's
+        make_sales_return() copies the *original* branch's payment modes.
+
+        If we don't remap, two things go wrong:
+        1. GL entries: the refund is posted against the wrong branch's cash
+           account (e.g. crediting Lebanon's cash instead of Boulaq's).
+        2. Shift closing: the foreign mode creates an orphan payment row
+           that doesn't exist in the current profile's opening balance,
+           blocking reconciliation.
+
+    Remapping strategy:
+        Modes are matched by their Mode of Payment *type* field:
+        - Cash -> Cash  (e.g. "Cash lebanon" -> "Boulaq Cash")
+        - Bank -> Bank  (e.g. "Lebanon Visa" -> "Visa")
+        - General -> first available in profile, or cash fallback
+
+        This ensures the GL account matches the physical cash drawer or
+        bank account at the branch where the return is processed.
+
+    Fallback chain for default mode:
+        1. POS Profile.posa_cash_mode_of_payment (explicit cash mode config)
+        2. First mode with type "Cash" in the profile
+        3. First mode in the profile (any type)
+
+    When remapping is skipped (no-op):
+        - Same profile (current == original)
+        - No current_profile provided
+        - All original modes already exist in the current profile
+        - No default_mode could be determined (empty profile)
+
+    Args:
+        payments_data: list of frappe._dict with mode_of_payment, amount, etc.
+                       (from Sales Invoice Payment child table of original invoice)
+        current_profile: POS Profile name where the return is being processed
+        original_profile: POS Profile name where the original sale happened
+
+    Returns:
+        The same payments_data list with mode_of_payment remapped in-place.
+        Shared modes (e.g. "Visa" exists in both profiles) are left unchanged.
+
+    Example:
+        Original invoice (profile "2- Lebanon"):
+            payments = [{"mode_of_payment": "Cash lebanon", "amount": 3240}]
+
+        Current profile "4- Boulaq" has modes:
+            [{"mode_of_payment": "Boulaq Cash", type: "Cash"},
+             {"mode_of_payment": "Visa",        type: "Bank"}]
+
+        After remap:
+            payments = [{"mode_of_payment": "Boulaq Cash", "amount": 3240}]
+
+        "Cash lebanon" (type=Cash) -> "Boulaq Cash" (type=Cash)
+    """
+    if not current_profile or current_profile == original_profile:
+        return payments_data
+
+    # Get current profile's payment modes
+    current_modes = {
+        row.mode_of_payment
+        for row in frappe.get_all(
+            "POS Payment Method",
+            filters={"parent": current_profile, "parenttype": "POS Profile"},
+            fields=["mode_of_payment"],
+        )
+    }
+
+    # Check if any payment needs remapping
+    needs_remap = any(p.mode_of_payment not in current_modes for p in payments_data)
+    if not needs_remap:
+        return payments_data
+
+    # Build type->mode map for the current profile.
+    # Uses setdefault so the first mode of each type wins (matches profile order).
+    mop = frappe.qb.DocType("Mode of Payment")
+    ppm = frappe.qb.DocType("POS Payment Method")
+    current_type_map = {}
+    rows = (
+        frappe.qb.from_(ppm)
+        .inner_join(mop).on(mop.name == ppm.mode_of_payment)
+        .select(ppm.mode_of_payment, mop.type)
+        .where(
+            (ppm.parent == current_profile)
+            & (ppm.parenttype == "POS Profile")
+        )
+    ).run(as_dict=True)
+
+    for row in rows:
+        current_type_map.setdefault(row.type, row.mode_of_payment)
+
+    # Default fallback: posa_cash_mode_of_payment > first Cash type > first mode
+    default_mode = (
+        frappe.db.get_value("POS Profile", current_profile, "posa_cash_mode_of_payment")
+        or current_type_map.get("Cash")
+        or (rows[0].mode_of_payment if rows else None)
+    )
+
+    if not default_mode:
+        return payments_data
+
+    # Fetch the type for each foreign mode in a single query
+    foreign_modes = [p.mode_of_payment for p in payments_data if p.mode_of_payment not in current_modes]
+    foreign_types = {}
+    if foreign_modes:
+        type_rows = frappe.get_all(
+            "Mode of Payment",
+            filters={"name": ["in", foreign_modes]},
+            fields=["name", "type"],
+        )
+        foreign_types = {r.name: r.type for r in type_rows}
+
+    # Remap: foreign Cash -> current Cash, foreign Bank -> current Bank, etc.
+    # If no type match in current profile, fall back to default_mode.
+    for payment in payments_data:
+        if payment.mode_of_payment in current_modes:
+            continue
+        foreign_type = foreign_types.get(payment.mode_of_payment)
+        payment.mode_of_payment = current_type_map.get(foreign_type, default_mode)
+
+    return payments_data
+
+
 @frappe.whitelist()
 def prepare_return_invoice(invoice_name, pos_opening_shift=None):
     """Prepare a return invoice using ERPNext's make_sales_return.
@@ -2116,6 +2244,28 @@ def prepare_return_invoice(invoice_name, pos_opening_shift=None):
         )
         .where(si_payment.parent == invoice_name)
     ).run(as_dict=True)
+
+    # Cross-branch return: remap foreign payment modes to the current profile.
+    #
+    # When the original invoice's POS profile differs from the current shift's
+    # profile, the original payment modes (e.g. "Cash lebanon") won't exist in
+    # the current profile ("4- Boulaq"). _remap_foreign_payment_modes matches
+    # by Mode of Payment type (Cash->Cash, Bank->Bank) so the frontend
+    # pre-fills the correct refund method and the resulting GL entries debit
+    # the correct branch cash/bank account.
+    #
+    # This is the primary fix point (Layer 1). The frontend and closing shift
+    # code have additional safety nets for cases where this remap doesn't run
+    # (e.g. no pos_opening_shift provided) or for already-submitted invoices
+    # with the wrong payment mode.
+    if pos_opening_shift:
+        current_profile = frappe.db.get_value(
+            "POS Opening Shift", pos_opening_shift, "pos_profile"
+        )
+        if current_profile:
+            payments_data = _remap_foreign_payment_modes(
+                payments_data, current_profile, invoice_info.pos_profile
+            )
 
     # Include original invoice data for reference (payments, amounts, etc.)
     return_dict["_original_invoice"] = {

--- a/pos_next/pos_next/doctype/pos_closing_shift/pos_closing_shift.js
+++ b/pos_next/pos_next/doctype/pos_closing_shift/pos_closing_shift.js
@@ -134,27 +134,42 @@ function add_to_pos_payments(d, frm) {
 }
 
 function add_to_payments(d, frm, conversion_rate) {
+        let cash_mode_of_payment = get_value(
+                "POS Profile",
+                frm.doc.pos_profile,
+                "posa_cash_mode_of_payment",
+        );
+        if (!cash_mode_of_payment) {
+                cash_mode_of_payment = "Cash";
+        }
+
+        // Cross-branch return safety net: collect known modes from opening balance
+        // so we can remap foreign payment modes on return invoices.
+        const known_modes = new Set(
+                frm.doc.payment_reconciliation.map((pay) => pay.mode_of_payment),
+        );
+
         d.payments.forEach((p) => {
+                let mode = p.mode_of_payment;
+
+                // Remap foreign modes on return invoices to the profile's cash mode.
+                // Same logic as Layer 3 in _process_invoice (Python).
+                if (d.is_return && !known_modes.has(mode)) {
+                        mode = cash_mode_of_payment;
+                }
+
                 const payment = frm.doc.payment_reconciliation.find(
-                        (pay) => pay.mode_of_payment === p.mode_of_payment,
+                        (pay) => pay.mode_of_payment === mode,
                 );
                 if (payment) {
                         let amount = get_base_value(p, "amount", "base_amount", conversion_rate);
-                        let cash_mode_of_payment = get_value(
-                                "POS Profile",
-                                frm.doc.pos_profile,
-                                "posa_cash_mode_of_payment",
-                        );
-                        if (!cash_mode_of_payment) {
-                                cash_mode_of_payment = "Cash";
-                        }
                         if (payment.mode_of_payment == cash_mode_of_payment) {
                                 amount -= get_base_value(d, "change_amount", "base_change_amount", conversion_rate);
                         }
                         payment.expected_amount += flt(amount);
                 } else {
                         frm.add_child("payment_reconciliation", {
-                                mode_of_payment: p.mode_of_payment,
+                                mode_of_payment: mode,
                                 opening_amount: 0,
                                 expected_amount: get_base_value(
                                         p,

--- a/pos_next/pos_next/doctype/pos_closing_shift/pos_closing_shift.py
+++ b/pos_next/pos_next/doctype/pos_closing_shift/pos_closing_shift.py
@@ -478,11 +478,40 @@ def _process_invoice(invoice, invoice_field, company_currency, cash_mode, paymen
         _aggregate_tax(taxes, t.account_head, t.rate, tax_amount)
 
     # Process payments
+    #
+    # Cross-branch return safety net (Layer 3):
+    #
+    # Return invoices submitted before the fix in prepare_return_invoice
+    # (Layer 1) may still carry foreign payment modes from the original
+    # invoice's POS profile. For example, a return against a "2- Lebanon"
+    # invoice done at "4- Boulaq" would have "Cash lebanon" as the payment
+    # mode, but "Cash lebanon" doesn't exist in Boulaq's opening balance.
+    #
+    # Without this guard, _aggregate_payment would create a new orphan row
+    # for "Cash lebanon" in the payment_reconciliation table. This causes:
+    # - A payment row the cashier didn't open with and can't reconcile
+    # - Validation errors from hooks that require closing_amount on all rows
+    # - The shift cannot be closed
+    #
+    # Fix: for return invoices only, if the payment mode is not in the set of
+    # known modes (opening balance + modes from previously processed invoices),
+    # remap it to the current profile's cash mode. This is safe because:
+    # - The cashier physically refunded from their own cash drawer
+    # - known_modes is built from the payments list which starts with the
+    #   opening balance (always matches the profile's configured modes)
+    # - Normal (non-return) invoices are never remapped — their modes are
+    #   legitimate and should create new rows if needed
+    known_modes = {pay.mode_of_payment for pay in payments}
     for p in invoice.payments:
         amount = get_base_value(p, "amount", "base_amount", conversion_rate)
-        if p.mode_of_payment == cash_mode:
+        mode = p.mode_of_payment
+
+        if is_return and mode not in known_modes:
+            mode = cash_mode
+
+        if mode == cash_mode:
             amount -= get_base_value(invoice, "change_amount", "base_change_amount", conversion_rate)
-        _aggregate_payment(payments, p.mode_of_payment, amount)
+        _aggregate_payment(payments, mode, amount)
 
     return transaction
 


### PR DESCRIPTION
## Summary
- Remaps foreign payment modes (from another POS branch) when processing cross-branch return invoices, preventing orphan payment reconciliation rows that block shift closing
- **Layer 1 (backend)**: `_remap_foreign_payment_modes()` in `prepare_return_invoice` — prevents future returns from copying foreign payment modes
- **Layer 2 (frontend)**: `initializePaymentsFromInvoice()` safety net — remaps foreign modes in the return invoice dialog dropdown
- **Layer 3a (closing - Python)**: `_process_invoice()` — handles already-submitted invoices with wrong payment mode (POS Next UI path)
- **Layer 3b (closing - JS)**: `add_to_payments()` in `pos_closing_shift.js` — same remap for the Frappe desk form closing path

## Test plan
- [x] Created "Branch POS Profile" with "Branch Cash" mode, separate from "Main POS Profile" with "Cash" mode
- [x] Created invoice on Main POS Profile with "Cash" payment
- [x] Created cross-branch return on Branch POS Profile — return invoice carries foreign "Cash" mode
- [x] Verified POS Next UI closing shift dialog shows "Branch Cash: -1000" (no orphan "Cash" row)
- [x] Verified Frappe desk form closing shift shows "Branch Cash: -1000" (no orphan "Cash" row)
- [x] Both Python (`make_closing_shift_from_opening`) and JS (`add_to_payments`) paths produce identical correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)