### PR TITLE
feat: auto-select quantity input when UOM dialog opens

### DIFF
--- a/POS/src/components/sale/ItemSelectionDialog.vue
+++ b/POS/src/components/sale/ItemSelectionDialog.vue
@@ -118,6 +118,7 @@
 							</button>
 							<div class="flex-1 h-full flex items-center justify-center px-3">
 								<input
+									ref="quantityInput"
 									v-model.number="quantity"
 									type="number"
 									min="1"
@@ -236,7 +237,7 @@
 import { DEFAULT_CURRENCY, formatCurrency as formatCurrencyUtil } from "@/utils/currency"
 import { Button, Dialog } from "frappe-ui"
 import { createResource } from "frappe-ui"
-import { computed, ref, watch } from "vue"
+import { computed, nextTick, ref, watch } from "vue"
 import TranslatedHTML from "../common/TranslatedHTML.vue"
 import { offlineState } from "@/utils/offline/offlineState"
 import { getCachedVariants, cacheItems } from "@/utils/offline/items"
@@ -267,6 +268,7 @@ const options = ref([])
 const selectedOption = ref(null)
 const quantity = ref(1)
 const selectedAttributes = ref({}) // For variant attribute selection
+const quantityInput = ref(null)
 
 // Computed properties for dialog customization
 const dialogTitle = computed(() => {
@@ -430,6 +432,11 @@ watch(
 	(isOpen) => {
 		if (isOpen && props.item) {
 			loadOptions()
+		}
+		if (isOpen && props.mode === "uom") {
+			nextTick(() => {
+				setTimeout(() => { quantityInput.value?.focus(); quantityInput.value?.select() }, 100)
+			})
 		}
 	},
 )


### PR DESCRIPTION
## Summary

- Add `ref="quantityInput"` to the quantity `<input>` in `ItemSelectionDialog`
- Import `nextTick` from Vue
- When the dialog opens in `uom` mode, automatically focus **and select** the quantity field so users can immediately type a new quantity without manually clearing the default value

## Behaviour Before / After

| Before | After |
|--------|-------|
| Dialog opens, cursor is not in the quantity field | Dialog opens, quantity field is focused and its value is selected — type to overwrite instantly |

## Testing

1. Open POS and add an item that has multiple UOMs configured.
2. Click the item to open the UOM selection dialog.
3. Verify the quantity input is focused and the default value (`1`) is selected.
4. Type a new quantity — it should replace the selected value immediately.