### PR TITLE
PN-39-hide-pos-actions-when-shift-is-closed

### DIFF
--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -148,7 +148,7 @@
 						<span>{{ __("Return Invoice") }}</span>
 					</button>
 					<button
-						v-if="canAccessShiftActions"
+						v-if="canAccessShiftActions && canSwitchToDesk"
 						@click="switchToDesk"
 						class="w-full text-start px-4 py-2.5 text-sm text-gray-700 hover:bg-emerald-50 flex items-center gap-3 transition-colors"
 					>
@@ -1044,6 +1044,7 @@ import { usePOSSettingsStore } from "@/stores/posSettings";
 import { usePOSShiftStore } from "@/stores/posShift";
 import { usePOSSyncStore } from "@/stores/posSync";
 import { usePOSUIStore } from "@/stores/posUI";
+import { useBootstrapStore } from "@/stores/bootstrap";
 import { logger } from "@/utils/logger";
 import { shouldValidateItemStock } from "@/utils/stockValidator";
 
@@ -1057,6 +1058,7 @@ const posSettingsStore = usePOSSettingsStore();
 const itemStore = useItemSearchStore();
 const stockStore = useStockStore();
 const customerSearchStore = useCustomerSearchStore();
+const bootstrapStore = useBootstrapStore();
 // Note: settingsStore is an alias to posSettingsStore (same Pinia store singleton)
 const settingsStore = posSettingsStore;
 
@@ -1191,6 +1193,9 @@ const profileWarehouses = computed(() => {
 });
 
 const canAccessShiftActions = computed(() => shiftStore.hasOpenShift);
+
+/** Desk link only for users with the Nexus Pos Manager role (from bootstrap API). */
+const canSwitchToDesk = computed(() => Boolean(bootstrapStore.data?.can_switch_to_desk));
 
 // Resize state
 let resizeState = null;
@@ -2244,7 +2249,7 @@ function openReturnDialog() {
 }
 
 function switchToDesk() {
-	if (!canAccessShiftActions.value || typeof window === "undefined") {
+	if (!canAccessShiftActions.value || !canSwitchToDesk.value || typeof window === "undefined") {
 		return;
 	}
 

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -1194,7 +1194,7 @@ const profileWarehouses = computed(() => {
 
 const canAccessShiftActions = computed(() => shiftStore.hasOpenShift);
 
-/** Desk link only for users with the Nexus Pos Manager role (from bootstrap API). */
+/** Desk link only for users with the Nexus POS Manager role (from bootstrap API). */
 const canSwitchToDesk = computed(() => Boolean(bootstrapStore.data?.can_switch_to_desk));
 
 // Resize state

--- a/pos_next/api/bootstrap.py
+++ b/pos_next/api/bootstrap.py
@@ -10,6 +10,7 @@ to initialize the POS application. Instead of making 5+ sequential API calls,
 the frontend fetches everything in one request.
 
 Data Returned:
+    - can_switch_to_desk: True if user has role "Nexus Pos Manager" (desk link in POS)
     - locale: User's language preference (e.g., "en", "ar")
     - precision: Number formatting settings from System Settings
         - currency: Decimal places for totals (default: 2)
@@ -46,6 +47,7 @@ def get_initial_data():
 			site_name: str,
 			locale: str,
 			precision: dict,
+			can_switch_to_desk: bool,
 			shift: dict | None,
 			pos_profile: dict | None,
 			pos_settings: dict | None,
@@ -63,6 +65,7 @@ def get_initial_data():
 		"site_name": frappe.local.site,
 		"locale": _get_user_language(),
 		"precision": _get_precision_settings(),
+		"can_switch_to_desk": "Nexus Pos Manager" in frappe.get_roles(),
 		"shift": None,
 		"pos_profile": None,
 		"pos_settings": None,

--- a/pos_next/api/bootstrap.py
+++ b/pos_next/api/bootstrap.py
@@ -10,7 +10,7 @@ to initialize the POS application. Instead of making 5+ sequential API calls,
 the frontend fetches everything in one request.
 
 Data Returned:
-    - can_switch_to_desk: True if user has role "Nexus Pos Manager" (desk link in POS)
+    - can_switch_to_desk: True if user has role "Nexus POS Manager" (desk link in POS)
     - locale: User's language preference (e.g., "en", "ar")
     - precision: Number formatting settings from System Settings
         - currency: Decimal places for totals (default: 2)
@@ -65,7 +65,7 @@ def get_initial_data():
 		"site_name": frappe.local.site,
 		"locale": _get_user_language(),
 		"precision": _get_precision_settings(),
-		"can_switch_to_desk": "Nexus Pos Manager" in frappe.get_roles(),
+		"can_switch_to_desk": "Nexus POS Manager" in frappe.get_roles(),
 		"shift": None,
 		"pos_profile": None,
 		"pos_settings": None,

--- a/pos_next/fixtures/role.json
+++ b/pos_next/fixtures/role.json
@@ -11,5 +11,18 @@
   "restrict_to_domain": null,
   "role_name": "POSNext Cashier",
   "two_factor_auth": 0
+ },
+ {
+  "desk_access": 1,
+  "disabled": 0,
+  "docstatus": 0,
+  "doctype": "Role",
+  "home_page": null,
+  "is_custom": 0,
+  "modified": "2026-03-30 18:17:23.060381",
+  "name": "Nexus Pos Manager",
+  "restrict_to_domain": null,
+  "role_name": "Nexus Pos Manager",
+  "two_factor_auth": 0
  }
 ]

--- a/pos_next/fixtures/role.json
+++ b/pos_next/fixtures/role.json
@@ -20,9 +20,9 @@
   "home_page": null,
   "is_custom": 0,
   "modified": "2026-03-30 18:17:23.060381",
-  "name": "Nexus Pos Manager",
+  "name": "Nexus POS Manager",
   "restrict_to_domain": null,
-  "role_name": "Nexus Pos Manager",
+  "role_name": "Nexus POS Manager",
   "two_factor_auth": 0
  }
 ]

--- a/pos_next/hooks.py
+++ b/pos_next/hooks.py
@@ -90,7 +90,7 @@ fixtures = [
     {
         "dt": "Role",
         "filters": [
-            ["role_name", "in", ["POSNext Cashier"]]
+            ["role_name", "in", ["POSNext Cashier","Nexus Pos Manager"]]
         ]
     },
     {

--- a/pos_next/hooks.py
+++ b/pos_next/hooks.py
@@ -90,7 +90,7 @@ fixtures = [
     {
         "dt": "Role",
         "filters": [
-            ["role_name", "in", ["POSNext Cashier","Nexus Pos Manager"]]
+            ["role_name", "in", ["POSNext Cashier","Nexus POS Manager"]]
         ]
     },
     {


### PR DESCRIPTION
- Updated role filters to include "Nexus Pos Manager" for access control.
- Enhanced the bootstrap API to return a flag indicating if the user can switch to the desk view based on their role.
- Modified the POS Sale page to conditionally render the "Switch To Desk" button based on the new role permission.
- Improved the switchToDesk function to check for the new permission before allowing navigation.