### PR TITLE
Implement offline receipt handling and enhance invoice printing functionality

### DIFF
--- a/POS/src/components/invoices/InvoiceDetailDialog.vue
+++ b/POS/src/components/invoices/InvoiceDetailDialog.vue
@@ -279,9 +279,8 @@
 import { useFormatters } from "@/composables/useFormatters"
 import { DEFAULT_CURRENCY, formatCurrency as formatCurrencyUtil } from "@/utils/currency"
 import { getInvoiceStatusColor } from "@/utils/invoice"
-import { getOfflineReceiptPayload } from "@/utils/offline/offlineReceiptCache"
 import { logger } from "@/utils/logger"
-import { isLocalOnlyInvoiceName } from "@/utils/printInvoice"
+import { hydrateLocalOnlyInvoice, isLocalOnlyInvoiceName } from "@/utils/printInvoice"
 import { Button, Dialog, call } from "frappe-ui"
 import { ref, watch, nextTick, computed } from "vue"
 
@@ -371,15 +370,15 @@ async function loadInvoiceDetails() {
 	loading.value = true
 	try {
 		if (isLocalOnlyInvoiceName(props.invoiceName)) {
-			const cached = getOfflineReceiptPayload(props.invoiceName)
-			if (cached) {
+			// Hydrate from sessionStorage first, fall back to IndexedDB so a
+			// post-reload detail view still resolves offline receipts.
+			const cached = await hydrateLocalOnlyInvoice({ name: props.invoiceName })
+			if (cached?.items?.length > 0) {
 				const result = JSON.parse(JSON.stringify(cached))
-				if (result.items) {
-					result.items = result.items.map((item) => ({
-						...item,
-						quantity: item.quantity ?? item.qty,
-					}))
-				}
+				result.items = result.items.map((item) => ({
+					...item,
+					quantity: item.quantity ?? item.qty,
+				}))
 				invoiceData.value = result
 				return
 			}

--- a/POS/src/components/invoices/InvoiceDetailDialog.vue
+++ b/POS/src/components/invoices/InvoiceDetailDialog.vue
@@ -279,7 +279,9 @@
 import { useFormatters } from "@/composables/useFormatters"
 import { DEFAULT_CURRENCY, formatCurrency as formatCurrencyUtil } from "@/utils/currency"
 import { getInvoiceStatusColor } from "@/utils/invoice"
+import { getOfflineReceiptPayload } from "@/utils/offline/offlineReceiptCache"
 import { logger } from "@/utils/logger"
+import { isLocalOnlyInvoiceName } from "@/utils/printInvoice"
 import { Button, Dialog, call } from "frappe-ui"
 import { ref, watch, nextTick, computed } from "vue"
 
@@ -368,6 +370,23 @@ async function loadInvoiceDetails() {
 
 	loading.value = true
 	try {
+		if (isLocalOnlyInvoiceName(props.invoiceName)) {
+			const cached = getOfflineReceiptPayload(props.invoiceName)
+			if (cached) {
+				const result = JSON.parse(JSON.stringify(cached))
+				if (result.items) {
+					result.items = result.items.map((item) => ({
+						...item,
+						quantity: item.quantity ?? item.qty,
+					}))
+				}
+				invoiceData.value = result
+				return
+			}
+			invoiceData.value = null
+			return
+		}
+
 		const result = await call("pos_next.api.invoices.get_invoice", {
 			invoice_name: props.invoiceName,
 		})

--- a/POS/src/components/sale/OfflineInvoicesDialog.vue
+++ b/POS/src/components/sale/OfflineInvoicesDialog.vue
@@ -61,6 +61,13 @@
 									>
 										{{ __('{0} failed', [invoice.retry_count]) }}
 									</span>
+									<span
+										v-if="invoice.data?.was_printed"
+										class="text-[10px] sm:text-xs px-2 py-0.5 sm:py-1 bg-amber-100 text-amber-800 rounded-full flex-shrink-0"
+										:title="__('Receipt was printed — customer may hold a physical copy')"
+									>
+										{{ __('Printed') }}
+									</span>
 								</div>
 								<div class="mt-2 flex flex-col gap-1 text-xs sm:text-sm text-gray-600">
 									<div class="flex flex-wrap items-center gap-x-3 gap-y-1">
@@ -87,8 +94,15 @@
 							<div class="flex items-center justify-end sm:justify-start gap-1 sm:gap-2">
 								<button
 									@click="editInvoice(invoice)"
-									class="p-1.5 sm:p-2 hover:bg-blue-50 rounded-lg transition-colors touch-manipulation"
-									:title="__('Edit Invoice')"
+									:disabled="isSyncing || invoice.data?.was_printed"
+									class="p-1.5 sm:p-2 hover:bg-blue-50 rounded-lg transition-colors touch-manipulation disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+									:title="
+										invoice.data?.was_printed
+											? __('Printed invoices cannot be edited — use Return to issue a credit note')
+											: isSyncing
+												? __('Sync in progress — editing disabled')
+												: __('Edit Invoice')
+									"
 								>
 									<svg class="w-4 h-4 sm:w-5 sm:h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
@@ -105,9 +119,19 @@
 									</svg>
 								</button>
 								<button
+									@click="printInvoice(invoice)"
+									class="p-1.5 sm:p-2 hover:bg-green-50 rounded-lg transition-colors touch-manipulation"
+									:title="invoice.data?.was_printed ? __('Reprint receipt (already printed once)') : __('Print receipt')"
+								>
+									<svg class="w-4 h-4 sm:w-5 sm:h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
+									</svg>
+								</button>
+								<button
 									@click="deleteInvoice(invoice)"
-									class="p-1.5 sm:p-2 hover:bg-red-50 rounded-lg transition-colors touch-manipulation"
-									:title="__('Delete')"
+									:disabled="isSyncing"
+									class="p-1.5 sm:p-2 hover:bg-red-50 rounded-lg transition-colors touch-manipulation disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+									:title="isSyncing ? __('Sync in progress — deletion disabled') : __('Delete')"
 								>
 									<svg class="w-4 h-4 sm:w-5 sm:h-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
@@ -249,6 +273,7 @@ const emit = defineEmits([
 	"sync-all",
 	"delete-invoice",
 	"edit-invoice",
+	"print-invoice",
 	"refresh",
 ])
 
@@ -312,8 +337,16 @@ function viewDetails(invoice) {
 }
 
 function editInvoice(invoice) {
+	if (props.isSyncing) return
+	if (invoice.data?.was_printed) return
 	emit("edit-invoice", invoice)
 	show.value = false
+}
+
+function printInvoice(invoice) {
+	// Emit the offline_id — the parent's handlePrintInvoice hydrates from
+	// sessionStorage first, then IndexedDB, so reprinting works across reloads.
+	emit("print-invoice", { name: invoice.offline_id })
 }
 
 function syncAll() {
@@ -321,6 +354,7 @@ function syncAll() {
 }
 
 function deleteInvoice(invoice) {
+	if (props.isSyncing) return
 	invoiceToDelete.value = invoice
 	showDeleteConfirm.value = true
 }

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -2048,7 +2048,13 @@ async function handlePaymentCompleted(paymentData) {
 				write_off_amount: paymentData.write_off_amount || 0,
 			};
 
-			const offlineReceiptName = `OFFLINE-${Date.now()}`;
+			// Save to the offline queue first so we can use the worker's
+			// canonical pos_offline_<uuid> id as the cache key — keeping
+			// IndexedDB and sessionStorage aligned on a single identifier.
+			const saveResult = await offlineStore.saveInvoiceOffline(invoiceData);
+			const offlineReceiptName =
+				saveResult?.offline_id || invoiceData.offline_id || `pos_offline_${Date.now()}`;
+
 			const paidAmount = paymentData.paid_amount ?? cartStore.grandTotal ?? 0;
 			const grandTotal = cartStore.grandTotal || 0;
 			const customerLabel =
@@ -2080,8 +2086,6 @@ async function handlePaymentCompleted(paymentData) {
 			};
 			uiStore.setLastOfflinePrintDoc(offlinePrintDoc);
 			cacheOfflineReceiptPayload(offlineReceiptName, offlinePrintDoc);
-
-			await offlineStore.saveInvoiceOffline(invoiceData);
 			uiStore.showPaymentDialog = false;
 			cartStore.clearCart();
 			// Reset cart hash after successful payment
@@ -2835,7 +2839,7 @@ function handleViewInvoice(invoice) {
 // Centralized print handler - uses printInvoice.js utilities
 async function handlePrintInvoice(invoiceData) {
 	try {
-		invoiceData = hydrateLocalOnlyInvoice(invoiceData || {});
+		invoiceData = await hydrateLocalOnlyInvoice(invoiceData || {});
 		const offlineSnapshot = uiStore.lastOfflinePrintDoc;
 		if (
 			invoiceData?.name &&

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -2038,6 +2038,7 @@ async function handlePaymentCompleted(paymentData) {
 			const invoiceData = {
 				pos_profile: cartStore.posProfile,
 				posa_pos_opening_shift: cartStore.posOpeningShift,
+				company: shiftStore.profileCompany,
 				customer: customerValue || shiftStore.profileCustomer,
 				items: preparedItems,
 				payments: JSON.parse(JSON.stringify(cartStore.payments)),
@@ -2046,6 +2047,7 @@ async function handlePaymentCompleted(paymentData) {
 				total_tax: cartStore.totalTax,
 				total_discount: cartStore.totalDiscount,
 				write_off_amount: paymentData.write_off_amount || 0,
+				change_amount: paymentData.change_amount || 0,
 			};
 
 			// Save to the offline queue first so we can use the worker's

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -2060,6 +2060,7 @@ async function handlePaymentCompleted(paymentData) {
 			const offlinePrintDoc = {
 				name: offlineReceiptName,
 				doctype: "Sales Invoice",
+				is_offline: true,
 				pos_profile: cartStore.posProfile,
 				posting_date: new Date().toISOString().slice(0, 10),
 				company: shiftStore.profileCompany || undefined,
@@ -2101,7 +2102,7 @@ async function handlePaymentCompleted(paymentData) {
 					);
 				} catch (error) {
 					log.error("Offline auto-print error:", error);
-					uiStore.showSuccess(offlineReceiptName, cartStore.grandTotal, paymentData.paid_amount);
+					uiStore.showSuccess(offlineReceiptName, grandTotal, paymentData.paid_amount);
 					showWarning(
 						__("Invoice {0} saved offline but print failed — open Print from the success dialog", [
 							offlineReceiptName,
@@ -2109,7 +2110,7 @@ async function handlePaymentCompleted(paymentData) {
 					);
 				}
 			} else {
-				uiStore.showSuccess(offlineReceiptName, cartStore.grandTotal, paymentData.paid_amount);
+				uiStore.showSuccess(offlineReceiptName, grandTotal, paymentData.paid_amount);
 				showSuccess(__("Invoice saved offline. Will sync when online"));
 			}
 		} else {

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -620,6 +620,7 @@
 				@sync-all="handleSyncAll"
 				@delete-invoice="handleDeleteOfflineInvoice"
 				@edit-invoice="handleEditOfflineInvoice"
+				@print-invoice="handlePrintInvoice"
 				@refresh="offlineStore.loadPendingInvoices"
 			/>
 
@@ -1114,6 +1115,12 @@ const offerReapplyTimer = ref(null);
 
 // Performance: Cache previous cart state to avoid unnecessary reapplications
 let previousCartHash = "";
+
+// Tracks the in-flight edit of a queued offline invoice. Set by
+// handleEditOfflineInvoice, consumed by the offline branch of
+// handlePaymentCompleted to supersede the original row, and cleared
+// whenever the edit is abandoned (cart cleared without checkout).
+let editingOfflineContext = null;
 
 // Helper function to compute cart hash
 function computeCartHash() {
@@ -2048,6 +2055,7 @@ async function handlePaymentCompleted(paymentData) {
 				total_discount: cartStore.totalDiscount,
 				write_off_amount: paymentData.write_off_amount || 0,
 				change_amount: paymentData.change_amount || 0,
+				edited_from: editingOfflineContext?.originalOfflineId || null,
 			};
 
 			// Save to the offline queue first so we can use the worker's
@@ -2056,6 +2064,20 @@ async function handlePaymentCompleted(paymentData) {
 			const saveResult = await offlineStore.saveInvoiceOffline(invoiceData);
 			const offlineReceiptName =
 				saveResult?.offline_id || invoiceData.offline_id || `pos_offline_${Date.now()}`;
+
+			// If this checkout was an edit of a previously-queued invoice, mark
+			// the original row as superseded (keeps audit trail, excludes from sync).
+			if (editingOfflineContext?.originalQueueId) {
+				try {
+					await offlineWorker.supersedeOfflineInvoice(
+						editingOfflineContext.originalQueueId,
+						offlineReceiptName,
+					);
+				} catch (err) {
+					log.error("Failed to supersede original offline invoice:", err);
+				}
+				editingOfflineContext = null;
+			}
 
 			const paidAmount = paymentData.paid_amount ?? cartStore.grandTotal ?? 0;
 			const grandTotal = cartStore.grandTotal || 0;
@@ -2127,6 +2149,26 @@ async function handlePaymentCompleted(paymentData) {
 
 			if (result) {
 				uiStore.clearLastOfflinePrintDoc();
+
+				// If this online checkout originated from editing a still-queued
+				// offline invoice, mark the original row as superseded so the
+				// background sync doesn't push it as a duplicate. We pass the
+				// server invoice name as replaced_by for audit trail.
+				if (editingOfflineContext?.originalQueueId) {
+					const serverName = result.name || result.message?.name || null;
+					try {
+						await offlineWorker.supersedeOfflineInvoice(
+							editingOfflineContext.originalQueueId,
+							serverName,
+						);
+					} catch (err) {
+						log.error("Failed to supersede edited offline invoice after online submit:", err);
+					}
+					editingOfflineContext = null;
+					// Refresh pending count so the OfflineInvoicesDialog badge updates.
+					await offlineStore.updatePendingCount();
+				}
+
 				const invoiceName = result.name || result.message?.name || __("Unknown");
 				const invoiceTotal = result.grand_total || result.total || 0;
 				const paidAmount = paymentData.paid_amount || invoiceTotal;
@@ -2167,6 +2209,10 @@ async function handlePaymentCompleted(paymentData) {
 		log.error("Error submitting invoice:", error);
 		uiStore.showPaymentDialog = false;
 
+		// Checkout failed mid-edit — clear the edit context so the NEXT
+		// checkout doesn't supersede the wrong row on a fresh, unrelated sale.
+		editingOfflineContext = null;
+
 		const errorContext = parseError(error);
 		uiStore.showError(
 			errorContext.title || __("Error"),
@@ -2194,6 +2240,7 @@ function confirmClearCart() {
 	cartStore.clearCart();
 	// Reset cart hash when cart is cleared
 	previousCartHash = "";
+	editingOfflineContext = null;
 	uiStore.showClearCartDialog = false;
 	showSuccess(__("All items removed from cart"));
 }
@@ -2558,6 +2605,21 @@ async function confirmClearCache() {
 
 async function handleEditOfflineInvoice(invoice) {
 	try {
+		if (offlineStore.isSyncing) {
+			showWarning(__("Cannot edit while syncing — please wait for sync to finish."));
+			return;
+		}
+
+		if (invoice.data?.was_printed) {
+			uiStore.showError(
+				__("Cannot edit printed invoice"),
+				__(
+					"A receipt for this invoice was already printed — the customer may have a physical copy. Use Return Invoice to issue a credit note instead.",
+				),
+			);
+			return;
+		}
+
 		cartStore.clearCart();
 
 		const invoiceData = invoice.data;
@@ -2582,7 +2644,12 @@ async function handleEditOfflineInvoice(invoice) {
 		// Initialize cart hash for the loaded cart so watchers work correctly
 		previousCartHash = computeCartHash();
 
-		await offlineStore.deleteOfflineInvoice(invoice.id);
+		// Record the edit source so the next checkout can supersede the
+		// original queue row (preserving audit trail instead of deleting it).
+		editingOfflineContext = {
+			originalQueueId: invoice.id,
+			originalOfflineId: invoice.offline_id,
+		};
 
 		showSuccess(__("Invoice loaded to cart for editing"));
 	} catch (error) {
@@ -2592,6 +2659,10 @@ async function handleEditOfflineInvoice(invoice) {
 
 async function handleDeleteOfflineInvoice(invoiceId) {
 	try {
+		if (offlineStore.isSyncing) {
+			showWarning(__("Cannot delete while syncing — please wait for sync to finish."));
+			return;
+		}
 		await offlineStore.deleteOfflineInvoice(invoiceId);
 	} catch (error) {
 		log.error("Error deleting offline invoice:", error);

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -1028,8 +1028,14 @@ import { useUserData } from "@/data/user";
 import { parseError } from "@/utils/errorHandler";
 import { cleanupUserSession } from "@/utils/sessionCleanup";
 import { offlineWorker } from "@/utils/offline/workerClient";
+import { cacheOfflineReceiptPayload } from "@/utils/offline/offlineReceiptCache";
 import { cacheInvoiceHistory, getCachedInvoiceHistory } from "@/utils/offline/sync";
-import { printInvoice, printInvoiceByName, printWithSilentFallback } from "@/utils/printInvoice";
+import {
+	hydrateLocalOnlyInvoice,
+	printInvoice,
+	printInvoiceByName,
+	printWithSilentFallback,
+} from "@/utils/printInvoice";
 import { qzConnected, connect as qzConnect, disconnect as qzDisconnect } from "@/utils/qzTray";
 
 import { Button, Dialog, createResource } from "frappe-ui";
@@ -2042,12 +2048,39 @@ async function handlePaymentCompleted(paymentData) {
 				write_off_amount: paymentData.write_off_amount || 0,
 			};
 
+			const offlineReceiptName = `OFFLINE-${Date.now()}`;
+			const paidAmount = paymentData.paid_amount ?? cartStore.grandTotal ?? 0;
+			const grandTotal = cartStore.grandTotal || 0;
+			const customerLabel =
+				cartStore.customer?.customer_name ||
+				cartStore.customer?.name ||
+				customerValue ||
+				shiftStore.profileCustomer;
+
+			const offlinePrintDoc = {
+				name: offlineReceiptName,
+				doctype: "Sales Invoice",
+				pos_profile: cartStore.posProfile,
+				posting_date: new Date().toISOString().slice(0, 10),
+				company: shiftStore.profileCompany || undefined,
+				customer_name: customerLabel,
+				items: preparedItems.map((item) => ({
+					...item,
+					quantity: item.qty ?? item.quantity,
+				})),
+				grand_total: grandTotal,
+				total_taxes_and_charges: cartStore.totalTax,
+				payments: invoiceData.payments,
+				paid_amount: paidAmount,
+				change_amount: paymentData.change_amount || 0,
+				outstanding_amount: Math.max(0, grandTotal - paidAmount),
+				status: Math.max(0, grandTotal - paidAmount) < 0.01 ? "Paid" : "Unpaid",
+				docstatus: 0,
+			};
+			uiStore.setLastOfflinePrintDoc(offlinePrintDoc);
+			cacheOfflineReceiptPayload(offlineReceiptName, offlinePrintDoc);
+
 			await offlineStore.saveInvoiceOffline(invoiceData);
-			uiStore.showSuccess(
-				`OFFLINE-${Date.now()}`,
-				cartStore.grandTotal,
-				paymentData.paid_amount
-			);
 			uiStore.showPaymentDialog = false;
 			cartStore.clearCart();
 			// Reset cart hash after successful payment
@@ -2058,7 +2091,27 @@ async function handlePaymentCompleted(paymentData) {
 				draftsStore.deleteDraft(draftIdToDelete);
 			}
 
-			showSuccess(__("Invoice saved offline. Will sync when online"));
+			if (shiftStore.autoPrintEnabled || posSettingsStore.silentPrint) {
+				try {
+					await handlePrintInvoice({ name: offlineReceiptName });
+					showSuccess(
+						__("Invoice {0} saved offline and sent to printer — will sync when online", [
+							offlineReceiptName,
+						]),
+					);
+				} catch (error) {
+					log.error("Offline auto-print error:", error);
+					uiStore.showSuccess(offlineReceiptName, cartStore.grandTotal, paymentData.paid_amount);
+					showWarning(
+						__("Invoice {0} saved offline but print failed — open Print from the success dialog", [
+							offlineReceiptName,
+						]),
+					);
+				}
+			} else {
+				uiStore.showSuccess(offlineReceiptName, cartStore.grandTotal, paymentData.paid_amount);
+				showSuccess(__("Invoice saved offline. Will sync when online"));
+			}
 		} else {
 			// Get item codes from cart before clearing
 			const soldItemCodes = cartStore.invoiceItems.map((item) => item.item_code);
@@ -2066,6 +2119,7 @@ async function handlePaymentCompleted(paymentData) {
 			const result = await cartStore.submitInvoice();
 
 			if (result) {
+				uiStore.clearLastOfflinePrintDoc();
 				const invoiceName = result.name || result.message?.name || __("Unknown");
 				const invoiceTotal = result.grand_total || result.total || 0;
 				const paidAmount = paymentData.paid_amount || invoiceTotal;
@@ -2780,6 +2834,16 @@ function handleViewInvoice(invoice) {
 // Centralized print handler - uses printInvoice.js utilities
 async function handlePrintInvoice(invoiceData) {
 	try {
+		invoiceData = hydrateLocalOnlyInvoice(invoiceData || {});
+		const offlineSnapshot = uiStore.lastOfflinePrintDoc;
+		if (
+			invoiceData?.name &&
+			offlineSnapshot?.name === invoiceData.name &&
+			offlineSnapshot.items?.length > 0
+		) {
+			invoiceData = offlineSnapshot;
+		}
+
 		// Silent print path — send directly to thermal printer via QZ Tray
 		if (posSettingsStore.silentPrint) {
 			const result = await printWithSilentFallback(invoiceData);

--- a/POS/src/stores/posSync.js
+++ b/POS/src/stores/posSync.js
@@ -415,6 +415,7 @@ export const usePOSSyncStore = defineStore("posSync", () => {
 		// Actions
 		saveInvoiceOffline,
 		loadPendingInvoices,
+		updatePendingCount,
 		deleteOfflineInvoice,
 		syncAllPending,
 		preloadDataForOffline,

--- a/POS/src/stores/posSync.js
+++ b/POS/src/stores/posSync.js
@@ -180,10 +180,10 @@ export const usePOSSyncStore = defineStore("posSync", () => {
 	 */
 	async function saveInvoiceOffline(invoiceData) {
 		try {
-			await offlineWorker.saveOfflineInvoice(invoiceData)
+			const result = await offlineWorker.saveOfflineInvoice(invoiceData)
 			await updatePendingCount()
 			log.info('Invoice saved offline successfully')
-			return true
+			return result || { success: true }
 		} catch (error) {
 			log.error('Failed to save invoice offline', error)
 			throw error

--- a/POS/src/stores/posUI.js
+++ b/POS/src/stores/posUI.js
@@ -43,6 +43,8 @@ export const usePOSUIStore = defineStore("posUI", () => {
 	const lastInvoiceName = ref("")
 	const lastInvoiceTotal = ref(0)
 	const lastPaidAmount = ref(0)
+	/** Full receipt payload for invoices not yet on the server (offline queue) */
+	const lastOfflinePrintDoc = ref(null)
 
 	// Customer dialog state
 	const initialCustomerName = ref("")
@@ -102,6 +104,14 @@ export const usePOSUIStore = defineStore("posUI", () => {
 		lastInvoiceTotal.value = total
 		lastPaidAmount.value = paidAmount !== null ? paidAmount : total
 		showSuccessDialog.value = true
+	}
+
+	function setLastOfflinePrintDoc(doc) {
+		lastOfflinePrintDoc.value = doc
+	}
+
+	function clearLastOfflinePrintDoc() {
+		lastOfflinePrintDoc.value = null
 	}
 
 	function setInitialCustomerName(name) {
@@ -164,6 +174,7 @@ export const usePOSUIStore = defineStore("posUI", () => {
 		showItemSelectionDialog.value = false
 		showErrorDialog.value = false
 		clearError()
+		lastOfflinePrintDoc.value = null
 	}
 
 	return {
@@ -196,6 +207,7 @@ export const usePOSUIStore = defineStore("posUI", () => {
 		lastInvoiceName,
 		lastInvoiceTotal,
 		lastPaidAmount,
+		lastOfflinePrintDoc,
 		initialCustomerName,
 		mobileActiveTab,
 		windowWidth,
@@ -212,6 +224,8 @@ export const usePOSUIStore = defineStore("posUI", () => {
 		showError,
 		clearError,
 		showSuccess,
+		setLastOfflinePrintDoc,
+		clearLastOfflinePrintDoc,
 		setInitialCustomerName,
 		setLeftPanelWidth,
 		setResizing,

--- a/POS/src/utils/offline/offlineReceiptCache.js
+++ b/POS/src/utils/offline/offlineReceiptCache.js
@@ -4,8 +4,9 @@ const log = logger.create("OfflineReceiptCache")
 const KEY_PREFIX = "pos_next_offline_rcpt:"
 
 /**
- * Persist a full receipt payload for a synthetic offline invoice id (e.g. OFFLINE-…).
- * Used so print / detail views never call ERPNext for names that are not in the DB yet.
+ * Persist a full receipt payload for a synthetic offline invoice id (e.g.
+ * pos_offline_<uuid>). Used so print / detail views never call ERPNext for
+ * names that are not in the DB yet.
  */
 export function cacheOfflineReceiptPayload(name, doc) {
 	if (typeof sessionStorage === "undefined" || !name || !doc) return
@@ -23,5 +24,36 @@ export function getOfflineReceiptPayload(name) {
 		return raw ? JSON.parse(raw) : null
 	} catch {
 		return null
+	}
+}
+
+/**
+ * Drop a single cached receipt — called after the invoice has been synced
+ * to the server and the server name is available for future lookups.
+ */
+export function removeOfflineReceiptPayload(name) {
+	if (typeof sessionStorage === "undefined" || !name) return
+	try {
+		sessionStorage.removeItem(`${KEY_PREFIX}${name}`)
+	} catch (e) {
+		log.warn("Could not remove offline receipt:", e)
+	}
+}
+
+/**
+ * Remove all cached offline receipts. Called on logout / session cleanup to
+ * prevent cross-cashier leakage on shared terminals.
+ */
+export function clearAllOfflineReceiptPayloads() {
+	if (typeof sessionStorage === "undefined") return
+	try {
+		const keys = []
+		for (let i = 0; i < sessionStorage.length; i++) {
+			const key = sessionStorage.key(i)
+			if (key?.startsWith(KEY_PREFIX)) keys.push(key)
+		}
+		for (const key of keys) sessionStorage.removeItem(key)
+	} catch (e) {
+		log.warn("Could not clear offline receipts:", e)
 	}
 }

--- a/POS/src/utils/offline/offlineReceiptCache.js
+++ b/POS/src/utils/offline/offlineReceiptCache.js
@@ -1,0 +1,27 @@
+import { logger } from "@/utils/logger"
+
+const log = logger.create("OfflineReceiptCache")
+const KEY_PREFIX = "pos_next_offline_rcpt:"
+
+/**
+ * Persist a full receipt payload for a synthetic offline invoice id (e.g. OFFLINE-…).
+ * Used so print / detail views never call ERPNext for names that are not in the DB yet.
+ */
+export function cacheOfflineReceiptPayload(name, doc) {
+	if (typeof sessionStorage === "undefined" || !name || !doc) return
+	try {
+		sessionStorage.setItem(`${KEY_PREFIX}${name}`, JSON.stringify(doc))
+	} catch (e) {
+		log.warn("Could not cache offline receipt:", e)
+	}
+}
+
+export function getOfflineReceiptPayload(name) {
+	if (typeof sessionStorage === "undefined" || !name) return null
+	try {
+		const raw = sessionStorage.getItem(`${KEY_PREFIX}${name}`)
+		return raw ? JSON.parse(raw) : null
+	} catch {
+		return null
+	}
+}

--- a/POS/src/utils/offline/sync.js
+++ b/POS/src/utils/offline/sync.js
@@ -3,6 +3,7 @@ import { logger } from "@/utils/logger"
 import { CoalescingMutex } from "@/utils/mutex"
 import { db } from "./db"
 import { offlineState } from "./offlineState"
+import { removeOfflineReceiptPayload } from "./offlineReceiptCache"
 import { generateOfflineId } from "./uuid"
 
 // Re-export for backwards compatibility
@@ -124,6 +125,24 @@ export const getOfflineInvoices = async () => {
 }
 
 /**
+ * Look up a single queued offline invoice by its offline_id. Used to rebuild
+ * a receipt payload after sessionStorage is wiped (e.g. a page refresh
+ * between checkout and the auto-print).
+ * @param {string} offlineId - pos_offline_<uuid>
+ * @returns {Promise<Object|null>} The invoice data or null if not queued.
+ */
+export const getOfflineInvoiceByOfflineId = async (offlineId) => {
+	if (!offlineId) return null
+	try {
+		const row = await db.invoice_queue.where("offline_id").equals(offlineId).first()
+		return row?.data || null
+	} catch (error) {
+		log.error("Failed to look up offline invoice", { offlineId, error })
+		return null
+	}
+}
+
+/**
  * Get count of pending offline invoices
  * @returns {Promise<number>}
  */
@@ -217,15 +236,19 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
 // ============================================================================
 
 /**
- * Mark an invoice as synced in the local database
+ * Mark an invoice as synced in the local database and drop its cached
+ * receipt payload — once the invoice exists on the server, print/detail
+ * lookups should go through the normal server path.
  * @param {number} id - Invoice queue ID
  * @param {string} serverInvoice - Server invoice name
+ * @param {string} [offlineId] - pos_offline_<uuid> cache key to evict
  */
-const markInvoiceSynced = async (id, serverInvoice) => {
+const markInvoiceSynced = async (id, serverInvoice, offlineId) => {
 	await db.invoice_queue.update(id, {
 		synced: true,
 		server_invoice: serverInvoice,
 	})
+	if (offlineId) removeOfflineReceiptPayload(offlineId)
 }
 
 /**
@@ -298,7 +321,7 @@ const syncInvoiceToServer = async (invoice, retryCount = 0) => {
 	if (offlineId) {
 		const syncStatus = await checkOfflineIdSynced(offlineId)
 		if (syncStatus.synced) {
-			await markInvoiceSynced(invoice.id, syncStatus.sales_invoice)
+			await markInvoiceSynced(invoice.id, syncStatus.sales_invoice, offlineId)
 			log.debug("Invoice already synced, skipping", {
 				id: invoice.id,
 				offline_id: offlineId,
@@ -318,7 +341,7 @@ const syncInvoiceToServer = async (invoice, retryCount = 0) => {
 
 		if (response.message || response.name) {
 			const serverName = response.name || response.message
-			await markInvoiceSynced(invoice.id, serverName)
+			await markInvoiceSynced(invoice.id, serverName, offlineId)
 			log.success("Invoice synced", {
 				id: invoice.id,
 				offline_id: offlineId,
@@ -383,7 +406,11 @@ export const syncOfflineInvoices = async () => {
 				// Check for duplicate error from server
 				const { isDuplicate, invoiceName } = checkDuplicateError(error)
 				if (isDuplicate) {
-					await markInvoiceSynced(invoice.id, invoiceName)
+					await markInvoiceSynced(
+						invoice.id,
+						invoiceName,
+						invoice.offline_id || invoice.data?.offline_id,
+					)
 					log.debug("Invoice is duplicate, marked as synced", { id: invoice.id })
 					result.skipped++
 					continue

--- a/POS/src/utils/offline/sync.js
+++ b/POS/src/utils/offline/sync.js
@@ -117,7 +117,7 @@ export const saveOfflineInvoice = async (invoiceData) => {
  */
 export const getOfflineInvoices = async () => {
 	try {
-		return await db.invoice_queue.filter((inv) => !inv.synced).toArray()
+		return await db.invoice_queue.filter((inv) => !inv.synced && !inv.superseded).toArray()
 	} catch (error) {
 		log.error("Failed to get offline invoices", error)
 		return []
@@ -148,7 +148,7 @@ export const getOfflineInvoiceByOfflineId = async (offlineId) => {
  */
 export const getOfflineInvoiceCount = async () => {
 	try {
-		return await db.invoice_queue.filter((inv) => !inv.synced).count()
+		return await db.invoice_queue.filter((inv) => !inv.synced && !inv.superseded).count()
 	} catch (error) {
 		log.error("Failed to get offline invoice count", error)
 		return 0

--- a/POS/src/utils/offline/workerClient.js
+++ b/POS/src/utils/offline/workerClient.js
@@ -466,6 +466,14 @@ class OfflineWorkerClient {
 		return this.sendMessage("DELETE_INVOICE", { id })
 	}
 
+	async markOfflineInvoicePrinted(offlineId) {
+		return this.sendMessage("MARK_INVOICE_PRINTED", { offline_id: offlineId })
+	}
+
+	async supersedeOfflineInvoice(id, replacedBy) {
+		return this.sendMessage("SUPERSEDE_INVOICE", { id, replaced_by: replacedBy })
+	}
+
 	async setManualOffline(value) {
 		// Update centralized offline state immediately for responsive UI
 		offlineState.setManualOffline(value)

--- a/POS/src/utils/printInvoice.js
+++ b/POS/src/utils/printInvoice.js
@@ -64,7 +64,7 @@ function receiptDocFromQueuedInvoice(offlineId, raw) {
 		discount_amount: Number.parseFloat(raw.total_discount) || 0,
 		payments,
 		paid_amount: paidAmount,
-		change_amount: 0,
+		change_amount: Number.parseFloat(raw.change_amount) || 0,
 		outstanding_amount: Math.max(0, grandTotal - paidAmount),
 		status: grandTotal - paidAmount < 0.01 ? "Paid" : "Unpaid",
 		docstatus: 0,

--- a/POS/src/utils/printInvoice.js
+++ b/POS/src/utils/printInvoice.js
@@ -1,6 +1,7 @@
 import { call } from "@/utils/apiWrapper"
-import { getOfflineReceiptPayload } from "@/utils/offline/offlineReceiptCache"
 import { logger } from "@/utils/logger"
+import { getOfflineReceiptPayload } from "@/utils/offline/offlineReceiptCache"
+import { getOfflineInvoiceByOfflineId } from "@/utils/offline/sync"
 import { printHTML as qzPrintHTML } from "@/utils/qzTray"
 
 const log = logger.create("PrintInvoice")
@@ -34,14 +35,65 @@ export function isLocalOnlyInvoiceName(name) {
 }
 
 /**
- * Merge session-cached offline receipt when callers only have { name }.
- * Prevents server print / get_invoice for synthetic OFFLINE-* ids.
+ * Build a minimal printable receipt doc from a raw queued invoice payload
+ * (the dict stored in IndexedDB invoice_queue.data). Used when sessionStorage
+ * has been wiped but the invoice is still in the local queue.
  */
-export function hydrateLocalOnlyInvoice(invoiceData) {
+function receiptDocFromQueuedInvoice(offlineId, raw) {
+	const items = Array.isArray(raw.items) ? raw.items : []
+	const payments = Array.isArray(raw.payments) ? raw.payments : []
+	const grandTotal = Number.parseFloat(raw.grand_total) || 0
+	const paidAmount = payments.reduce(
+		(sum, p) => sum + (Number.parseFloat(p.amount) || 0),
+		0,
+	)
+	return {
+		name: offlineId,
+		doctype: "Sales Invoice",
+		is_offline: true,
+		pos_profile: raw.pos_profile,
+		posting_date: raw.posting_date || new Date().toISOString().slice(0, 10),
+		company: raw.company,
+		customer_name: raw.customer,
+		items: items.map((item) => ({
+			...item,
+			quantity: item.quantity ?? item.qty,
+		})),
+		grand_total: grandTotal,
+		total_taxes_and_charges: Number.parseFloat(raw.total_tax) || 0,
+		discount_amount: Number.parseFloat(raw.total_discount) || 0,
+		payments,
+		paid_amount: paidAmount,
+		change_amount: 0,
+		outstanding_amount: Math.max(0, grandTotal - paidAmount),
+		status: grandTotal - paidAmount < 0.01 ? "Paid" : "Unpaid",
+		docstatus: 0,
+	}
+}
+
+/**
+ * Hydrate a local-only invoice from cache. Checks sessionStorage first
+ * (fast path, survives within the tab), then falls back to IndexedDB
+ * (survives page reloads while the invoice is still in the offline queue).
+ * Prevents server print / get_invoice for synthetic pos_offline_* ids.
+ */
+export async function hydrateLocalOnlyInvoice(invoiceData) {
 	if (!invoiceData?.name || !isLocalOnlyInvoiceName(invoiceData.name)) return invoiceData
 	if (invoiceData.items?.length > 0) return invoiceData
+
 	const cached = getOfflineReceiptPayload(invoiceData.name)
 	if (cached?.items?.length > 0) return cached
+
+	// sessionStorage wiped (page reload) — rebuild from IndexedDB queue.
+	try {
+		const queued = await getOfflineInvoiceByOfflineId(invoiceData.name)
+		if (queued?.items?.length > 0) {
+			return receiptDocFromQueuedInvoice(invoiceData.name, queued)
+		}
+	} catch (err) {
+		log.warn("IndexedDB hydrate fallback failed:", err?.message || err)
+	}
+
 	return invoiceData
 }
 
@@ -224,7 +276,7 @@ export async function printInvoice(invoiceData, printFormat = null, letterhead =
 	try {
 		if (!invoiceData?.name) throw new Error("Invalid invoice data")
 
-		invoiceData = hydrateLocalOnlyInvoice(invoiceData)
+		invoiceData = await hydrateLocalOnlyInvoice(invoiceData)
 
 		// Pending offline / local IDs are not in ERPNext — use embedded receipt HTML.
 		if (isLocalOnlyInvoiceName(invoiceData.name)) {
@@ -270,8 +322,8 @@ export async function printInvoice(invoiceData, printFormat = null, letterhead =
  * then open the browser print window.
  */
 export async function printInvoiceByName(invoiceName, printFormat = null, letterhead = null) {
-	const localDoc = hydrateLocalOnlyInvoice({ name: invoiceName })
 	if (isLocalOnlyInvoiceName(invoiceName)) {
+		const localDoc = await hydrateLocalOnlyInvoice({ name: invoiceName })
 		if (!localDoc.items?.length) {
 			throw new Error(
 				__(
@@ -305,7 +357,7 @@ export async function printInvoiceByName(invoiceName, printFormat = null, letter
  */
 export async function silentPrintInvoice(invoiceName, printFormat = null) {
 	if (isLocalOnlyInvoiceName(invoiceName)) {
-		const doc = hydrateLocalOnlyInvoice({ name: invoiceName })
+		const doc = await hydrateLocalOnlyInvoice({ name: invoiceName })
 		if (doc.items?.length > 0) return silentPrintInvoiceFromDoc(doc)
 		throw new Error(
 			__(
@@ -353,7 +405,7 @@ export async function silentPrintInvoiceFromDoc(invoiceData) {
  * internally, so no separate connection logic is needed here.
  */
 export async function printWithSilentFallback(invoiceData, printFormat = null) {
-	invoiceData = hydrateLocalOnlyInvoice(invoiceData)
+	invoiceData = await hydrateLocalOnlyInvoice(invoiceData)
 	const invoiceName = invoiceData?.name
 	if (!invoiceName) throw new Error("Invalid invoice data — missing name")
 

--- a/POS/src/utils/printInvoice.js
+++ b/POS/src/utils/printInvoice.js
@@ -15,6 +15,19 @@ function formatCurrency(amount) {
 	return Number.parseFloat(amount || 0).toFixed(2)
 }
 
+/**
+ * Fall back to summing payment rows when paid_amount is not set —
+ * offline invoices lack paid_amount until server submission.
+ */
+function derivePaidAmount(invoiceData) {
+	if (invoiceData.paid_amount != null) return invoiceData.paid_amount
+	if (!Array.isArray(invoiceData.payments)) return 0
+	return invoiceData.payments.reduce(
+		(sum, p) => sum + (Number.parseFloat(p.amount) || 0),
+		0,
+	)
+}
+
 /** Sales Invoices not yet on the server (offline queue / local receipt id). */
 export function isLocalOnlyInvoiceName(name) {
 	return typeof name === "string" && (name.startsWith("OFFLINE-") || name.startsWith("pos_offline_"))
@@ -63,6 +76,10 @@ const RECEIPT_STYLES = `
 		display: flex; justify-content: space-between; font-size: 13px; font-weight: bold;
 		border: 1px solid #000; padding: 8px; margin-top: 8px; border-radius: 4px;
 	}
+	.offline-badge {
+		text-align: center; font-size: 11px; font-weight: bold;
+		border: 1px dashed #000; padding: 4px; margin-bottom: 10px;
+	}
 	.footer { text-align: center; margin-top: 20px; padding-top: 10px; border-top: 2px dashed #000; font-size: 11px; }
 	@media print {
 		@page { size: 80mm auto; margin: 0; }
@@ -76,14 +93,15 @@ const RECEIPT_STYLES = `
  */
 export function buildReceiptHTML(invoiceData) {
 	const items = invoiceData.items || []
+	const paidAmount = derivePaidAmount(invoiceData)
 	const itemsHtml = items
 		.map((item) => {
 			const hasDiscount =
 				(item.discount_percentage && Number.parseFloat(item.discount_percentage) > 0) ||
 				(item.discount_amount && Number.parseFloat(item.discount_amount) > 0)
 			const isFree = item.is_free_item
-			const qty = item.quantity || item.qty
-			const displayRate = item.price_list_rate || item.rate
+			const qty = item.quantity || item.qty || 0
+			const displayRate = item.price_list_rate || item.rate || 0
 			const subtotal = qty * displayRate
 			return `
 						<div class="item-row">
@@ -105,10 +123,12 @@ export function buildReceiptHTML(invoiceData) {
 					<div style="font-size: 12px;">${invoiceData.header || __("TAX INVOICE")}</div>
 				</div>
 
+				${invoiceData.is_offline ? `<div class="offline-badge">${__("OFFLINE — PENDING SYNC")}</div>` : ""}
+
 				<div class="invoice-info">
 					<div><span>${__("Invoice #:")}</span><span><strong>${invoiceData.name}</strong></span></div>
 					<div><span>${__("Date:")}</span><span>${new Date(invoiceData.posting_date || Date.now()).toLocaleString()}</span></div>
-					${invoiceData.customer_name ? `<div><span>${__("Customer:")}</span><span>${invoiceData.customer_name}</span></div>` : ""}
+					${invoiceData.customer_name || invoiceData.customer ? `<div><span>${__("Customer:")}</span><span>${invoiceData.customer_name || invoiceData.customer}</span></div>` : ""}
 					${(invoiceData.status === "Partly Paid" || (invoiceData.outstanding_amount && invoiceData.outstanding_amount > 0 && invoiceData.outstanding_amount < invoiceData.grand_total)) ? `<div class="partial-status"><span>${__("Status:")}</span><span>${__("PARTIAL PAYMENT")}</span></div>` : ""}
 				</div>
 
@@ -129,7 +149,7 @@ export function buildReceiptHTML(invoiceData) {
 				<div class="payments">
 					<div style="font-weight: bold; margin-bottom: 5px; font-size: 12px;">${__("Payments:")}</div>
 					${invoiceData.payments.map((p) => `<div class="payment-row"><span>${p.mode_of_payment}:</span><span>${formatCurrency(p.amount)}</span></div>`).join("")}
-					<div class="payment-row total-paid"><span>${__("Total Paid:")}</span><span>${formatCurrency(invoiceData.paid_amount || 0)}</span></div>
+					<div class="payment-row total-paid"><span>${__("Total Paid:")}</span><span>${formatCurrency(paidAmount)}</span></div>
 					${invoiceData.change_amount && invoiceData.change_amount > 0 ? `<div class="payment-row" style="font-weight: bold; margin-top: 5px;"><span>${__("Change:")}</span><span>${formatCurrency(invoiceData.change_amount)}</span></div>` : ""}
 					${invoiceData.outstanding_amount && invoiceData.outstanding_amount > 0 ? `<div class="outstanding-row"><span>${__("BALANCE DUE:")}</span><span>${formatCurrency(invoiceData.outstanding_amount)}</span></div>` : ""}
 				</div>` : ""}
@@ -377,12 +397,15 @@ export async function printWithSilentFallback(invoiceData, printFormat = null) {
 // ============================================================================
 
 /**
- * Last-resort receipt renderer. Builds a complete HTML document from the
- * invoice data and writes it into a new window. Only triggered when the
- * browser blocks the /printview popup.
+ * Renders the receipt locally in a popup window. Used offline, for pending
+ * local-only invoices, and as the fallback when /printview is unavailable.
  */
 export function printInvoiceCustom(invoiceData) {
 	const printWindow = window.open("", "_blank", "width=350,height=600")
+	if (!printWindow) {
+		log.error("Cannot open print window — popup blocked.")
+		throw new Error("Popup blocked — check your browser settings.")
+	}
 
 	const printContent = buildReceiptDocumentHTML(invoiceData, { includeControls: true })
 
@@ -391,4 +414,5 @@ export function printInvoiceCustom(invoiceData) {
 	printWindow.onload = () => {
 		setTimeout(() => printWindow.print(), 250)
 	}
+	return true
 }

--- a/POS/src/utils/printInvoice.js
+++ b/POS/src/utils/printInvoice.js
@@ -2,6 +2,7 @@ import { call } from "@/utils/apiWrapper"
 import { logger } from "@/utils/logger"
 import { getOfflineReceiptPayload } from "@/utils/offline/offlineReceiptCache"
 import { getOfflineInvoiceByOfflineId } from "@/utils/offline/sync"
+import { offlineWorker } from "@/utils/offline/workerClient"
 import { printHTML as qzPrintHTML } from "@/utils/qzTray"
 
 const log = logger.create("PrintInvoice")
@@ -32,6 +33,19 @@ function derivePaidAmount(invoiceData) {
 /** Sales Invoices not yet on the server (offline queue / local receipt id). */
 export function isLocalOnlyInvoiceName(name) {
 	return typeof name === "string" && (name.startsWith("OFFLINE-") || name.startsWith("pos_offline_"))
+}
+
+/**
+ * Fire-and-forget: flag the queued invoice as printed so a later edit
+ * can warn the cashier a physical receipt is already in the customer's hands.
+ * Silently no-ops for synced / server-side invoices.
+ */
+function flagOfflineInvoicePrinted(invoiceName) {
+	if (!isLocalOnlyInvoiceName(invoiceName)) return
+	// Don't await — printing should never block on this bookkeeping call.
+	offlineWorker.markOfflineInvoicePrinted(invoiceName).catch((err) => {
+		log.warn("Failed to mark offline invoice printed:", err?.message || err)
+	})
 }
 
 /**
@@ -396,6 +410,7 @@ export async function silentPrintInvoiceFromDoc(invoiceData) {
 	const fullHTML = buildReceiptDocumentHTML(invoiceData, { includeControls: false })
 	await qzPrintHTML(fullHTML)
 	log.info(`Silent print (local receipt) for ${invoiceData?.name}`)
+	flagOfflineInvoicePrinted(invoiceData?.name)
 	return true
 }
 
@@ -466,5 +481,6 @@ export function printInvoiceCustom(invoiceData) {
 	printWindow.onload = () => {
 		setTimeout(() => printWindow.print(), 250)
 	}
+	flagOfflineInvoicePrinted(invoiceData?.name)
 	return true
 }

--- a/POS/src/utils/printInvoice.js
+++ b/POS/src/utils/printInvoice.js
@@ -1,4 +1,5 @@
 import { call } from "@/utils/apiWrapper"
+import { getOfflineReceiptPayload } from "@/utils/offline/offlineReceiptCache"
 import { logger } from "@/utils/logger"
 import { printHTML as qzPrintHTML } from "@/utils/qzTray"
 
@@ -12,6 +13,155 @@ const DEFAULT_PRINT_FORMAT = "POS Next Receipt"
 
 function formatCurrency(amount) {
 	return Number.parseFloat(amount || 0).toFixed(2)
+}
+
+/** Sales Invoices not yet on the server (offline queue / local receipt id). */
+export function isLocalOnlyInvoiceName(name) {
+	return typeof name === "string" && (name.startsWith("OFFLINE-") || name.startsWith("pos_offline_"))
+}
+
+/**
+ * Merge session-cached offline receipt when callers only have { name }.
+ * Prevents server print / get_invoice for synthetic OFFLINE-* ids.
+ */
+export function hydrateLocalOnlyInvoice(invoiceData) {
+	if (!invoiceData?.name || !isLocalOnlyInvoiceName(invoiceData.name)) return invoiceData
+	if (invoiceData.items?.length > 0) return invoiceData
+	const cached = getOfflineReceiptPayload(invoiceData.name)
+	if (cached?.items?.length > 0) return cached
+	return invoiceData
+}
+
+const RECEIPT_STYLES = `
+	* { margin: 0; padding: 0; box-sizing: border-box; }
+	body {
+		font-family: 'Courier New', monospace;
+		padding: 10px; width: 80mm; margin: 0; max-width: 80mm;
+		font-weight: bold; color: black;
+	}
+	.receipt { width: 100%; }
+	.header { text-align: center; margin-bottom: 20px; border-bottom: 2px dashed #000; padding-bottom: 10px; }
+	.company-name { font-size: 18px; font-weight: bold; margin-bottom: 5px; }
+	.invoice-info { margin-bottom: 15px; font-size: 12px; }
+	.invoice-info div { display: flex; justify-content: space-between; margin-bottom: 3px; }
+	.partial-status { color: #000; font-weight: bold; margin-bottom: 5px; }
+	.items-table { width: 100%; margin-bottom: 15px; border-top: 1px dashed #000; border-bottom: 1px dashed #000; padding: 10px 0; }
+	.item-row { margin-bottom: 10px; font-size: 12px; }
+	.item-name { font-weight: bold; margin-bottom: 3px; }
+	.item-details { display: flex; justify-content: space-between; font-size: 11px; }
+	.item-discount { display: flex; justify-content: space-between; font-size: 10px; margin-top: 2px; }
+	.item-serials { font-size: 9px; margin-top: 3px; padding: 3px 5px; border: 1px dashed #000; border-radius: 2px; }
+	.item-serials-label { font-weight: bold; margin-bottom: 2px; }
+	.item-serials-list { word-break: break-all; }
+	.totals { margin-top: 15px; border-top: 1px dashed #000; padding-top: 10px; }
+	.total-row { display: flex; justify-content: space-between; margin-bottom: 5px; font-size: 12px; }
+	.grand-total { font-size: 16px; font-weight: bold; border-top: 2px solid #000; padding-top: 10px; margin-top: 10px; }
+	.payments { margin-top: 15px; border-top: 1px dashed #000; padding-top: 10px; }
+	.payment-row { display: flex; justify-content: space-between; margin-bottom: 3px; font-size: 11px; }
+	.total-paid { font-weight: bold; border-top: 1px solid #000; padding-top: 5px; margin-top: 5px; }
+	.outstanding-row {
+		display: flex; justify-content: space-between; font-size: 13px; font-weight: bold;
+		border: 1px solid #000; padding: 8px; margin-top: 8px; border-radius: 4px;
+	}
+	.footer { text-align: center; margin-top: 20px; padding-top: 10px; border-top: 2px dashed #000; font-size: 11px; }
+	@media print {
+		@page { size: 80mm auto; margin: 0; }
+		body { width: 80mm; padding: 5mm; margin: 0; }
+		.no-print { display: none; }
+	}
+`
+
+/**
+ * Inner receipt HTML (no shell). Used for local/offline invoices and QZ Tray.
+ */
+export function buildReceiptHTML(invoiceData) {
+	const items = invoiceData.items || []
+	const itemsHtml = items
+		.map((item) => {
+			const hasDiscount =
+				(item.discount_percentage && Number.parseFloat(item.discount_percentage) > 0) ||
+				(item.discount_amount && Number.parseFloat(item.discount_amount) > 0)
+			const isFree = item.is_free_item
+			const qty = item.quantity || item.qty
+			const displayRate = item.price_list_rate || item.rate
+			const subtotal = qty * displayRate
+			return `
+						<div class="item-row">
+							<div class="item-name">${item.item_name || item.item_code} ${isFree ? __("(FREE)") : ""}</div>
+							<div class="item-details">
+								<span>${qty} × ${formatCurrency(displayRate)}</span>
+								<span><strong>${formatCurrency(subtotal)}</strong></span>
+							</div>
+							${hasDiscount ? `<div class="item-discount"><span>Discount ${item.discount_percentage ? `(${Number(item.discount_percentage).toFixed(2)}%)` : ""}</span><span>-${formatCurrency(item.discount_amount || 0)}</span></div>` : ""}
+							${item.serial_no ? `<div class="item-serials"><div class="item-serials-label">${__("Serial No:")}</div><div class="item-serials-list">${String(item.serial_no).replace(/\n/g, ", ")}</div></div>` : ""}
+						</div>`
+		})
+		.join("")
+
+	return `
+			<div class="receipt">
+				<div class="header">
+					<div class="company-name">${invoiceData.company || "POS Next"}</div>
+					<div style="font-size: 12px;">${invoiceData.header || __("TAX INVOICE")}</div>
+				</div>
+
+				<div class="invoice-info">
+					<div><span>${__("Invoice #:")}</span><span><strong>${invoiceData.name}</strong></span></div>
+					<div><span>${__("Date:")}</span><span>${new Date(invoiceData.posting_date || Date.now()).toLocaleString()}</span></div>
+					${invoiceData.customer_name ? `<div><span>${__("Customer:")}</span><span>${invoiceData.customer_name}</span></div>` : ""}
+					${(invoiceData.status === "Partly Paid" || (invoiceData.outstanding_amount && invoiceData.outstanding_amount > 0 && invoiceData.outstanding_amount < invoiceData.grand_total)) ? `<div class="partial-status"><span>${__("Status:")}</span><span>${__("PARTIAL PAYMENT")}</span></div>` : ""}
+				</div>
+
+				<div class="items-table">
+					${itemsHtml}
+				</div>
+
+				<div class="totals">
+					${invoiceData.total_taxes_and_charges && invoiceData.total_taxes_and_charges > 0 ? `
+					<div class="total-row"><span>${__("Subtotal:")}</span><span>${formatCurrency((invoiceData.grand_total || 0) - (invoiceData.total_taxes_and_charges || 0))}</span></div>
+					<div class="total-row"><span>${__("Tax:")}</span><span>${formatCurrency(invoiceData.total_taxes_and_charges)}</span></div>` : ""}
+					${invoiceData.discount_amount ? `
+					<div class="total-row" style="color: #28a745;"><span>Additional Discount${invoiceData.additional_discount_percentage ? ` (${Number(invoiceData.additional_discount_percentage).toFixed(1)}%)` : ""}:</span><span>-${formatCurrency(Math.abs(invoiceData.discount_amount))}</span></div>` : ""}
+					<div class="total-row grand-total"><span>${__("TOTAL:")}</span><span>${formatCurrency(invoiceData.grand_total)}</span></div>
+				</div>
+
+				${invoiceData.payments && invoiceData.payments.length > 0 ? `
+				<div class="payments">
+					<div style="font-weight: bold; margin-bottom: 5px; font-size: 12px;">${__("Payments:")}</div>
+					${invoiceData.payments.map((p) => `<div class="payment-row"><span>${p.mode_of_payment}:</span><span>${formatCurrency(p.amount)}</span></div>`).join("")}
+					<div class="payment-row total-paid"><span>${__("Total Paid:")}</span><span>${formatCurrency(invoiceData.paid_amount || 0)}</span></div>
+					${invoiceData.change_amount && invoiceData.change_amount > 0 ? `<div class="payment-row" style="font-weight: bold; margin-top: 5px;"><span>${__("Change:")}</span><span>${formatCurrency(invoiceData.change_amount)}</span></div>` : ""}
+					${invoiceData.outstanding_amount && invoiceData.outstanding_amount > 0 ? `<div class="outstanding-row"><span>${__("BALANCE DUE:")}</span><span>${formatCurrency(invoiceData.outstanding_amount)}</span></div>` : ""}
+				</div>` : ""}
+
+				<div class="footer">
+					<div style="margin-bottom: 5px;">${invoiceData.footer || __("Thank you for your business!")}</div>
+					${invoiceData.footer ? "" : `<div style="font-size: 10px;">Powered by <a href="https://nexus.brainwise.me" target="_blank" style="color: #3b82f6; text-decoration: none; font-weight: 600;">BrainWise</a></div>`}
+				</div>
+			</div>`
+}
+
+function buildReceiptDocumentHTML(invoiceData, { includeControls = false } = {}) {
+	const controls = includeControls
+		? `
+			<div class="no-print" style="text-align: center; margin-top: 20px;">
+				<button onclick="window.print()" style="padding: 10px 20px; font-size: 14px; cursor: pointer;">${__("Print Receipt")}</button>
+				<button onclick="window.close()" style="padding: 10px 20px; font-size: 14px; cursor: pointer; margin-left: 10px;">${__("Close")}</button>
+			</div>`
+		: ""
+	return `
+		<!DOCTYPE html>
+		<html>
+		<head>
+			<meta charset="UTF-8">
+			<title>${__("Invoice - {0}", [invoiceData.name])}</title>
+			<style>${RECEIPT_STYLES}</style>
+		</head>
+		<body>
+			${buildReceiptHTML(invoiceData)}
+			${controls}
+		</body>
+		</html>`
 }
 
 /**
@@ -54,6 +204,16 @@ export async function printInvoice(invoiceData, printFormat = null, letterhead =
 	try {
 		if (!invoiceData?.name) throw new Error("Invalid invoice data")
 
+		invoiceData = hydrateLocalOnlyInvoice(invoiceData)
+
+		// Pending offline / local IDs are not in ERPNext — use embedded receipt HTML.
+		if (isLocalOnlyInvoiceName(invoiceData.name)) {
+			if (invoiceData.items?.length > 0) return printInvoiceCustom(invoiceData)
+			throw new Error(
+				__("This offline receipt is no longer in browser storage. Sync the invoice, then print from history."),
+			)
+		}
+
 		const doctype = invoiceData.doctype || "Sales Invoice"
 		const format = printFormat || DEFAULT_PRINT_FORMAT
 
@@ -75,6 +235,12 @@ export async function printInvoice(invoiceData, printFormat = null, letterhead =
 		return true
 	} catch (error) {
 		log.error("Browser print failed:", error)
+		if (
+			isLocalOnlyInvoiceName(invoiceData?.name) &&
+			!(invoiceData.items?.length > 0)
+		) {
+			throw error
+		}
 		return printInvoiceCustom(invoiceData)
 	}
 }
@@ -84,6 +250,18 @@ export async function printInvoice(invoiceData, printFormat = null, letterhead =
  * then open the browser print window.
  */
 export async function printInvoiceByName(invoiceName, printFormat = null, letterhead = null) {
+	const localDoc = hydrateLocalOnlyInvoice({ name: invoiceName })
+	if (isLocalOnlyInvoiceName(invoiceName)) {
+		if (!localDoc.items?.length) {
+			throw new Error(
+				__(
+					"This offline receipt is no longer in browser storage. Complete checkout again or sync, then print from history.",
+				),
+			)
+		}
+		const settings = await resolvePrintSettings(localDoc.pos_profile, printFormat, letterhead)
+		return printInvoice(localDoc, settings.printFormat, settings.letterhead)
+	}
 	const invoiceDoc = await call("pos_next.api.invoices.get_invoice", {
 		invoice_name: invoiceName,
 	})
@@ -106,6 +284,15 @@ export async function printInvoiceByName(invoiceName, printFormat = null, letter
  * Paper size and margins are controlled by the QZ Tray config in qzTray.js.
  */
 export async function silentPrintInvoice(invoiceName, printFormat = null) {
+	if (isLocalOnlyInvoiceName(invoiceName)) {
+		const doc = hydrateLocalOnlyInvoice({ name: invoiceName })
+		if (doc.items?.length > 0) return silentPrintInvoiceFromDoc(doc)
+		throw new Error(
+			__(
+				"This offline receipt is no longer in browser storage. Use browser print from the success dialog after checkout.",
+			),
+		)
+	}
 	const format = printFormat || DEFAULT_PRINT_FORMAT
 
 	const result = await call("frappe.www.printview.get_html_and_style", {
@@ -131,13 +318,43 @@ export async function silentPrintInvoice(invoiceName, printFormat = null) {
 }
 
 /**
+ * Silent-print a full invoice dict using the same HTML as the offline receipt fallback.
+ */
+export async function silentPrintInvoiceFromDoc(invoiceData) {
+	const fullHTML = buildReceiptDocumentHTML(invoiceData, { includeControls: false })
+	await qzPrintHTML(fullHTML)
+	log.info(`Silent print (local receipt) for ${invoiceData?.name}`)
+	return true
+}
+
+/**
  * Try silent print, fall back to browser print on failure.
  * silentPrintInvoice → qzPrintHTML → connect() handles auto-reconnect
  * internally, so no separate connection logic is needed here.
  */
 export async function printWithSilentFallback(invoiceData, printFormat = null) {
+	invoiceData = hydrateLocalOnlyInvoice(invoiceData)
 	const invoiceName = invoiceData?.name
 	if (!invoiceName) throw new Error("Invalid invoice data — missing name")
+
+	if (
+		isLocalOnlyInvoiceName(invoiceName) &&
+		invoiceData.items?.length > 0
+	) {
+		try {
+			await silentPrintInvoiceFromDoc(invoiceData)
+			return { method: "silent", success: true }
+		} catch (err) {
+			log.warn("Silent local receipt failed, falling back to browser:", err?.message || err)
+		}
+		try {
+			printInvoiceCustom(invoiceData)
+			return { method: "browser", success: true }
+		} catch (err) {
+			log.error("Browser print for local receipt failed:", err)
+			return { method: "browser", success: false }
+		}
+	}
 
 	try {
 		await silentPrintInvoice(invoiceName, printFormat)
@@ -167,119 +384,7 @@ export async function printWithSilentFallback(invoiceData, printFormat = null) {
 export function printInvoiceCustom(invoiceData) {
 	const printWindow = window.open("", "_blank", "width=350,height=600")
 
-	const printContent = `
-		<!DOCTYPE html>
-		<html>
-		<head>
-			<meta charset="UTF-8">
-			<title>${__("Invoice - {0}", [invoiceData.name])}</title>
-			<style>
-				* { margin: 0; padding: 0; box-sizing: border-box; }
-				body {
-					font-family: 'Courier New', monospace;
-					padding: 10px; width: 80mm; margin: 0; max-width: 80mm;
-					font-weight: bold; color: black;
-				}
-				.receipt { width: 100%; }
-				.header { text-align: center; margin-bottom: 20px; border-bottom: 2px dashed #000; padding-bottom: 10px; }
-				.company-name { font-size: 18px; font-weight: bold; margin-bottom: 5px; }
-				.invoice-info { margin-bottom: 15px; font-size: 12px; }
-				.invoice-info div { display: flex; justify-content: space-between; margin-bottom: 3px; }
-				.partial-status { color: #000; font-weight: bold; margin-bottom: 5px; }
-				.items-table { width: 100%; margin-bottom: 15px; border-top: 1px dashed #000; border-bottom: 1px dashed #000; padding: 10px 0; }
-				.item-row { margin-bottom: 10px; font-size: 12px; }
-				.item-name { font-weight: bold; margin-bottom: 3px; }
-				.item-details { display: flex; justify-content: space-between; font-size: 11px; }
-				.item-discount { display: flex; justify-content: space-between; font-size: 10px; margin-top: 2px; }
-				.item-serials { font-size: 9px; margin-top: 3px; padding: 3px 5px; border: 1px dashed #000; border-radius: 2px; }
-				.item-serials-label { font-weight: bold; margin-bottom: 2px; }
-				.item-serials-list { word-break: break-all; }
-				.totals { margin-top: 15px; border-top: 1px dashed #000; padding-top: 10px; }
-				.total-row { display: flex; justify-content: space-between; margin-bottom: 5px; font-size: 12px; }
-				.grand-total { font-size: 16px; font-weight: bold; border-top: 2px solid #000; padding-top: 10px; margin-top: 10px; }
-				.payments { margin-top: 15px; border-top: 1px dashed #000; padding-top: 10px; }
-				.payment-row { display: flex; justify-content: space-between; margin-bottom: 3px; font-size: 11px; }
-				.total-paid { font-weight: bold; border-top: 1px solid #000; padding-top: 5px; margin-top: 5px; }
-				.outstanding-row {
-					display: flex; justify-content: space-between; font-size: 13px; font-weight: bold;
-					border: 1px solid #000; padding: 8px; margin-top: 8px; border-radius: 4px;
-				}
-				.footer { text-align: center; margin-top: 20px; padding-top: 10px; border-top: 2px dashed #000; font-size: 11px; }
-				@media print {
-					@page { size: 80mm auto; margin: 0; }
-					body { width: 80mm; padding: 5mm; margin: 0; }
-					.no-print { display: none; }
-				}
-			</style>
-		</head>
-		<body>
-			<div class="receipt">
-				<div class="header">
-					<div class="company-name">${invoiceData.company || "POS Next"}</div>
-					<div style="font-size: 12px;">${invoiceData.header || __("TAX INVOICE")}</div>
-				</div>
-
-				<div class="invoice-info">
-					<div><span>${__("Invoice #:")}</span><span><strong>${invoiceData.name}</strong></span></div>
-					<div><span>${__("Date:")}</span><span>${new Date(invoiceData.posting_date || Date.now()).toLocaleString()}</span></div>
-					${invoiceData.customer_name ? `<div><span>${__("Customer:")}</span><span>${invoiceData.customer_name}</span></div>` : ""}
-					${(invoiceData.status === "Partly Paid" || (invoiceData.outstanding_amount && invoiceData.outstanding_amount > 0 && invoiceData.outstanding_amount < invoiceData.grand_total)) ? `<div class="partial-status"><span>${__("Status:")}</span><span>${__("PARTIAL PAYMENT")}</span></div>` : ""}
-				</div>
-
-				<div class="items-table">
-					${invoiceData.items
-						.map((item) => {
-							const hasDiscount =
-								(item.discount_percentage && Number.parseFloat(item.discount_percentage) > 0) ||
-								(item.discount_amount && Number.parseFloat(item.discount_amount) > 0)
-							const isFree = item.is_free_item
-							const qty = item.quantity || item.qty
-							const displayRate = item.price_list_rate || item.rate
-							const subtotal = qty * displayRate
-							return `
-						<div class="item-row">
-							<div class="item-name">${item.item_name || item.item_code} ${isFree ? __("(FREE)") : ""}</div>
-							<div class="item-details">
-								<span>${qty} × ${formatCurrency(displayRate)}</span>
-								<span><strong>${formatCurrency(subtotal)}</strong></span>
-							</div>
-							${hasDiscount ? `<div class="item-discount"><span>Discount ${item.discount_percentage ? `(${Number(item.discount_percentage).toFixed(2)}%)` : ""}</span><span>-${formatCurrency(item.discount_amount || 0)}</span></div>` : ""}
-							${item.serial_no ? `<div class="item-serials"><div class="item-serials-label">${__("Serial No:")}</div><div class="item-serials-list">${item.serial_no.replace(/\n/g, ", ")}</div></div>` : ""}
-						</div>`
-						})
-						.join("")}
-				</div>
-
-				<div class="totals">
-					${invoiceData.total_taxes_and_charges && invoiceData.total_taxes_and_charges > 0 ? `
-					<div class="total-row"><span>${__("Subtotal:")}</span><span>${formatCurrency((invoiceData.grand_total || 0) - (invoiceData.total_taxes_and_charges || 0))}</span></div>
-					<div class="total-row"><span>${__("Tax:")}</span><span>${formatCurrency(invoiceData.total_taxes_and_charges)}</span></div>` : ""}
-					${invoiceData.discount_amount ? `
-					<div class="total-row" style="color: #28a745;"><span>Additional Discount${invoiceData.additional_discount_percentage ? ` (${Number(invoiceData.additional_discount_percentage).toFixed(1)}%)` : ""}:</span><span>-${formatCurrency(Math.abs(invoiceData.discount_amount))}</span></div>` : ""}
-					<div class="total-row grand-total"><span>${__("TOTAL:")}</span><span>${formatCurrency(invoiceData.grand_total)}</span></div>
-				</div>
-
-				${invoiceData.payments && invoiceData.payments.length > 0 ? `
-				<div class="payments">
-					<div style="font-weight: bold; margin-bottom: 5px; font-size: 12px;">${__("Payments:")}</div>
-					${invoiceData.payments.map((p) => `<div class="payment-row"><span>${p.mode_of_payment}:</span><span>${formatCurrency(p.amount)}</span></div>`).join("")}
-					<div class="payment-row total-paid"><span>${__("Total Paid:")}</span><span>${formatCurrency(invoiceData.paid_amount || 0)}</span></div>
-					${invoiceData.change_amount && invoiceData.change_amount > 0 ? `<div class="payment-row" style="font-weight: bold; margin-top: 5px;"><span>${__("Change:")}</span><span>${formatCurrency(invoiceData.change_amount)}</span></div>` : ""}
-					${invoiceData.outstanding_amount && invoiceData.outstanding_amount > 0 ? `<div class="outstanding-row"><span>${__("BALANCE DUE:")}</span><span>${formatCurrency(invoiceData.outstanding_amount)}</span></div>` : ""}
-				</div>` : ""}
-
-				<div class="footer">
-					<div style="margin-bottom: 5px;">${invoiceData.footer || __("Thank you for your business!")}</div>
-					${invoiceData.footer ? "" : `<div style="font-size: 10px;">Powered by <a href="https://nexus.brainwise.me" target="_blank" style="color: #3b82f6; text-decoration: none; font-weight: 600;">BrainWise</a></div>`}
-				</div>
-			</div>
-
-			<div class="no-print" style="text-align: center; margin-top: 20px;">
-				<button onclick="window.print()" style="padding: 10px 20px; font-size: 14px; cursor: pointer;">${__("Print Receipt")}</button>
-				<button onclick="window.close()" style="padding: 10px 20px; font-size: 14px; cursor: pointer; margin-left: 10px;">${__("Close")}</button>
-			</div>
-		</body>
-		</html>`
+	const printContent = buildReceiptDocumentHTML(invoiceData, { includeControls: true })
 
 	printWindow.document.write(printContent)
 	printWindow.document.close()

--- a/POS/src/utils/sessionCleanup.js
+++ b/POS/src/utils/sessionCleanup.js
@@ -1,4 +1,5 @@
 import { clearAllDrafts } from "@/utils/draftManager"
+import { clearAllOfflineReceiptPayloads } from "@/utils/offline/offlineReceiptCache"
 import { usePOSCartStore } from "@/stores/posCart"
 import { usePOSUIStore } from "@/stores/posUI"
 import { useSessionLock } from "@/composables/useSessionLock"
@@ -30,6 +31,10 @@ export async function cleanupUserSession() {
 	for (const key of USER_KEYS) {
 		localStorage.removeItem(key)
 	}
+
+	// Clear cashier-specific sessionStorage (offline receipt cache) so the next
+	// user on the same tab can't read the previous user's receipts.
+	clearAllOfflineReceiptPayloads()
 
 	// 2. Clear Pinia stores
 	const cartStore = usePOSCartStore()

--- a/POS/src/workers/offline.worker.js
+++ b/POS/src/workers/offline.worker.js
@@ -367,7 +367,7 @@ async function getOfflineInvoiceCount() {
 
 		const count = await db
 			.table("invoice_queue")
-			.filter((invoice) => invoice.synced === false)
+			.filter((invoice) => invoice.synced === false && !invoice.superseded)
 			.count()
 		return count
 	} catch (error) {
@@ -395,7 +395,7 @@ async function getOfflineInvoices() {
 
 		const invoices = await db
 			.table("invoice_queue")
-			.filter((invoice) => invoice.synced === false)
+			.filter((invoice) => invoice.synced === false && !invoice.superseded)
 			.toArray()
 		return invoices
 	} catch (error) {
@@ -1366,6 +1366,41 @@ async function deleteOfflineInvoice(id) {
 	}
 }
 
+// Mark an invoice row as superseded by an edit. The row stays in the queue
+// for audit but is excluded from sync and from the pending count.
+async function supersedeOfflineInvoice(id, replacedBy) {
+	try {
+		const db = await initDB()
+		await db.table("invoice_queue").update(id, {
+			superseded: true,
+			replaced_by: replacedBy || null,
+			superseded_at: Date.now(),
+		})
+		return { success: true }
+	} catch (error) {
+		log.error("Error superseding offline invoice", error)
+		throw error
+	}
+}
+
+// Mark a queued offline invoice as printed. Used by the print flow so
+// later edits can warn the cashier that a physical receipt is already out.
+async function markOfflineInvoicePrinted(offlineId) {
+	if (!offlineId) return { success: false }
+	try {
+		const db = await initDB()
+		const row = await db.table("invoice_queue").where("offline_id").equals(offlineId).first()
+		if (!row) return { success: false, reason: "not found" }
+		await db.table("invoice_queue").update(row.id, {
+			data: { ...row.data, was_printed: true, last_printed_at: Date.now() },
+		})
+		return { success: true }
+	} catch (error) {
+		log.error("Error marking offline invoice printed", error)
+		return { success: false, error: String(error) }
+	}
+}
+
 // Update stock quantities in cached items
 async function updateStockQuantities(stockUpdates) {
 	try {
@@ -1735,6 +1770,14 @@ self.onmessage = async (event) => {
 
 			case "DELETE_INVOICE":
 				result = await deleteOfflineInvoice(payload.id)
+				break
+
+			case "MARK_INVOICE_PRINTED":
+				result = await markOfflineInvoicePrinted(payload.offline_id)
+				break
+
+			case "SUPERSEDE_INVOICE":
+				result = await supersedeOfflineInvoice(payload.id, payload.replaced_by)
 				break
 
 			case "SET_SHOW_VARIANTS_AS_ITEMS":


### PR DESCRIPTION
## Summary

Adds full offline receipt handling to POS Next: invoices created while offline are saved locally, printed immediately from a cached payload, survive page reloads, and sync to the backend when connectivity returns. Also hardens the print renderer and unifies the identity of an offline invoice across its lifecycle.

## What's in this PR

### Offline receipt creation & print (`POSSale.vue`, `printInvoice.js`)
- On payment completion while offline, build a cached print document (items, payments, taxes, `grand_total`, `change_amount`, `company`, `pos_profile`) and print immediately.
- `printInvoice` now accepts a local-only invoice name and hydrates it from the offline cache instead of fetching from the server.
- Offline badge is rendered on the printed receipt so cashiers can tell offline prints apart.
- Renderer hardened against missing fields; captured `grandTotal` is passed through explicitly rather than recomputed.

### Printed / Superseded flags + Reprint (`OfflineInvoicesDialog.vue`, `posUI.js`, `offlineReceiptCache.js`)
- `was_printed` + `last_printed_at` persisted on the offline invoice record.
- **Reprint** button in the Offline Invoices dialog (with tooltip "Reprint receipt (already printed once)") re-renders from cache.
- Once printed, **edit is blocked** with tooltip: "Printed invoices cannot be edited — use Return to issue a credit note".
- `superseded` flag supports the edit-reconnect flow so amended offline invoices don't double-post.

### Reload persistence (`offline.worker.js`, `sync.js`, `workerClient.js`)
- `change_amount` and `company` are persisted on the queued record so the receipt can be rebuilt after a page reload.
- Unified `offline_id` (e.g. `pos_offline_<uuid>`) is used end-to-end: create → print → reload → sync.
- Offline receipt cache is cleared on logout and after successful sync (`sessionCleanup.js`).

### Sync & connection state (`posSync.js`, `InvoiceDetailDialog.vue`)
- "Sync All" button in the Offline Invoices dialog when online; pending count badge in the top bar.
- Detail dialog can open offline invoices from cache for inspection.

## Commits
- `a3098c3f` feat(offline): printed/superseded flags, reprint button, edit-reconnect fix
- `72914ed0` fix(offline-print): persist change_amount and company for reload rebuild
- `ec825bb7` fix(offline-print): unify ids, survive reload, clear cache on logout/sync
- `fe25c4b3` fix(offline-print): pass captured grandTotal, add offline badge, harden renderer
- `f66874f1` Implement offline receipt handling and enhance invoice printing functionality

## Manual test (verified via Playwright MCP against http://localhost:8000/pos/)
- [x] POS loads with Administrator on Main POS Profile, shift open
- [x] Create invoice while server is unreachable → "Offline Invoices" dialog shows "1 Pending Invoice(s)" with "Printed" badge
- [x] IndexedDB `invoice_queue` record contains `change_amount`, `company="BrainWise (Demo)"`, `was_printed=true`, `last_printed_at`, unified `offline_id`
- [x] Reprint button opens a new print tab and updates `last_printed_at`
- [x] Edit button is disabled on printed invoices with the correct tooltip
- [x] Full page reload: record + all fields persist, receipt can be reprinted from cache
- [x] When back online, "Sync All" submits the queue (~3s); server returns a real Sales Invoice (`ACC-SINV-2026-00343`, ê 47.00, Walk-In Customer); UI shows "0 Pending Invoice(s)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)