### PR TITLE
fix: update date filtering in sales vs shifts report

### DIFF
--- a/pos_next/pos_next/report/sales_vs_shifts_report/sales_vs_shifts_report.py
+++ b/pos_next/pos_next/report/sales_vs_shifts_report/sales_vs_shifts_report.py
@@ -683,9 +683,9 @@ def build_conditions(filters):
 	conditions = []
 
 	if filters.get("from_date"):
-		conditions.append("pcs.period_start_date >= %(from_date)s")
+		conditions.append("DATE(pcs.period_start_date) >= %(from_date)s")
 	if filters.get("to_date"):
-		conditions.append("pcs.period_end_date <= %(to_date)s")
+		conditions.append("DATE(pcs.period_end_date) <= %(to_date)s")
 	if filters.get("pos_profile"):
 		conditions.append("pcs.pos_profile = %(pos_profile)s")
 	if filters.get("cashier"):


### PR DESCRIPTION
Refine date conditions in the sales vs shifts report to ensure proper filtering by converting date fields to the correct format. This change enhances the accuracy of the report's date range functionality.