### PR TITLE
fix: validate customer credit source ownership

### DIFF
--- a/pos_next/api/credit_sales.py
+++ b/pos_next/api/credit_sales.py
@@ -284,7 +284,12 @@ def redeem_customer_credit(invoice_name, customer_credit_dict):
 
 		if credit_type == "Invoice":
 			# Validate and lock the credit source before creating JE
-			_validate_and_lock_invoice_credit(credit_origin, credit_to_redeem)
+			_validate_and_lock_invoice_credit(
+				credit_origin,
+				credit_to_redeem,
+				invoice_doc.customer,
+				invoice_doc.company,
+			)
 
 			# Create JE to allocate credit from original invoice to new invoice
 			je_name = _create_credit_allocation_journal_entry(
@@ -296,7 +301,12 @@ def redeem_customer_credit(invoice_name, customer_credit_dict):
 
 		elif credit_type == "Advance":
 			# Validate and lock the advance payment before allocation
-			_validate_and_lock_advance_credit(credit_origin, credit_to_redeem)
+			_validate_and_lock_advance_credit(
+				credit_origin,
+				credit_to_redeem,
+				invoice_doc.customer,
+				invoice_doc.company,
+			)
 
 			# Create Payment Entry to allocate advance payment
 			pe_name = _create_payment_entry_from_advance(
@@ -309,7 +319,20 @@ def redeem_customer_credit(invoice_name, customer_credit_dict):
 	return created_journal_entries
 
 
-def _validate_and_lock_invoice_credit(invoice_name, amount_to_redeem):
+def _validate_credit_source_ownership(source_name, source_customer, source_company, customer, company):
+	"""Ensure a credit source belongs to the same customer and company as the target invoice."""
+	if source_customer != customer:
+		frappe.throw(
+			_("Credit source {0} does not belong to customer {1}").format(source_name, customer)
+		)
+
+	if source_company != company:
+		frappe.throw(
+			_("Credit source {0} does not belong to company {1}").format(source_name, company)
+		)
+
+
+def _validate_and_lock_invoice_credit(invoice_name, amount_to_redeem, customer, company):
 	"""
 	Validate and lock invoice credit using SELECT FOR UPDATE.
 	This prevents race conditions when multiple users try to use the same credit.
@@ -317,6 +340,8 @@ def _validate_and_lock_invoice_credit(invoice_name, amount_to_redeem):
 	Args:
 		invoice_name: Source invoice name with credit
 		amount_to_redeem: Amount being redeemed
+		customer: Target invoice customer
+		company: Target invoice company
 
 	Raises:
 		frappe.ValidationError: If insufficient credit available
@@ -329,7 +354,12 @@ def _validate_and_lock_invoice_credit(invoice_name, amount_to_redeem):
 	# This blocks other transactions from reading/modifying until we commit
 	query = (
 		frappe.qb.from_(SalesInvoice)
-		.select(SalesInvoice.name, SalesInvoice.outstanding_amount)
+		.select(
+			SalesInvoice.name,
+			SalesInvoice.outstanding_amount,
+			SalesInvoice.customer,
+			SalesInvoice.company,
+		)
 		.where(
 			(SalesInvoice.name == invoice_name) &
 			(SalesInvoice.docstatus == 1)
@@ -341,6 +371,14 @@ def _validate_and_lock_invoice_credit(invoice_name, amount_to_redeem):
 
 	if not result:
 		frappe.throw(_("Credit source invoice {0} not found or not submitted").format(invoice_name))
+
+	_validate_credit_source_ownership(
+		invoice_name,
+		result[0].customer,
+		result[0].company,
+		customer,
+		company,
+	)
 
 	current_outstanding = flt(result[0].outstanding_amount)
 	available_credit = -current_outstanding  # Credit is negative outstanding
@@ -355,7 +393,7 @@ def _validate_and_lock_invoice_credit(invoice_name, amount_to_redeem):
 		)
 
 
-def _validate_and_lock_advance_credit(payment_entry_name, amount_to_redeem):
+def _validate_and_lock_advance_credit(payment_entry_name, amount_to_redeem, customer, company):
 	"""
 	Validate and lock advance payment using SELECT FOR UPDATE.
 	This prevents race conditions when multiple users try to use the same advance.
@@ -363,6 +401,8 @@ def _validate_and_lock_advance_credit(payment_entry_name, amount_to_redeem):
 	Args:
 		payment_entry_name: Payment Entry name with unallocated amount
 		amount_to_redeem: Amount being allocated
+		customer: Target invoice customer
+		company: Target invoice company
 
 	Raises:
 		frappe.ValidationError: If insufficient unallocated amount
@@ -374,7 +414,14 @@ def _validate_and_lock_advance_credit(payment_entry_name, amount_to_redeem):
 	# Use SELECT FOR UPDATE to lock the row
 	query = (
 		frappe.qb.from_(PaymentEntry)
-		.select(PaymentEntry.name, PaymentEntry.unallocated_amount)
+		.select(
+			PaymentEntry.name,
+			PaymentEntry.unallocated_amount,
+			PaymentEntry.party,
+			PaymentEntry.company,
+			PaymentEntry.party_type,
+			PaymentEntry.payment_type,
+		)
 		.where(
 			(PaymentEntry.name == payment_entry_name) &
 			(PaymentEntry.docstatus == 1)
@@ -386,6 +433,19 @@ def _validate_and_lock_advance_credit(payment_entry_name, amount_to_redeem):
 
 	if not result:
 		frappe.throw(_("Payment Entry {0} not found or not submitted").format(payment_entry_name))
+
+	if result[0].party_type != "Customer" or result[0].payment_type != "Receive":
+		frappe.throw(
+			_("Payment Entry {0} is not a valid customer advance").format(payment_entry_name)
+		)
+
+	_validate_credit_source_ownership(
+		payment_entry_name,
+		result[0].party,
+		result[0].company,
+		customer,
+		company,
+	)
 
 	available_amount = flt(result[0].unallocated_amount)
 
@@ -417,6 +477,14 @@ def _create_credit_allocation_journal_entry(invoice_doc, original_invoice_name, 
 	"""
 	# Get original invoice
 	original_invoice = frappe.get_doc("Sales Invoice", original_invoice_name)
+
+	_validate_credit_source_ownership(
+		original_invoice.name,
+		original_invoice.customer,
+		original_invoice.company,
+		invoice_doc.customer,
+		invoice_doc.company,
+	)
 
 	# Get cost center
 	cost_center = invoice_doc.get("cost_center") or frappe.get_cached_value(
@@ -485,6 +553,19 @@ def _create_payment_entry_from_advance(invoice_doc, payment_entry_name, amount):
 	"""
 	# Get payment entry
 	payment_entry = frappe.get_doc("Payment Entry", payment_entry_name)
+
+	if payment_entry.party_type != "Customer" or payment_entry.payment_type != "Receive":
+		frappe.throw(
+			_("Payment Entry {0} is not a valid customer advance").format(payment_entry_name)
+		)
+
+	_validate_credit_source_ownership(
+		payment_entry.name,
+		payment_entry.party,
+		payment_entry.company,
+		invoice_doc.customer,
+		invoice_doc.company,
+	)
 
 	# Check if already allocated
 	if payment_entry.unallocated_amount < amount:

--- a/pos_next/api/test_credit_sales.py
+++ b/pos_next/api/test_credit_sales.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2025, BrainWise and contributors
+# For license information, please see license.txt
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from pos_next.api import credit_sales
+
+
+def _builder_with_result(result):
+	builder = Mock()
+	builder.select.return_value = builder
+	builder.where.return_value = builder
+	builder.for_update.return_value = builder
+	builder.run.return_value = result
+	return builder
+
+
+def _raise_runtime_error(message):
+	raise RuntimeError(str(message))
+
+
+class TestCreditSales(unittest.TestCase):
+	@patch("pos_next.api.credit_sales.frappe.throw", side_effect=_raise_runtime_error)
+	@patch("pos_next.api.credit_sales.frappe.qb.from_")
+	def test_validate_invoice_credit_rejects_mismatched_customer(self, mock_from, _mock_throw):
+		mock_from.return_value = _builder_with_result(
+			[
+				SimpleNamespace(
+					name="SRC-INV",
+					outstanding_amount=-100,
+					customer="Other Customer",
+					company="Sonex",
+				)
+			]
+		)
+
+		with self.assertRaisesRegex(RuntimeError, "does not belong to customer Guest"):
+			credit_sales._validate_and_lock_invoice_credit("SRC-INV", 50, "Guest", "Sonex")
+
+	@patch("pos_next.api.credit_sales.frappe.throw", side_effect=_raise_runtime_error)
+	@patch("pos_next.api.credit_sales.frappe.qb.from_")
+	def test_validate_advance_credit_rejects_mismatched_company(self, mock_from, _mock_throw):
+		mock_from.return_value = _builder_with_result(
+			[
+				SimpleNamespace(
+					name="PE-0001",
+					unallocated_amount=100,
+					party="Guest",
+					company="Other Company",
+					party_type="Customer",
+					payment_type="Receive",
+				)
+			]
+		)
+
+		with self.assertRaisesRegex(RuntimeError, "does not belong to company Sonex"):
+			credit_sales._validate_and_lock_advance_credit("PE-0001", 50, "Guest", "Sonex")
+
+	@patch("pos_next.api.credit_sales._create_credit_allocation_journal_entry")
+	@patch("pos_next.api.credit_sales._validate_and_lock_invoice_credit")
+	@patch("pos_next.api.credit_sales.frappe.get_doc")
+	def test_redeem_customer_credit_passes_invoice_context_to_validators(
+		self,
+		mock_get_doc,
+		mock_validate_invoice,
+		mock_create_je,
+	):
+		invoice_doc = Mock()
+		invoice_doc.docstatus = 1
+		invoice_doc.customer = "Guest"
+		invoice_doc.company = "Sonex"
+		mock_get_doc.return_value = invoice_doc
+		mock_create_je.return_value = "ACC-JV-0001"
+
+		result = credit_sales.redeem_customer_credit(
+			"ACC-SINV-0001",
+			[
+				{
+					"type": "Invoice",
+					"credit_origin": "SRC-INV",
+					"credit_to_redeem": 75,
+				}
+			],
+		)
+
+		self.assertEqual(result, ["ACC-JV-0001"])
+		mock_validate_invoice.assert_called_once_with("SRC-INV", 75, "Guest", "Sonex")
+
+	@patch("pos_next.api.credit_sales.frappe.throw", side_effect=_raise_runtime_error)
+	def test_create_payment_entry_from_advance_rejects_non_customer_receive_entries(self, _mock_throw):
+		invoice_doc = Mock()
+		invoice_doc.customer = "Guest"
+		invoice_doc.company = "Sonex"
+
+		payment_entry = Mock()
+		payment_entry.party_type = "Supplier"
+		payment_entry.payment_type = "Pay"
+
+		with patch("pos_next.api.credit_sales.frappe.get_doc", return_value=payment_entry):
+			with self.assertRaisesRegex(RuntimeError, "is not a valid customer advance"):
+				credit_sales._create_payment_entry_from_advance(invoice_doc, "PE-0001", 25)


### PR DESCRIPTION
## Summary
- validate that credit redemption sources belong to the same customer and company as the target invoice
- reject non-customer or non-receive payment entries before advance allocation
- add regression tests for invoice-credit, advance-credit, and redemption-context validation

## Problem
`redeem_customer_credit()` accepted client-supplied source document names and only validated submission state and available amount.

That meant invoice-credit and advance-credit sources were not checked against the target invoice's customer or company before allocation.

## Staging Reproduction
Confirmed on a staging environment (ERPNext `16.11.0` / POSNext `1.15.0`):
- staging only had one real customer/company, so I used temporary rows inside a single DB transaction and rolled them back
- `_validate_and_lock_invoice_credit()` passed for a submitted source row owned by `TEMP-OTHER-CUSTOMER` / `OTHER-COMPANY`
- `_validate_and_lock_advance_credit()` also passed for a submitted advance row owned by `TEMP-OTHER-CUSTOMER` / `OTHER-COMPANY`
- current code accepted both because the validators had no target customer/company inputs and no ownership checks

## Fix
- pass target invoice customer/company into both validation helpers
- validate source customer/company under the row lock before allocation
- keep the same ownership checks in the downstream JE / Payment Entry mutation paths for defense in depth

## Verification
- staging reproduction confirmed the original bug
- local verification was limited to `py_compile` in this workspace
