### PR TITLE
fix: enforce one-use coupons across submitted sales invoices

### DIFF
--- a/pos_next/pos_next/doctype/pos_coupon/pos_coupon.py
+++ b/pos_next/pos_next/doctype/pos_coupon/pos_coupon.py
@@ -9,6 +9,9 @@ from frappe.utils import strip, flt
 from frappe.utils import getdate, today
 
 
+ONE_USE_COUPON_DOCTYPES = ("Sales Invoice", "POS Invoice")
+
+
 class POSCoupon(Document):
     def autoname(self):
         self.coupon_name = strip(self.coupon_name)
@@ -101,12 +104,7 @@ def check_coupon_code(coupon_code, customer=None, company=None):
 
     # Check one-time use per customer
     if coupon.one_use and customer:
-        # Check if customer has already used this coupon
-        used_count = frappe.db.count("POS Invoice", filters={
-            "customer": customer,
-            "coupon_code": coupon.coupon_code,
-            "docstatus": 1
-        })
+        used_count = _get_customer_coupon_usage_count(customer, coupon.coupon_code)
         if used_count > 0:
             res["msg"] = _("Sorry, you have already used this coupon code")
             return res
@@ -116,6 +114,27 @@ def check_coupon_code(coupon_code, customer=None, company=None):
     res["valid"] = True
 
     return res
+
+
+def _get_customer_coupon_usage_count(customer, coupon_code):
+    """Count submitted coupon usage across POSNext's actual sales doctypes."""
+    used_count = 0
+
+    for doctype in ONE_USE_COUPON_DOCTYPES:
+        if not frappe.db.table_exists(doctype):
+            continue
+
+        meta = frappe.get_meta(doctype)
+        if not meta.has_field("coupon_code"):
+            continue
+
+        used_count += frappe.db.count(doctype, filters={
+            "customer": customer,
+            "coupon_code": coupon_code,
+            "docstatus": 1,
+        })
+
+    return used_count
 
 
 def apply_coupon_discount(coupon, cart_total, net_total=None):

--- a/pos_next/pos_next/doctype/pos_coupon/test_pos_coupon.py
+++ b/pos_next/pos_next/doctype/pos_coupon/test_pos_coupon.py
@@ -1,9 +1,55 @@
 # Copyright (c) 2021, Youssef Restom and Contributors
 # See license.txt
 
-# import frappe
 import unittest
+from unittest.mock import Mock, patch
+
+from pos_next.pos_next.doctype.pos_coupon.pos_coupon import (
+    _get_customer_coupon_usage_count,
+)
 
 
 class TestPOSCoupon(unittest.TestCase):
-    pass
+    @patch("pos_next.pos_next.doctype.pos_coupon.pos_coupon.frappe.get_meta")
+    @patch("pos_next.pos_next.doctype.pos_coupon.pos_coupon.frappe.db")
+    def test_one_use_coupon_counts_sales_invoice_and_pos_invoice(self, mock_db, mock_get_meta):
+        def table_exists(doctype):
+            return doctype in {"Sales Invoice", "POS Invoice"}
+
+        def count(doctype, filters=None):
+            counts = {"Sales Invoice": 1, "POS Invoice": 2}
+            return counts[doctype]
+
+        mock_db.table_exists.side_effect = table_exists
+        mock_db.count.side_effect = count
+        mock_get_meta.return_value = Mock(has_field=Mock(return_value=True))
+
+        used_count = _get_customer_coupon_usage_count("Customer A", "SAVE10")
+
+        self.assertEqual(used_count, 3)
+        mock_db.count.assert_any_call(
+            "Sales Invoice",
+            filters={"customer": "Customer A", "coupon_code": "SAVE10", "docstatus": 1},
+        )
+        mock_db.count.assert_any_call(
+            "POS Invoice",
+            filters={"customer": "Customer A", "coupon_code": "SAVE10", "docstatus": 1},
+        )
+
+    @patch("pos_next.pos_next.doctype.pos_coupon.pos_coupon.frappe.get_meta")
+    @patch("pos_next.pos_next.doctype.pos_coupon.pos_coupon.frappe.db")
+    def test_one_use_coupon_skips_doctypes_without_coupon_field(self, mock_db, mock_get_meta):
+        mock_db.table_exists.return_value = True
+        mock_db.count.return_value = 4
+        mock_get_meta.side_effect = [
+            Mock(has_field=Mock(return_value=True)),
+            Mock(has_field=Mock(return_value=False)),
+        ]
+
+        used_count = _get_customer_coupon_usage_count("Customer A", "SAVE10")
+
+        self.assertEqual(used_count, 4)
+        mock_db.count.assert_called_once_with(
+            "Sales Invoice",
+            filters={"customer": "Customer A", "coupon_code": "SAVE10", "docstatus": 1},
+        )


### PR DESCRIPTION
## Summary
- count one-use coupon usage across submitted Sales Invoice and legacy POS Invoice records
- skip doctypes that do not expose a coupon_code field
- add regression tests for the one-use coupon usage helper

## Testing
- python3 -m py_compile pos_next/pos_next/doctype/pos_coupon/pos_coupon.py pos_next/pos_next/doctype/pos_coupon/test_pos_coupon.py
- full Frappe unit tests were not run in this workspace because the frappe module is not installed here

Closes #194