### PR TITLE
fix: submit customer credit redemption payload from POS

### DIFF
--- a/POS/src/composables/useInvoice.js
+++ b/POS/src/composables/useInvoice.js
@@ -820,6 +820,76 @@ export function useInvoice() {
 		}
 	}
 
+	function serializeInvoicePayments(rawPayments) {
+		return rawPayments
+			.filter((payment) => !payment?.is_customer_credit)
+			.map((payment) => ({
+				mode_of_payment: payment.mode_of_payment,
+				amount: payment.amount,
+				type: payment.type,
+			}))
+	}
+
+	function buildCustomerCreditPayload(rawPayments) {
+		const creditPayments = rawPayments.filter((payment) => payment?.is_customer_credit)
+
+		if (!creditPayments.length) {
+			return {
+				invoicePayments: serializeInvoicePayments(rawPayments),
+				redeemedCustomerCredit: 0,
+				customerCreditDict: [],
+			}
+		}
+
+		const creditSources = new Map()
+		for (const payment of creditPayments) {
+			for (const credit of payment.credit_details || []) {
+				if (!credit?.type || !credit?.credit_origin) continue
+				const key = `${credit.type}:${credit.credit_origin}`
+				if (!creditSources.has(key)) {
+					creditSources.set(key, credit)
+				}
+			}
+		}
+
+		const redeemedCustomerCredit = roundCurrency(
+			creditPayments.reduce((sum, payment) => sum + Number(payment.amount || 0), 0),
+		)
+
+		let remainingCreditToAllocate = redeemedCustomerCredit
+		const customerCreditDict = []
+
+		for (const credit of creditSources.values()) {
+			if (remainingCreditToAllocate <= 0) break
+
+			const availableCredit = roundCurrency(
+				Number(credit.available_credit ?? credit.total_credit ?? 0),
+			)
+			if (availableCredit <= 0) continue
+
+			const creditToRedeem = Math.min(availableCredit, remainingCreditToAllocate)
+			if (creditToRedeem <= 0) continue
+
+			customerCreditDict.push({
+				...credit,
+				credit_to_redeem: roundCurrency(creditToRedeem),
+			})
+			remainingCreditToAllocate = roundCurrency(
+				remainingCreditToAllocate - creditToRedeem,
+			)
+		}
+
+		if (remainingCreditToAllocate > 0.01) {
+			throw new Error("Unable to allocate the selected customer credit")
+		}
+
+		return {
+			invoicePayments: serializeInvoicePayments(rawPayments),
+			redeemedCustomerCredit,
+			customerCreditDict,
+		}
+	}
+
 	async function saveDraft(targetDoctype = "Sales Invoice") {
 		/**
 		 * Save invoice as draft (Step 1)
@@ -828,6 +898,7 @@ export function useInvoice() {
 		// Use toRaw() to ensure we get current, non-reactive values (prevents stale cached quantities)
 		const rawItems = toRaw(invoiceItems.value)
 		const rawPayments = toRaw(payments.value)
+		const { invoicePayments } = buildCustomerCreditPayload(rawPayments)
 
 		const invoiceData = {
 			doctype: targetDoctype,
@@ -835,11 +906,7 @@ export function useInvoice() {
 			posa_pos_opening_shift: posOpeningShift.value,
 			customer: customer.value?.name || customer.value,
 			items: formatItemsForSubmission(rawItems),
-			payments: rawPayments.map((p) => ({
-				mode_of_payment: p.mode_of_payment,
-				amount: p.amount,
-				type: p.type,
-			})),
+			payments: invoicePayments,
 			discount_amount: additionalDiscount.value || 0,
 			coupon_code: couponCode.value,
 			is_pos: 1,
@@ -892,6 +959,11 @@ export function useInvoice() {
 				const rawItems = toRaw(invoiceItems.value)
 				const rawPayments = toRaw(payments.value)
 				const rawSalesTeam = toRaw(salesTeam.value)
+				const {
+					invoicePayments,
+					redeemedCustomerCredit,
+					customerCreditDict,
+				} = buildCustomerCreditPayload(rawPayments)
 
 				const invoiceData = {
 					doctype: targetDoctype,
@@ -899,11 +971,7 @@ export function useInvoice() {
 					posa_pos_opening_shift: posOpeningShift.value,
 					customer: customer.value?.name || customer.value,
 					items: formatItemsForSubmission(rawItems),
-					payments: rawPayments.map((p) => ({
-						mode_of_payment: p.mode_of_payment,
-						amount: p.amount,
-						type: p.type,
-					})),
+					payments: invoicePayments,
 					discount_amount: additionalDiscount.value || 0,
 					coupon_code: couponCode.value,
 					is_pos: 1,
@@ -945,6 +1013,11 @@ export function useInvoice() {
 					change_amount:
 						remainingAmount.value < 0 ? Math.abs(remainingAmount.value) : 0,
 					write_off_amount: writeOffAmount || 0,
+				}
+
+				if (redeemedCustomerCredit > 0 && customerCreditDict.length > 0) {
+					submitData.redeemed_customer_credit = redeemedCustomerCredit
+					submitData.customer_credit_dict = customerCreditDict
 				}
 
 				try {

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -1956,6 +1956,7 @@ async function handlePaymentCompleted(paymentData) {
 		if (paymentData.payments && Array.isArray(paymentData.payments)) {
 			paymentData.payments.forEach((p) => {
 				cartStore.payments.push({
+					...p,
 					mode_of_payment: p.mode_of_payment,
 					amount: p.amount,
 					type: p.type,

--- a/pos_next/api/invoices.py
+++ b/pos_next/api/invoices.py
@@ -1350,6 +1350,12 @@ def submit_invoice(invoice=None, data=None):
         # (global Stock Settings, POS Settings, and POS Profile flags)
         _validate_stock_on_invoice(invoice_doc)
 
+        # Allow pure customer-credit POS sales to submit without a payment row.
+        customer_credit_dict = data.get("customer_credit_dict") or invoice.get("customer_credit_dict")
+        redeemed_customer_credit = data.get("redeemed_customer_credit") or invoice.get("redeemed_customer_credit")
+        if redeemed_customer_credit and not invoice_doc.payments:
+            invoice_doc.flags.pos_next_redeemed_customer_credit = flt(redeemed_customer_credit)
+
         # Save before submit
         invoice_doc.flags.ignore_permissions = True
         frappe.flags.ignore_account_permission = True
@@ -1414,9 +1420,6 @@ def submit_invoice(invoice=None, data=None):
             _complete_offline_sync(sync_record_name, invoice_doc.name)
 
         # Handle credit redemption after successful submission
-        customer_credit_dict = data.get("customer_credit_dict") or invoice.get("customer_credit_dict")
-        redeemed_customer_credit = data.get("redeemed_customer_credit") or invoice.get("redeemed_customer_credit")
-
         if redeemed_customer_credit and customer_credit_dict:
             try:
                 from pos_next.api.credit_sales import redeem_customer_credit

--- a/pos_next/overrides/sales_invoice.py
+++ b/pos_next/overrides/sales_invoice.py
@@ -129,6 +129,21 @@ class CustomSalesInvoice(SalesInvoice):
 					# and appends change amount entries directly to it
 					self.make_gle_for_change_amount(gl_entries)
 
+	def validate_pos_paid_amount(self):
+		"""
+		Allow pure customer-credit POS sales to submit without a payment row.
+
+		POSNext redeems customer credit after submit through Journal Entries /
+		Payment Entry allocation, so there is no real Mode of Payment row to send.
+		Only bypass the core POS payment-row check when submit_invoice has explicitly
+		marked the document for customer-credit redemption.
+		"""
+		if getattr(self.flags, "pos_next_redeemed_customer_credit", 0):
+			if len(self.payments) == 0 and cint(self.is_pos) and flt(self.grand_total) > 0:
+				return
+
+		super().validate_pos_paid_amount()
+
 	def get_party_and_party_type_for_pos_gl_entry(self, mode_of_payment, account):
 		"""
 		Get party type and party for wallet payment GL entries.


### PR DESCRIPTION
## Summary

Fix customer-credit POS sales so the frontend submits the redemption payload the backend already expects.

Before this change:
- the payment dialog created `Customer Credit` entries with `is_customer_credit` and `credit_details`
- `POSSale.vue` stripped that metadata before submit
- `submit_invoice()` never received `customer_credit_dict` / `redeemed_customer_credit`
- pure customer-credit sales could not redeem credit correctly

This patch:
- preserves customer-credit metadata through the POS submit flow
- builds `customer_credit_dict` and `redeemed_customer_credit` in `useInvoice.js`
- excludes synthetic `Customer Credit` rows from normal invoice `payments`
- allows pure customer-credit POS sales to pass core POS payment-row validation only when POSNext has explicitly marked the invoice for redemption

## Validation

- reproduced the bug on staging (`frappe 16.12.0`, `erpnext 16.11.0`, `pos_next 1.15.0`)
- applied the fix on staging and reran the same bench-console sale flow
- confirmed the invoice submitted successfully
- confirmed customer-credit redemption created a linked Journal Entry
- confirmed the saved invoice finished with `outstanding_amount = 0`

## Issue

Closes #210
