### PR TITLE
PN-17: Credit return to wallet and auto-create wallet on customer insert

### DIFF
--- a/POS/src/components/sale/ReturnInvoiceDialog.vue
+++ b/POS/src/components/sale/ReturnInvoiceDialog.vue
@@ -1052,6 +1052,8 @@ const createReturnResource = createResource({
 				// Link to original invoice item row for accurate return tracking in ERPNext
 				sales_invoice_item: item.name,
 			})),
+			// Flag to indicate return amount should be added to customer credit balance
+			add_to_customer_balance: addToCustomerCredit.value,
 			// Payment amounts are negative for refunds
 			// If addToCustomerCredit is true, send empty payments array so outstanding stays negative
 			// This negative outstanding becomes customer credit balance

--- a/pos_next/api/invoices.py
+++ b/pos_next/api/invoices.py
@@ -340,9 +340,9 @@ def get_payment_account(mode_of_payment, company):
 def _set_payment_accounts(payments, company):
     """Set the account for each payment entry that is missing one.
 
-    Uses BaseDocument.set() for assignment which directly writes to __dict__,
-    avoiding potential issues with attribute assignment on child-table Document
-    objects (e.g. 'SalesInvoicePayment' object does not support item assignment).
+    Handles both Document objects (from invoice_doc.payments) and plain dicts
+    (from frontend data).  Document objects use BaseDocument.set() which writes
+    directly to __dict__, while plain dicts use normal key assignment.
     """
     if not payments or not company:
         return
@@ -354,12 +354,18 @@ def _set_payment_accounts(payments, company):
         try:
             account_info = get_payment_account(mode_of_payment, company)
             if account_info:
-                payment.set("account", account_info.get("account"))
+                account = account_info.get("account")
+                if hasattr(payment, "set") and callable(payment.set):
+                    payment.set("account", account)
+                else:
+                    payment["account"] = account
         except Exception as e:
             frappe.log_error(
                 f"Failed to get payment account for {mode_of_payment}: {e}",
                 "Payment Account Lookup",
             )
+
+
 # ==========================================
 # Stock Validation Functions
 # ==========================================
@@ -1353,6 +1359,7 @@ def submit_invoice(invoice=None, data=None):
         invoice_doc.submit()
         invoice_submitted = True
         # Handle wallet transaction reversal for returns
+        wallet_reversal_ok = False
         if invoice_doc.get("is_return") and invoice_doc.get("return_against"):
             from pos_next.pos_next.doctype.wallet_transaction.wallet_transaction import reverse_wallet_transactions_for_return
             try:
@@ -1360,6 +1367,7 @@ def submit_invoice(invoice=None, data=None):
                     original_invoice=invoice_doc.return_against,
                     return_invoice=invoice_doc.name
                 )
+                wallet_reversal_ok = True
             except Exception as wallet_reversal_error:
                 frappe.log_error(
                     title="Wallet Reversal Error",
@@ -1375,9 +1383,13 @@ def submit_invoice(invoice=None, data=None):
                     indicator="orange"
                 )
 
-            # Credit return amount to customer wallet when "Add to Customer Credit Balance" is enabled
+        # Credit return amount to customer wallet when "Add to Customer Credit Balance" is enabled.
+        # Only proceed if the wallet reversal above succeeded (or was not needed) to
+        # avoid double-crediting the customer when reversal fails.
+        if invoice_doc.get("is_return"):
             add_to_customer_balance = invoice.get("add_to_customer_balance")
-            if add_to_customer_balance:
+            has_return_against = bool(invoice_doc.get("return_against"))
+            if add_to_customer_balance and (wallet_reversal_ok or not has_return_against):
                 from pos_next.pos_next.doctype.wallet_transaction.wallet_transaction import credit_return_to_wallet
                 try:
                     credit_return_to_wallet(

--- a/pos_next/api/invoices.py
+++ b/pos_next/api/invoices.py
@@ -337,6 +337,29 @@ def get_payment_account(mode_of_payment, company):
     )
 
 
+def _set_payment_accounts(payments, company):
+    """Set the account for each payment entry that is missing one.
+
+    Uses BaseDocument.set() for assignment which directly writes to __dict__,
+    avoiding potential issues with attribute assignment on child-table Document
+    objects (e.g. 'SalesInvoicePayment' object does not support item assignment).
+    """
+    if not payments or not company:
+        return
+
+    for payment in payments:
+        mode_of_payment = payment.get("mode_of_payment")
+        if not mode_of_payment or payment.get("account"):
+            continue
+        try:
+            account_info = get_payment_account(mode_of_payment, company)
+            if account_info:
+                payment.set("account", account_info.get("account"))
+        except Exception as e:
+            frappe.log_error(
+                f"Failed to get payment account for {mode_of_payment}: {e}",
+                "Payment Account Lookup",
+            )
 # ==========================================
 # Stock Validation Functions
 # ==========================================
@@ -685,20 +708,7 @@ def update_invoice(data):
         )
 
         if company and invoice_doc.get("payments") and doctype == "Sales Invoice":
-            for payment in invoice_doc.payments:
-                mode_of_payment = payment.get("mode_of_payment")
-                if mode_of_payment and not payment.get("account"):
-                    try:
-                        account_info = get_payment_account(
-                            mode_of_payment, company
-                        )
-                        if account_info:
-                            payment.account = account_info.get("account")
-                    except Exception as e:
-                        frappe.log_error(
-                            f"Failed to get payment account for {mode_of_payment}: {e}",
-                            "Payment Account Lookup"
-                        )
+            _set_payment_accounts(invoice_doc.payments, company)
 
         # Validate return items if this is a return invoice
         if (data.get("is_return") or invoice_doc.get("is_return")) and invoice_doc.get(
@@ -858,20 +868,7 @@ def update_invoice(data):
             invoice_doc.base_grand_total = 0.0
 
         # Set accounts for payment methods before saving
-        for payment in invoice_doc.payments:
-            mode_of_payment = payment.get("mode_of_payment")
-            if mode_of_payment and not payment.get("account"):
-                try:
-                    account_info = get_payment_account(
-                        mode_of_payment, invoice_doc.company
-                    )
-                    if account_info:
-                        payment.account = account_info.get("account")
-                except Exception as e:
-                    frappe.log_error(
-                        f"Failed to get payment account for {mode_of_payment}: {e}",
-                        "Payment Account Lookup"
-                    )
+        _set_payment_accounts(invoice_doc.payments, invoice_doc.company)
 
         # For return invoices, ensure payments are negative
         if invoice_doc.get("is_return"):
@@ -1278,13 +1275,7 @@ def submit_invoice(invoice=None, data=None):
 
         # Set accounts for all payment methods before saving
         if doctype == "Sales Invoice" and hasattr(invoice_doc, "payments"):
-            for payment in invoice_doc.payments:
-                if payment.mode_of_payment:
-                    account_info = get_payment_account(
-                        payment.mode_of_payment, invoice_doc.company
-                    )
-                    if account_info:
-                        payment.account = account_info.get("account")
+            _set_payment_accounts(invoice_doc.payments, invoice_doc.company)
 
         # Handle sales team (multiple sales persons)
         sales_team_data = invoice.get("sales_team") or data.get("sales_team")
@@ -1363,21 +1354,49 @@ def submit_invoice(invoice=None, data=None):
         invoice_submitted = True
         # Handle wallet transaction reversal for returns
         if invoice_doc.get("is_return") and invoice_doc.get("return_against"):
+            from pos_next.pos_next.doctype.wallet_transaction.wallet_transaction import reverse_wallet_transactions_for_return
             try:
-                from pos_next.pos_next.doctype.wallet_transaction.wallet_transaction import reverse_wallet_transactions_for_return
                 reverse_wallet_transactions_for_return(
                     original_invoice=invoice_doc.return_against,
                     return_invoice=invoice_doc.name
                 )
-            except Exception as wallet_error:
+            except Exception as wallet_reversal_error:
                 frappe.log_error(
-                    title="Wallet Reversal on Return Error",
-                    message=f"Return Invoice: {invoice_doc.name}, Error: {str(wallet_error)}\n{frappe.get_traceback()}"
+                    title="Wallet Reversal Error",
+                    message=(
+                        f"Return invoice: {invoice_doc.name}, "
+                        f"Original invoice: {invoice_doc.return_against}, "
+                        f"Error: {str(wallet_reversal_error)}\n{frappe.get_traceback()}"
+                    )
                 )
                 frappe.msgprint(
-                    _("Return submitted but wallet reversal failed. Please check manually."),
-                    alert=True, indicator="orange"
+                    _("Return invoice submitted successfully, but wallet reversal failed. Please contact administrator."),
+                    alert=True,
+                    indicator="orange"
                 )
+
+            # Credit return amount to customer wallet when "Add to Customer Credit Balance" is enabled
+            add_to_customer_balance = invoice.get("add_to_customer_balance")
+            if add_to_customer_balance:
+                from pos_next.pos_next.doctype.wallet_transaction.wallet_transaction import credit_return_to_wallet
+                try:
+                    credit_return_to_wallet(
+                        return_invoice=invoice_doc.name,
+                        amount=abs(flt(invoice_doc.grand_total))
+                    )
+                except Exception as wallet_credit_error:
+                    frappe.log_error(
+                        title="Wallet Credit on Return Error",
+                        message=(
+                            f"Return invoice: {invoice_doc.name}, "
+                            f"Error: {str(wallet_credit_error)}\n{frappe.get_traceback()}"
+                        )
+                    )
+                    frappe.msgprint(
+                        _("Return submitted but wallet credit failed. Please contact administrator."),
+                        alert=True,
+                        indicator="orange"
+                    )
         # Complete the offline sync record
         if sync_record_name:
             _complete_offline_sync(sync_record_name, invoice_doc.name)

--- a/pos_next/api/wallet.py
+++ b/pos_next/api/wallet.py
@@ -59,6 +59,23 @@ def process_loyalty_to_wallet(doc, method=None):
 	if not loyalty_program:
 		return
 
+	# Check if the invoice amount meets the applicable tier's min_spent threshold.
+	# Single Tier Program: the one rule's min_spent must be met.
+	# Multiple Tier Program: the invoice must reach at least the lowest tier's min_spent.
+	lp_doc = frappe.get_doc("Loyalty Program", loyalty_program)
+	tiers = sorted(
+		[d.as_dict() for d in lp_doc.collection_rules],
+		key=lambda r: flt(r.get("min_spent")),
+	)
+	invoice_amount = abs(flt(doc.grand_total))
+	matched_tier = None
+	for t in tiers:
+		if flt(invoice_amount) >= flt(t.get("min_spent")):
+			matched_tier = t
+	if not matched_tier:
+		# Invoice amount below the minimum spend threshold of all tiers — no loyalty credit
+		return
+
 	# Get the loyalty points earned from this invoice
 	loyalty_entry = frappe.db.get_value(
 		"Loyalty Point Entry",

--- a/pos_next/api/wallet.py
+++ b/pos_next/api/wallet.py
@@ -257,12 +257,27 @@ def get_customer_wallet(customer, company=None):
 
 
 def create_wallet_on_customer_insert(doc, method=None):
-	"""Hook: after_insert on Customer. Creates a wallet for the default company."""
+	"""Hook: after_insert on Customer. Creates a wallet for the default company
+	only when auto_create_wallet is enabled in POS Settings."""
 	company = frappe.get_cached_value("Global Defaults", "Global Defaults", "default_company")
 	if not company:
 		return
+
+	# Only auto-create wallets when a POS profile with auto_create_wallet exists
+	pos_profile = frappe.db.get_value(
+		"POS Profile",
+		{"company": company, "disabled": 0},
+		"name"
+	)
+	if not pos_profile:
+		return
+
+	pos_settings = get_pos_settings(pos_profile)
+	if not pos_settings or not cint(pos_settings.get("auto_create_wallet")):
+		return
+
 	try:
-		get_or_create_wallet(doc.name, company)
+		get_or_create_wallet(doc.name, company, pos_settings=pos_settings)
 	except Exception:
 		frappe.log_error(frappe.get_traceback(), f"Wallet auto-create failed for {doc.name}")
 

--- a/pos_next/api/wallet.py
+++ b/pos_next/api/wallet.py
@@ -256,8 +256,19 @@ def get_customer_wallet(customer, company=None):
 	return wallet
 
 
+def create_wallet_on_customer_insert(doc, method=None):
+	"""Hook: after_insert on Customer. Creates a wallet for the default company."""
+	company = frappe.get_cached_value("Global Defaults", "Global Defaults", "default_company")
+	if not company:
+		return
+	try:
+		get_or_create_wallet(doc.name, company)
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), f"Wallet auto-create failed for {doc.name}")
+
+
 @frappe.whitelist()
-def get_or_create_wallet(customer, company, pos_settings=None):
+def get_or_create_wallet(customer, company, pos_settings=None, force_create=False):
 	"""Get existing wallet or create a new one."""
 
 	# Check if wallet exists
@@ -281,7 +292,7 @@ def get_or_create_wallet(customer, company, pos_settings=None):
 		if pos_profile:
 			pos_settings = get_pos_settings(pos_profile)
 
-	if pos_settings and not cint(pos_settings.get("auto_create_wallet")):
+	if not force_create and (not pos_settings or not cint(pos_settings.get("auto_create_wallet"))):
 		return None
 
 	# Get wallet account
@@ -457,8 +468,8 @@ def create_manual_wallet_credit(customer, company, amount, remarks=None):
 	if flt(amount) <= 0:
 		frappe.throw(_("Amount must be greater than zero"))
 
-	# Get or create wallet
-	wallet = get_or_create_wallet(customer, company)
+	# Manual credits should be able to create wallets even when POS auto-create is disabled.
+	wallet = get_or_create_wallet(customer, company, force_create=True)
 
 	if not wallet:
 		frappe.throw(_("Could not create wallet for customer {0}").format(customer))

--- a/pos_next/hooks.py
+++ b/pos_next/hooks.py
@@ -206,7 +206,8 @@ doc_events = {
 	"Customer": {
 		"after_insert": [
 			"pos_next.api.customers.auto_assign_loyalty_program",
-			"pos_next.realtime_events.emit_customer_event"
+			"pos_next.realtime_events.emit_customer_event",
+			"pos_next.api.wallet.create_wallet_on_customer_insert"
 		],
 		"on_update": "pos_next.realtime_events.emit_customer_event",
 		"on_trash": "pos_next.realtime_events.emit_customer_event"

--- a/pos_next/pos_next/doctype/wallet_transaction/wallet_transaction.py
+++ b/pos_next/pos_next/doctype/wallet_transaction/wallet_transaction.py
@@ -508,7 +508,7 @@ def reverse_wallet_transactions_for_return(original_invoice, return_invoice):
 		)
 		if lp_details and lp_details.get("collection_rules"):
 			tiers = sorted(
-				[d.as_dict() if hasattr(d, "as_dict") else d for d in lp_details.collection_rules],
+				[d.as_dict() if callable(getattr(d, "as_dict", None)) else d for d in lp_details.collection_rules],
 				key=lambda r: flt(r.get("min_spent")),
 			)
 			# Find the highest tier the original invoice amount qualified for

--- a/pos_next/pos_next/doctype/wallet_transaction/wallet_transaction.py
+++ b/pos_next/pos_next/doctype/wallet_transaction/wallet_transaction.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.utils import flt, today
 from erpnext.accounts.general_ledger import make_gl_entries
 from erpnext.controllers.accounts_controller import AccountsController
+from pos_next.api.wallet import get_or_create_wallet
 
 class WalletTransaction(AccountsController):
 	def validate(self):
@@ -108,8 +109,9 @@ class WalletTransaction(AccountsController):
 				"remarks": self.remarks or _("Wallet Credit: {0}").format(self.name)
 			}
 			# Receivable/Payable accounts require party information
-			source_account_type = frappe.get_cached_value("Account", source_account, "account_type")
-			if source_account_type in ("Receivable", "Payable") and self.customer:
+			if not hasattr(self, '_source_account_type'):
+				self._source_account_type = frappe.get_cached_value("Account", source_account, "account_type")
+			if self._source_account_type in ("Receivable", "Payable") and self.customer:
 				source_gl["party_type"] = "Customer"
 				source_gl["party"] = self.customer
 			gl_entries.append(self.get_gl_dict(source_gl))
@@ -283,8 +285,7 @@ def credit_loyalty_points_to_wallet(customer, company, loyalty_points, conversio
 		return None
 
 	# Get or create customer wallet
-	from pos_next.pos_next.doctype.wallet.wallet import get_or_create_wallet
-	wallet = get_or_create_wallet(customer, company)
+	wallet = get_or_create_wallet(customer, company, force_create=True)
 
 	# Create wallet credit transaction
 	transaction = create_wallet_credit(
@@ -317,27 +318,31 @@ def credit_return_to_wallet(return_invoice, amount=None):
 	Returns:
 		Wallet Transaction document or None
 	"""
-	return_doc = frappe.get_doc("Sales Invoice", return_invoice)
+	return_data = frappe.db.get_value(
+		"Sales Invoice",
+		return_invoice,
+		["customer", "company", "grand_total", "is_return", "return_against"],
+		as_dict=True,
+	)
 
-	if not return_doc.is_return:
+	if not return_data or not return_data.is_return:
 		frappe.log_error(
 			title="Wallet Credit on Return Error",
 			message=f"Invoice {return_invoice} is not a return invoice"
 		)
 		return None
 
-	customer = return_doc.customer
-	company = return_doc.company
+	customer = return_data.customer
+	company = return_data.company
 
 	# Determine credit amount: explicit amount or absolute grand_total
-	credit_amount = flt(amount) if amount else abs(flt(return_doc.grand_total))
+	credit_amount = flt(amount) if amount else abs(flt(return_data.grand_total))
 
 	if credit_amount <= 0:
 		return None
 
 	# Get or create customer wallet
-	from pos_next.pos_next.doctype.wallet.wallet import get_or_create_wallet
-	wallet = get_or_create_wallet(customer, company)
+	wallet = get_or_create_wallet(customer, company, force_create=True)
 
 	if not wallet:
 		frappe.log_error(
@@ -384,10 +389,12 @@ def credit_return_to_wallet(return_invoice, amount=None):
 			if has_gl:
 				return existing_transaction
 			# No GL entries → broken submission. Cancel and recreate below.
+			# NOTE: We intentionally do NOT call frappe.db.commit() here so
+			# the cancellation stays within the caller's transaction boundary
+			# and can be rolled back if the subsequent re-creation fails.
 			try:
 				existing_transaction.flags.ignore_permissions = True
 				existing_transaction.cancel()
-				frappe.db.commit()
 			except Exception:
 				frappe.log_error(
 					title="Wallet Transaction Recovery Error",
@@ -408,7 +415,7 @@ def credit_return_to_wallet(return_invoice, amount=None):
 		"reference_name": return_invoice,
 		"remarks": _("Return credit to wallet for {0} against {1}: {2}").format(
 			return_invoice,
-			return_doc.return_against or "",
+			return_data.return_against or "",
 			frappe.format_value(credit_amount, {"fieldtype": "Currency"})
 		)
 	})
@@ -446,7 +453,11 @@ def reverse_wallet_transactions_for_return(original_invoice, return_invoice):
 		return
 
 	existing = frappe.db.exists("Wallet Transaction", {
-    "reference_name": return_invoice, "transaction_type": "Debit", "docstatus": ["!=", 2]
+		"reference_doctype": "Sales Invoice",
+		"reference_name": return_invoice,
+		"transaction_type": "Debit",
+		"source_type": "Refund",
+		"docstatus": ["!=", 2],
 	})
 	if existing:
 		return
@@ -485,9 +496,26 @@ def reverse_wallet_transactions_for_return(original_invoice, return_invoice):
 	min_spent = 0
 	below_min_threshold = False
 	if loyalty_program:
-		min_spent = frappe.db.get_value("Loyalty Program Collection",{"parent": loyalty_program},"min_spent")
-		if min_spent:
-			min_spent = flt(min_spent)
+		from erpnext.accounts.doctype.loyalty_program.loyalty_program import (
+			get_loyalty_program_details_with_points,
+		)
+		lp_details = get_loyalty_program_details_with_points(
+			customer=original_doc.customer,
+			loyalty_program=loyalty_program,
+			company=original_doc.company,
+			silent=True,
+			current_transaction_amount=0,
+		)
+		if lp_details and lp_details.get("collection_rules"):
+			tiers = sorted(
+				[d.as_dict() if hasattr(d, "as_dict") else d for d in lp_details.collection_rules],
+				key=lambda r: flt(r.get("min_spent")),
+			)
+			# Find the highest tier the original invoice amount qualified for
+			for tier in reversed(tiers):
+				if flt(original_total) >= flt(tier.get("min_spent")):
+					min_spent = flt(tier.get("min_spent"))
+					break
 	invoiced_amount_after_return = flt(original_total) - flt(returned_amount)
 	if min_spent and flt(invoiced_amount_after_return) < flt(min_spent):
 		below_min_threshold = True

--- a/pos_next/pos_next/doctype/wallet_transaction/wallet_transaction.py
+++ b/pos_next/pos_next/doctype/wallet_transaction/wallet_transaction.py
@@ -489,45 +489,71 @@ def reverse_wallet_transactions_for_return(original_invoice, return_invoice):
 	return_ratio = returned_amount / original_total
 	is_full_return = return_ratio >= 0.999  # Allow small rounding tolerance
 
-	# Get loyalty program factors using the same function that calculates the original credit
-	# Original: points = eligible_amount / collection_factor, wallet = points * conversion_factor
+	# Get loyalty program details for tier-aware reversal of Loyalty Credit.
+	# Supports both "Single Tier Program" (one rule) and "Multiple Tier Program" (many rules).
+	# Original credit: points = int(eligible_amount / collection_factor), wallet = points * conversion_factor
 	loyalty_program = frappe.db.get_value("Customer", original_doc.customer, "loyalty_program")
 
-	min_spent = 0
-	below_min_threshold = False
+	tiers = []
+	conversion_factor = 1.0
 	if loyalty_program:
-		from erpnext.accounts.doctype.loyalty_program.loyalty_program import (
-			get_loyalty_program_details_with_points,
+		lp_doc = frappe.get_doc("Loyalty Program", loyalty_program)
+		conversion_factor = flt(lp_doc.conversion_factor) or 1.0
+		tiers = sorted(
+			[d.as_dict() for d in lp_doc.collection_rules],
+			key=lambda r: flt(r.get("min_spent")),
 		)
-		lp_details = get_loyalty_program_details_with_points(
-			customer=original_doc.customer,
-			loyalty_program=loyalty_program,
-			company=original_doc.company,
-			silent=True,
-			current_transaction_amount=0,
-		)
-		if lp_details and lp_details.get("collection_rules"):
-			tiers = sorted(
-				[d.as_dict() if callable(getattr(d, "as_dict", None)) else d for d in lp_details.collection_rules],
-				key=lambda r: flt(r.get("min_spent")),
-			)
-			# Find the highest tier the original invoice amount qualified for
-			for tier in reversed(tiers):
-				if flt(original_total) >= flt(tier.get("min_spent")):
-					min_spent = flt(tier.get("min_spent"))
-					break
+
 	invoiced_amount_after_return = flt(original_total) - flt(returned_amount)
-	if min_spent and flt(invoiced_amount_after_return) < flt(min_spent):
-		below_min_threshold = True
+
+	def _find_tier(amount):
+		"""Return the highest tier whose min_spent <= amount, or None."""
+		matched = None
+		for t in tiers:
+			if flt(amount) >= flt(t.get("min_spent")):
+				matched = t
+		return matched
+
+	# Determine the applicable tier for the post-return effective amount
+	new_tier = _find_tier(invoiced_amount_after_return) if tiers else None
+
 	for wt in wallet_transactions:
-		if is_full_return or below_min_threshold:
-			# Full return - cancel the wallet transaction
+		# ── Decide: cancel entirely  OR  create a partial Debit ──
+		should_cancel = False
+		reverse_amount = 0
+
+		if is_full_return:
+			should_cancel = True
+
+		elif wt.transaction_type == "Loyalty Credit" and tiers:
+			# Tier-aware reversal for Loyalty Credit
+			if not new_tier:
+				# Post-return amount below the lowest tier's min_spent → reverse ALL
+				should_cancel = True
+			else:
+				# Recalculate what the credit should be for the post-return amount
+				new_cf = flt(new_tier.get("collection_factor")) or 1.0
+				recalculated_points = int(flt(invoiced_amount_after_return) / new_cf)
+				recalculated_credit = flt(recalculated_points) * flt(conversion_factor)
+				reverse_amount = flt(flt(wt.amount) - recalculated_credit, 2)
+
+				if flt(reverse_amount) >= flt(wt.amount):
+					# Recalculated credit is zero or negative → cancel entirely
+					should_cancel = True
+					reverse_amount = 0
+
+		else:
+			# Regular Credit (or Loyalty Credit without tiers) → proportional reversal
+			reverse_amount = flt(wt.amount * return_ratio, 2)
+
+		# ── Execute the reversal ──
+		if should_cancel:
 			try:
 				wt_doc = frappe.get_doc("Wallet Transaction", wt.name)
 				wt_doc.flags.ignore_permissions = True
 				wt_doc.cancel()
 				frappe.msgprint(
-					_("Cancelled Wallet Transaction {0} due to full return").format(wt.name),
+					_("Cancelled Wallet Transaction {0} due to return").format(wt.name),
 					alert=True, indicator="blue"
 				)
 			except Exception as e:
@@ -535,12 +561,8 @@ def reverse_wallet_transactions_for_return(original_invoice, return_invoice):
 					title="Wallet Transaction Cancel on Return Error",
 					message=f"WT: {wt.name}, Return: {return_invoice}, Error: {str(e)}\n{frappe.get_traceback()}"
 				)
-		else:
-			reverse_amount = flt(wt.amount * return_ratio, 2)
-			
-			if reverse_amount <= 0:
-				continue
 
+		elif reverse_amount > 0:
 			try:
 				reverse_wt = frappe.get_doc({
 					"doctype": "Wallet Transaction",

--- a/pos_next/pos_next/doctype/wallet_transaction/wallet_transaction.py
+++ b/pos_next/pos_next/doctype/wallet_transaction/wallet_transaction.py
@@ -7,7 +7,6 @@ from frappe.utils import flt, today
 from erpnext.accounts.general_ledger import make_gl_entries
 from erpnext.controllers.accounts_controller import AccountsController
 
-
 class WalletTransaction(AccountsController):
 	def validate(self):
 		self.validate_wallet()
@@ -101,15 +100,19 @@ class WalletTransaction(AccountsController):
 		if self.transaction_type in ["Credit", "Loyalty Credit"]:
 			# Credit to wallet (increase balance)
 			# Debit source account, Credit wallet account (with party)
-			gl_entries.append(
-				self.get_gl_dict({
-					"account": source_account,
-					"debit": amount,
-					"debit_in_account_currency": amount,
-					"cost_center": cost_center,
-					"remarks": self.remarks or _("Wallet Credit: {0}").format(self.name)
-				})
-			)
+			source_gl = {
+				"account": source_account,
+				"debit": amount,
+				"debit_in_account_currency": amount,
+				"cost_center": cost_center,
+				"remarks": self.remarks or _("Wallet Credit: {0}").format(self.name)
+			}
+			# Receivable/Payable accounts require party information
+			source_account_type = frappe.get_cached_value("Account", source_account, "account_type")
+			if source_account_type in ("Receivable", "Payable") and self.customer:
+				source_gl["party_type"] = "Customer"
+				source_gl["party"] = self.customer
+			gl_entries.append(self.get_gl_dict(source_gl))
 			gl_entries.append(
 				self.get_gl_dict({
 					"account": wallet_account,
@@ -136,15 +139,20 @@ class WalletTransaction(AccountsController):
 					"remarks": self.remarks or _("Wallet Debit: {0}").format(self.name)
 				})
 			)
-			gl_entries.append(
-				self.get_gl_dict({
-					"account": source_account,
-					"credit": amount,
-					"credit_in_account_currency": amount,
-					"cost_center": cost_center,
-					"remarks": self.remarks or _("Wallet Debit: {0}").format(self.name)
-				})
-			)
+			debit_source_gl = {
+				"account": source_account,
+				"credit": amount,
+				"credit_in_account_currency": amount,
+				"cost_center": cost_center,
+				"remarks": self.remarks or _("Wallet Debit: {0}").format(self.name)
+			}
+			# Receivable/Payable accounts require party information
+			if not hasattr(self, '_source_account_type'):
+				self._source_account_type = frappe.get_cached_value("Account", source_account, "account_type")
+			if self._source_account_type in ("Receivable", "Payable") and self.customer:
+				debit_source_gl["party_type"] = "Customer"
+				debit_source_gl["party"] = self.customer
+			gl_entries.append(self.get_gl_dict(debit_source_gl))
 
 		return gl_entries
 
@@ -292,106 +300,254 @@ def credit_loyalty_points_to_wallet(customer, company, loyalty_points, conversio
 
 	return transaction
 
+def credit_return_to_wallet(return_invoice, amount=None):
+	"""
+	Create a Credit wallet transaction when "Add to Customer Credit Balance"
+	is enabled on a return invoice.
+
+	The return amount is credited to the customer's wallet instead of a cash refund.
+	Works for both full and partial returns — the amount is taken from the
+	return invoice's grand_total (absolute value) or can be explicitly passed.
+
+	Args:
+		return_invoice: Return Sales Invoice name (is_return=1)
+		amount: Explicit credit amount (optional). If not provided,
+				uses abs(return_invoice.grand_total).
+
+	Returns:
+		Wallet Transaction document or None
+	"""
+	return_doc = frappe.get_doc("Sales Invoice", return_invoice)
+
+	if not return_doc.is_return:
+		frappe.log_error(
+			title="Wallet Credit on Return Error",
+			message=f"Invoice {return_invoice} is not a return invoice"
+		)
+		return None
+
+	customer = return_doc.customer
+	company = return_doc.company
+
+	# Determine credit amount: explicit amount or absolute grand_total
+	credit_amount = flt(amount) if amount else abs(flt(return_doc.grand_total))
+
+	if credit_amount <= 0:
+		return None
+
+	# Get or create customer wallet
+	from pos_next.pos_next.doctype.wallet.wallet import get_or_create_wallet
+	wallet = get_or_create_wallet(customer, company)
+
+	if not wallet:
+		frappe.log_error(
+			title="Wallet Credit on Return Error",
+			message=f"Could not get or create wallet for customer {customer}, company {company}"
+		)
+		return None
+
+	# Determine source account — use company's default receivable account for refunds
+	source_account = frappe.get_cached_value("Company", company, "default_receivable_account")
+
+	if not source_account:
+		frappe.log_error(
+			title="Wallet Credit on Return Error",
+			message=f"No default receivable account for company {company}"
+		)
+		return None
+
+	# Idempotency guard: if submit_invoice is retried for the same return invoice,
+	# reuse the existing wallet credit transaction instead of creating duplicates.
+	existing_transaction_name = frappe.db.get_value(
+		"Wallet Transaction",
+		{
+			"reference_doctype": "Sales Invoice",
+			"reference_name": return_invoice,
+			"transaction_type": "Credit",
+			"source_type": "Refund",
+			"docstatus": ["!=", 2],
+		},
+		"name",
+	)
+	if existing_transaction_name:
+		existing_transaction = frappe.get_doc("Wallet Transaction", existing_transaction_name)
+		if existing_transaction.docstatus == 0:
+			# Recover stuck draft created by a crashed prior attempt.
+			existing_transaction.flags.ignore_permissions = True
+			existing_transaction.submit()
+			return existing_transaction
+
+		if existing_transaction.docstatus == 1:
+			# Check if GL entries exist — a previous attempt may have set docstatus=1
+			# but failed during make_gl_entries(), leaving a broken transaction.
+			has_gl = frappe.db.exists("GL Entry", {"voucher_no": existing_transaction.name})
+			if has_gl:
+				return existing_transaction
+			# No GL entries → broken submission. Cancel and recreate below.
+			try:
+				existing_transaction.flags.ignore_permissions = True
+				existing_transaction.cancel()
+				frappe.db.commit()
+			except Exception:
+				frappe.log_error(
+					title="Wallet Transaction Recovery Error",
+					message=f"Could not cancel broken WT {existing_transaction.name}: {frappe.get_traceback()}"
+				)
+				return None
+
+	transaction = frappe.get_doc({
+		"doctype": "Wallet Transaction",
+		"transaction_type": "Credit",
+		"wallet": wallet["name"],
+		"company": company,
+		"posting_date": today(),
+		"amount": credit_amount,
+		"source_type": "Refund",
+		"source_account": source_account,
+		"reference_doctype": "Sales Invoice",
+		"reference_name": return_invoice,
+		"remarks": _("Return credit to wallet for {0} against {1}: {2}").format(
+			return_invoice,
+			return_doc.return_against or "",
+			frappe.format_value(credit_amount, {"fieldtype": "Currency"})
+		)
+	})
+	transaction.flags.ignore_permissions = True
+	transaction.insert(ignore_permissions=True)
+	transaction.submit()
+
+	frappe.msgprint(
+		_("Credited {0} to customer wallet for return {1}").format(
+			frappe.format_value(credit_amount, {"fieldtype": "Currency"}),
+			return_invoice
+		),
+		alert=True, indicator="green"
+	)
+	return transaction
+
+
 @frappe.whitelist()
 def reverse_wallet_transactions_for_return(original_invoice, return_invoice):
-    """
-    Reverse wallet transactions linked to the original invoice when a return is made.
-    
-    For full returns: Cancel the linked Wallet Transaction(s)
-    For partial returns: Create a proportional Debit transaction to reverse the credit
-    
-    Args:
-        original_invoice: Original Sales Invoice name
-        return_invoice: Return Sales Invoice name (is_return=1)
-    """
-    # Get the return invoice to calculate return ratio
-    return_doc = frappe.get_doc("Sales Invoice", return_invoice)
-    original_doc = frappe.get_doc("Sales Invoice", original_invoice)
-    
-    if not return_doc.is_return or return_doc.return_against != original_invoice:
-        return
-    
-    # Find all submitted Wallet Transactions linked to the original invoice
-    wallet_transactions = frappe.get_all(
-        "Wallet Transaction",
-        filters={
-            "reference_doctype": "Sales Invoice",
-            "reference_name": original_invoice,
-            "docstatus": 1,
-            "transaction_type": ["in", ["Credit", "Loyalty Credit"]]
-        },
-        fields=["name", "wallet", "amount", "transaction_type", "source_type",
-                "source_account", "company", "customer"]
-    )
-    
-    if not wallet_transactions:
-        return
-    
-    # Calculate return ratio based on grand_total
-    # return grand_total is negative, original is positive
-    original_total = abs(flt(original_doc.grand_total))
-    return_total = abs(flt(return_doc.grand_total))
-    
-    if original_total <= 0:
-        return
-    
-    # Check if this is a full return (all items returned)
-    return_ratio = flt(return_total / original_total, 2)
-    is_full_return = return_ratio >= 0.999  # Allow small rounding tolerance
-    
-    for wt in wallet_transactions:
-        if is_full_return:
-            # Full return - cancel the wallet transaction
-            try:
-                wt_doc = frappe.get_doc("Wallet Transaction", wt.name)
-                wt_doc.flags.ignore_permissions = True
-                wt_doc.cancel()
-                frappe.msgprint(
-                    _("Cancelled Wallet Transaction {0} due to full return").format(wt.name),
-                    alert=True, indicator="blue"
-                )
-            except Exception as e:
-                frappe.log_error(
-                    title="Wallet Transaction Cancel on Return Error",
-                    message=f"WT: {wt.name}, Return: {return_invoice}, Error: {str(e)}\n{frappe.get_traceback()}"
-                )
-        else:
-            # Partial return - create a proportional debit (reverse) transaction
-            reverse_amount = flt(wt.amount * return_ratio, 2)
-            
-            if reverse_amount <= 0:
-                continue
-            
-            try:
-                reverse_wt = frappe.get_doc({
-                    "doctype": "Wallet Transaction",
-                    "transaction_type": "Debit",
-                    "wallet": wt.wallet,
-                    "company": wt.company,
-                    "posting_date": today(),
-                    "amount": reverse_amount,
-                    "source_type": "Refund",
-                    "source_account": wt.source_account,
-                    "reference_doctype": "Sales Invoice",
-                    "reference_name": return_invoice,
-                    "remarks": _("Wallet reversal for return {0} against {1} (ratio: {2}%)").format(
-                        return_invoice, original_invoice, round(return_ratio * 100, 1)
-                    )
-                })
-                reverse_wt.flags.ignore_permissions = True
-                reverse_wt.insert()
-                reverse_wt.submit()
-                
-                frappe.msgprint(
-                    _("Created wallet debit of {0} for partial return {1}").format(
-                        frappe.format_value(reverse_amount, {"fieldtype": "Currency"}),
-                        return_invoice
-                    ),
-                    alert=True, indicator="blue"
-                )
-            except Exception as e:
-                frappe.log_error(
-                    title="Wallet Reversal on Partial Return Error",
-                    message=f"Original WT: {wt.name}, Return: {return_invoice}, "
-                            f"Amount: {reverse_amount}, Error: {str(e)}\n{frappe.get_traceback()}"
-                )
+	"""
+	Reverse wallet transactions linked to the original invoice when a return is made.
+
+	For full returns: Cancel the linked Wallet Transaction(s)
+	For partial returns: Create a proportional Debit transaction to reverse the credit
+
+	Args:
+		original_invoice: Original Sales Invoice name
+		return_invoice: Return Sales Invoice name (is_return=1)
+	"""
+	# Get the return invoice to calculate return ratio
+	return_doc = frappe.get_doc("Sales Invoice", return_invoice)
+	original_doc = frappe.get_doc("Sales Invoice", original_invoice)
+
+	if not return_doc.is_return or return_doc.return_against != original_invoice:
+		return
+
+	existing = frappe.db.exists("Wallet Transaction", {
+    "reference_name": return_invoice, "transaction_type": "Debit", "docstatus": ["!=", 2]
+	})
+	if existing:
+		return
+	# Find all submitted Wallet Transactions linked to the original invoice
+	wallet_transactions = frappe.get_all(
+		"Wallet Transaction",
+		filters={
+			"reference_doctype": "Sales Invoice",
+			"reference_name": original_invoice,
+			"docstatus": 1,
+			"transaction_type": ["in", ["Credit", "Loyalty Credit"]]
+		},
+		fields=["name", "wallet", "amount", "transaction_type", "source_type",
+				"source_account", "company", "customer"]
+	)
+
+	if not wallet_transactions:
+		return
+
+	# return grand_total is negative, original is positive
+	original_total = abs(flt(original_doc.grand_total))
+	returned_amount = abs(flt(return_doc.grand_total))
+
+	if original_total <= 0:
+		return
+
+	# Check if this is a full return
+	# Keep full precision for ratio; only round the final reverse_amount
+	return_ratio = returned_amount / original_total
+	is_full_return = return_ratio >= 0.999  # Allow small rounding tolerance
+
+	# Get loyalty program factors using the same function that calculates the original credit
+	# Original: points = eligible_amount / collection_factor, wallet = points * conversion_factor
+	loyalty_program = frappe.db.get_value("Customer", original_doc.customer, "loyalty_program")
+
+	min_spent = 0
+	below_min_threshold = False
+	if loyalty_program:
+		min_spent = frappe.db.get_value("Loyalty Program Collection",{"parent": loyalty_program},"min_spent")
+		if min_spent:
+			min_spent = flt(min_spent)
+	invoiced_amount_after_return = flt(original_total) - flt(returned_amount)
+	if min_spent and flt(invoiced_amount_after_return) < flt(min_spent):
+		below_min_threshold = True
+	for wt in wallet_transactions:
+		if is_full_return or below_min_threshold:
+			# Full return - cancel the wallet transaction
+			try:
+				wt_doc = frappe.get_doc("Wallet Transaction", wt.name)
+				wt_doc.flags.ignore_permissions = True
+				wt_doc.cancel()
+				frappe.msgprint(
+					_("Cancelled Wallet Transaction {0} due to full return").format(wt.name),
+					alert=True, indicator="blue"
+				)
+			except Exception as e:
+				frappe.log_error(
+					title="Wallet Transaction Cancel on Return Error",
+					message=f"WT: {wt.name}, Return: {return_invoice}, Error: {str(e)}\n{frappe.get_traceback()}"
+				)
+		else:
+			reverse_amount = flt(wt.amount * return_ratio, 2)
+			
+			if reverse_amount <= 0:
+				continue
+
+			try:
+				reverse_wt = frappe.get_doc({
+					"doctype": "Wallet Transaction",
+					"transaction_type": "Debit",
+					"wallet": wt.wallet,
+					"company": wt.company,
+					"posting_date": today(),
+					"amount": reverse_amount,
+					"source_type": "Refund",
+					"source_account": wt.source_account,
+					"reference_doctype": "Sales Invoice",
+					"reference_name": return_invoice,
+					"remarks": _("Wallet reversal for return {0} against {1}: returned {2}, reversed {3}").format(
+						return_invoice, original_invoice,
+						frappe.format_value(returned_amount, {"fieldtype": "Currency"}),
+						frappe.format_value(reverse_amount, {"fieldtype": "Currency"})
+					)
+				})
+				reverse_wt.flags.ignore_permissions = True
+				reverse_wt.insert()
+				reverse_wt.submit()
+
+				frappe.msgprint(
+					_("Created wallet debit of {0} for partial return {1}").format(
+						frappe.format_value(reverse_amount, {"fieldtype": "Currency"}),
+						return_invoice
+					),
+					alert=True, indicator="blue"
+				)
+			except Exception as e:
+				frappe.log_error(
+					title="Wallet Transaction Reverse on Partial Return Error",
+					message=(
+						f"WT: {wt.name}, Return: {return_invoice}, "
+						f"Original: {original_invoice}, Reverse Amount: {reverse_amount}, "
+						f"Error: {str(e)}\n{frappe.get_traceback()}"
+					)
+				)


### PR DESCRIPTION
- Add create_wallet_on_customer_insert hook for Customer after_insert
- Add force_create parameter to get_or_create_wallet for manual wallet creation
- Add credit_return_to_wallet function for crediting return amounts to customer wallet
- Improve wallet transaction GL entries with party info for Receivable/Payable accounts
- Improve error handling for broken wallet transactions (recover draft, cancel broken)
- Refactor payment account assignment into _set_payment_accounts helper (bug fix)
- Add add_to_customer_balance flag in ReturnInvoiceDialog
- Improve wallet reversal and credit error handling in submit_invoice