### PR TITLE
feat: allow searching items by item group in POS search

### DIFF
--- a/POS/src/components/sale/ItemsSelector.vue
+++ b/POS/src/components/sale/ItemsSelector.vue
@@ -839,7 +839,7 @@ const totalPages = computed(() => {
 const SEARCH_PLACEHOLDERS = Object.freeze({
 	auto: __("Auto-Add ON - Type or scan barcode"),
 	scanner: __("Scanner ON - Enable Auto for automatic addition"),
-	default: __("Search by item code, name or scan barcode"),
+	default: __("Search by item code, name, item group or scan barcode"),
 })
 
 // Sort configuration

--- a/POS/src/composables/useItems.js
+++ b/POS/src/composables/useItems.js
@@ -67,7 +67,8 @@ export function useItems(posProfile, cartItems = ref([])) {
 				(item) =>
 					item.item_name?.toLowerCase().includes(term) ||
 					item.item_code?.toLowerCase().includes(term) ||
-					item.barcode?.toLowerCase().includes(term),
+					item.barcode?.toLowerCase().includes(term) ||
+					item.item_group?.toLowerCase().includes(term)
 			)
 		}
 

--- a/pos_next/api/items.py
+++ b/pos_next/api/items.py
@@ -1114,7 +1114,7 @@ def get_items(pos_profile, search_term=None, item_group=None, start=0, limit=20,
 			search_words = [word.strip() for word in effective_search_term.split() if word.strip()]
 
 			# Word-order independent: all words must appear somewhere in item fields
-			search_text = "CONCAT(COALESCE(i.name, ''), ' ', COALESCE(i.item_name, ''), ' ', COALESCE(i.description, ''))"
+			search_text = "CONCAT(COALESCE(i.name, ''), ' ', COALESCE(i.item_name, ''), ' ', COALESCE(i.item_group, ''), ' ', COALESCE(i.description, ''))"
 			word_conditions = " AND ".join([f"{search_text} LIKE %s"] * len(search_words))
 
 			# Also match if barcode contains the search term


### PR DESCRIPTION
### Summary
This PR enhances the POS item search functionality by allowing users to search items using the **Item Group** name directly from the POS search bar.

### Problem
When there are many item groups, scrolling and selecting the correct item group filter becomes time-consuming for the cashier.

### Before
Previously, the POS search bar only supported searching by **item code**, **item name**, or **barcode**.  
If a cashier wanted to find items belonging to a specific **Item Group**, they had to manually scroll through the available item group filters and select the desired group.

This process becomes inconvenient and slower when there are many item groups available in the POS interface.

### Solution
The POS search functionality has been extended to include **Item Group names** as part of the searchable fields.

Users can now type the name of an item group directly in the search bar to quickly display items belonging to that group.

### After
![Screencastfrom2026-03-1014-02-50-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/e2439eeb-66e7-483d-a350-29d2c9affa2f)