### PR TITLE
fix: honor coupon apply_on in POS

### DIFF
--- a/POS/src/components/sale/CouponDialog.vue
+++ b/POS/src/components/sale/CouponDialog.vue
@@ -162,6 +162,14 @@ const props = defineProps({
 		required: true,
 		note: __("Cart subtotal BEFORE tax - used for discount calculations"),
 	},
+	taxAmount: {
+		type: Number,
+		default: 0,
+	},
+	grandTotal: {
+		type: Number,
+		default: 0,
+	},
 	items: Array,
 	posProfile: String,
 	customer: String,
@@ -257,6 +265,14 @@ function applyGiftCard(card) {
 	applyCoupon()
 }
 
+function getCouponBaseAmount(coupon) {
+	const grandTotal = Number.parseFloat(props.grandTotal || 0)
+	const taxAmount = Number.parseFloat(props.taxAmount || 0)
+	const netTotal = Math.max(grandTotal - taxAmount, 0)
+
+	return coupon.apply_on === "Grand Total" ? grandTotal : netTotal
+}
+
 async function applyCoupon() {
 	if (!couponCode.value.trim()) {
 		errorMessage.value = __("Please enter a coupon code")
@@ -282,9 +298,10 @@ async function applyCoupon() {
 		}
 
 		const coupon = validationData.coupon
+		const baseAmount = getCouponBaseAmount(coupon)
 
-		// Check minimum amount (on subtotal before tax)
-		if (coupon.min_amount && props.subtotal < coupon.min_amount) {
+		// Check minimum amount on the configured coupon base
+		if (coupon.min_amount && baseAmount < coupon.min_amount) {
 			errorMessage.value = __('This coupon requires a minimum purchase of ', [formatCurrency(coupon.min_amount)])
 			showWarning(errorMessage.value)
 			return
@@ -297,15 +314,15 @@ async function applyCoupon() {
 			amount: coupon.discount_type === "Amount" ? coupon.discount_amount : 0,
 		}
 
-		let discountAmount = calculateDiscountAmount(discountObj, props.subtotal)
+		let discountAmount = calculateDiscountAmount(discountObj, baseAmount)
 
 		// Apply maximum discount limit if specified
 		if (coupon.max_amount && discountAmount > coupon.max_amount) {
 			discountAmount = coupon.max_amount
 		}
 
-		// Clamp discount to subtotal to prevent negative totals
-		discountAmount = Math.min(discountAmount, props.subtotal)
+		// Clamp discount to the selected coupon base to prevent negative totals
+		discountAmount = Math.min(discountAmount, baseAmount)
 
 		appliedDiscount.value = {
 			name: coupon.coupon_name || coupon.coupon_code,
@@ -315,6 +332,7 @@ async function applyCoupon() {
 			type: coupon.discount_type,
 			coupon: coupon,
 			apply_on: coupon.apply_on,
+			base_amount: baseAmount,
 		}
 
 		emit("discount-applied", appliedDiscount.value)

--- a/POS/src/composables/useInvoice.js
+++ b/POS/src/composables/useInvoice.js
@@ -534,12 +534,17 @@ export function useInvoice() {
 		// Store coupon code for tracking
 		couponCode.value = discount.code || discount.name
 
-		// Use centralized calculation to handle percentage/amount and clamping
-		let discountAmount = calculateDiscountAmount(discount, subtotal.value)
+		const baseAmount =
+			typeof discount.base_amount === "number"
+				? discount.base_amount
+				: subtotal.value
 
-		// Clamp discount to subtotal (cannot exceed total)
-		if (discountAmount > subtotal.value) {
-			discountAmount = subtotal.value
+		// Use centralized calculation to handle percentage/amount and clamping
+		let discountAmount = calculateDiscountAmount(discount, baseAmount)
+
+		// Clamp discount to the same base the coupon was calculated against
+		if (discountAmount > baseAmount) {
+			discountAmount = baseAmount
 		}
 
 		// Ensure non-negative

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -545,6 +545,8 @@
 			<CouponDialog
 				v-model="uiStore.showCouponDialog"
 				:subtotal="cartStore.subtotal"
+				:tax-amount="cartStore.totalTax"
+				:grand-total="cartStore.grandTotal"
 				:items="cartStore.invoiceItems"
 				:pos-profile="shiftStore.profileName"
 				:customer="cartStore.customer?.name || cartStore.customer"


### PR DESCRIPTION
## Summary
- honor coupon `apply_on` when computing the discount amount in the POS coupon dialog
- use the same selected base amount when applying the coupon to the cart so percentage coupons are not recalculated against subtotal
- pass tax and grand total into the coupon dialog so `Grand Total` and `Net Total` coupons produce different results as intended

## Root cause
`CouponDialog.vue` always validated `min_amount` and calculated the coupon from `subtotal`, even when the coupon itself carried `apply_on = "Grand Total"` or `apply_on = "Net Total"`.

The stale frontend calculation was then repeated in `useInvoice.applyDiscount()`, which recalculated percentage discounts against `subtotal` again.

## Validation
- confirmed on the staging code path before patching: coupon dialog ignored `coupon.apply_on` and always used `subtotal`
- confirmed current upstream code still had the same behavior before patching
- deployed the patch to a staging environment and rebuilt POS assets
- local verification was limited to `git diff --check` in this workspace
