### PR TITLE
feat: implement ignore_pricing_rule in POS Profile

### DIFF
--- a/POS/src/stores/posCart.js
+++ b/POS/src/stores/posCart.js
@@ -1,6 +1,7 @@
 import { useInvoice } from "@/composables/useInvoice"
 import { usePOSOffersStore } from "@/stores/posOffers"
 import { usePOSSettingsStore } from "@/stores/posSettings"
+import { usePOSShiftStore } from "@/stores/posShift"
 import { parseError } from "@/utils/errorHandler"
 import {
 	shouldValidateItemStock,
@@ -1373,6 +1374,12 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		// Only process offers if we have a POS profile
 		// posProfile.value is the profile NAME (a string), not an object
 		if (!posProfile.value) {
+			return
+		}
+
+		// Skip offer processing if POS Profile has ignore_pricing_rule enabled
+		const shiftStore = usePOSShiftStore()
+		if (shiftStore.currentProfile?.ignore_pricing_rule) {
 			return
 		}
 

--- a/POS/src/stores/posOffers.js
+++ b/POS/src/stores/posOffers.js
@@ -3,6 +3,7 @@ import { computed, ref } from "vue"
 import { call } from "@/utils/apiWrapper"
 import { isOffline } from "@/utils/offline"
 import { offlineWorker } from "@/utils/offline/workerClient"
+import { usePOSShiftStore } from "@/stores/posShift"
 
 const defaultSnapshot = () => ({
 	subtotal: 0,
@@ -283,6 +284,13 @@ export const usePOSOffersStore = defineStore("posOffers", () => {
 	 * @returns {Promise<boolean>} True if offers are available (fetched or cached)
 	 */
 	async function ensureOffersFetched(posProfile) {
+		// Skip fetching offers if POS Profile has ignore_pricing_rule enabled
+		const shiftStore = usePOSShiftStore()
+		if (shiftStore.currentProfile?.ignore_pricing_rule) {
+			hasFetched.value = true
+			return false
+		}
+
 		// If already fetched, return immediately
 		if (hasFetched.value) {
 			return true

--- a/pos_next/api/bootstrap.py
+++ b/pos_next/api/bootstrap.py
@@ -97,6 +97,7 @@ def get_initial_data():
 		"print_format": pos_profile.get("print_format"),
 		"auto_print": pos_profile.get("print_receipt_on_order_complete", 0),
 		"country": pos_profile.get("country"),
+		"ignore_pricing_rule": pos_profile.ignore_pricing_rule or 0,
 	}
 
 	result["pos_settings"] = _get_pos_settings(pos_profile)

--- a/pos_next/api/invoices.py
+++ b/pos_next/api/invoices.py
@@ -2634,6 +2634,10 @@ def apply_offers(invoice_data, selected_offers=None):
 
         profile = frappe.get_cached_doc("POS Profile", invoice.get("pos_profile"))
 
+        # Respect POS Profile's ignore_pricing_rule setting
+        if profile.ignore_pricing_rule:
+            return {"items": items}
+
         # Batch fetch all item details in a single query (reduces N queries to 1)
         item_codes = list({item.get("item_code") for item in items if item.get("item_code")})
         item_details_map = {}

--- a/pos_next/api/offers.py
+++ b/pos_next/api/offers.py
@@ -405,6 +405,11 @@ def get_offers(pos_profile: str) -> List[Dict]:
 	"""
 	try:
 		profile = frappe.get_doc("POS Profile", pos_profile)
+
+		# Respect POS Profile's ignore_pricing_rule setting
+		if profile.ignore_pricing_rule:
+			return []
+
 		date = nowdate()
 
 		offers = []


### PR DESCRIPTION
Added functionality to respect the ignore_pricing_rule setting in the POS Profile across various components. This change prevents offer processing and fetching when the rule is enabled, ensuring that pricing rules are correctly applied based on the profile's configuration.