### PR TITLE
fix: prevent ERPNext from wiping payment amounts during invoice creation

### DIFF
--- a/pos_next/api/invoices.py
+++ b/pos_next/api/invoices.py
@@ -863,8 +863,31 @@ def update_invoice(data):
 
         invoice_doc.disable_rounded_total = disable_rounded
 
-        # Populate missing fields (company, currency, accounts, etc.)
-        invoice_doc.set_missing_values()
+        # ========================================================================
+        # POPULATE MISSING FIELDS — using for_validate=True intentionally
+        # ========================================================================
+        # ERPNext's set_missing_values() calls set_pos_fields() internally.
+        #
+        # With for_validate=False (the default):
+        #   set_pos_fields() -> update_multi_mode_option() which does:
+        #     1. doc.set("payments", [])          — wipes ALL payment rows
+        #     2. Rebuilds payments from POS Profile template with amount=0
+        #   Result: frontend payment amounts are destroyed before the invoice
+        #   is saved, causing invoices to appear unpaid (outstanding = grand_total).
+        #
+        # With for_validate=True:
+        #   set_pos_fields() skips update_multi_mode_option() entirely,
+        #   and only fills in missing fields (debit_to, currency, write_off_account,
+        #   cost_center, etc.) without overwriting values already set.
+        #   Payment accounts are set separately via _set_payment_accounts() below.
+        #
+        # This is safe on all ERPNext versions because POS Next already sets
+        # the fields that for_validate=True skips:
+        #   - ignore_pricing_rule  → set above (line ~752)
+        #   - customer             → sent from frontend
+        #   - tax_category         → sent from frontend or not needed
+        # ========================================================================
+        invoice_doc.set_missing_values(for_validate=True)
 
         # Calculate totals and apply discounts (with rounding disabled)
         invoice_doc.calculate_taxes_and_totals()


### PR DESCRIPTION
ERPNext's set_missing_values() calls set_pos_fields() -> update_multi_mode_option() which does doc.set("payments", []) and rebuilds the payments table from the POS Profile template with amount=0. This destroys the payment amounts sent by the POS frontend, causing invoices to save as unpaid (outstanding = grand_total).

Root cause: ERPNext removed the `if not self.get("payments")` guard in set_pos_fields() (commit 239728e4d9), so update_multi_mode_option() now runs unconditionally during set_missing_values(for_validate=False).

Fix: Call set_missing_values(for_validate=True) instead. This skips the destructive payment rebuild while still populating missing fields (debit_to, currency, write_off_account, cost_center, etc.). Payment accounts are already handled separately by _set_payment_accounts().

Safe on all ERPNext versions — POS Next already sets the fields that for_validate=True skips (ignore_pricing_rule, customer, tax_category).