### PR TITLE
feat: keyboard shortcuts + Enter-to-pay in payment dialog

### DIFF
--- a/POS/src/components/sale/PaymentDialog.vue
+++ b/POS/src/components/sale/PaymentDialog.vue
@@ -633,7 +633,23 @@
 						</div>
 						<div class="grid grid-cols-4 gap-1.5">
 							<button
-								v-for="amount in quickAmounts"
+								v-if="quickAmounts.length > 0"
+								ref="firstQuickAmountBtnRef"
+								@click="addCustomPayment(lastSelectedMethod, quickAmounts[0])"
+								@keydown.enter.stop.prevent="handleFirstQuickAmountEnter"
+								:disabled="isQuickAmountDisabled(quickAmounts[0])"
+								:class="[
+									'font-semibold rounded-lg border-2 transition-all',
+									isCompactMode ? 'px-2 py-2 text-sm' : 'px-2 py-2 text-sm',
+									isQuickAmountDisabled(quickAmounts[0])
+										? 'bg-gray-50 border-gray-100 text-gray-300 cursor-not-allowed'
+										: 'bg-white border-gray-200 hover:border-blue-400 hover:bg-blue-50 text-gray-700 hover:text-blue-600'
+								]"
+							>
+								{{ formatCurrency(quickAmounts[0]) }}
+							</button>
+							<button
+								v-for="amount in quickAmounts.slice(1)"
 								:key="amount"
 								@click="addCustomPayment(lastSelectedMethod, amount)"
 								:disabled="isQuickAmountDisabled(amount)"
@@ -685,6 +701,7 @@
 										isExactAmountModeActive && !isCashPaymentMethod(lastSelectedMethod) ? 'text-gray-300' : 'text-gray-400'
 									]">{{ currencySymbol }}</span>
 									<input
+										ref="mobileAmountInputRef"
 										v-model="mobileCustomAmount"
 										type="number"
 										inputmode="decimal"
@@ -699,6 +716,7 @@
 												? 'bg-gray-50 border-gray-100 text-gray-300 cursor-not-allowed'
 												: 'bg-white border-gray-200 focus:ring-1 focus:ring-blue-500'
 										]"
+										@keydown.enter.prevent="handleMobileAmountEnter"
 									/>
 								</div>
 								<button
@@ -1178,12 +1196,16 @@ watch(
 function handleNumpadEnter(value) {
 	if (value > 0 && lastSelectedMethod.value) {
 		numpadAddPayment()
+		nextTick(() => {
+			if (remainingAmount.value === 0 && totalPaid.value > 0 && canComplete.value) {
+				completePayment()
+			}
+		})
 	} else if (
 		remainingAmount.value === 0 &&
 		totalPaid.value > 0 &&
 		canComplete.value
 	) {
-		// If fully paid and can complete, trigger complete payment
 		completePayment()
 	}
 }
@@ -1203,12 +1225,43 @@ const {
 
 // Mobile custom amount state
 const mobileCustomAmount = ref("")
+const mobileAmountInputRef = ref(null)
+
+// Desktop first quick-amount button ref (focused on open for Enter-to-pay)
+const firstQuickAmountBtnRef = ref(null)
 
 function addMobileCustomPayment() {
 	const amount = Number.parseFloat(mobileCustomAmount.value)
 	if (amount > 0 && lastSelectedMethod.value) {
 		addCustomPayment(lastSelectedMethod.value, amount)
 		mobileCustomAmount.value = ""
+	}
+}
+
+async function handleMobileAmountEnter() {
+	const amount = Number.parseFloat(mobileCustomAmount.value)
+	if (amount > 0 && lastSelectedMethod.value) {
+		await addCustomPayment(lastSelectedMethod.value, amount)
+		mobileCustomAmount.value = ""
+		nextTick(() => {
+			mobileAmountInputRef.value?.focus()
+			mobileAmountInputRef.value?.select()
+		})
+		if (canComplete.value && !isSubmitting.value) {
+			completePayment()
+		}
+	} else if (canComplete.value && !isSubmitting.value) {
+		completePayment()
+	} else if (props.allowCreditSale && paymentEntries.value.length === 0) {
+		addCreditAccountPayment()
+	}
+}
+
+async function handleFirstQuickAmountEnter() {
+	if (!lastSelectedMethod.value || !quickAmounts.value?.[0]) return
+	await addCustomPayment(lastSelectedMethod.value, quickAmounts.value[0])
+	if (canComplete.value && !isSubmitting.value) {
+		completePayment()
 	}
 }
 
@@ -1988,6 +2041,16 @@ watch(show, (newVal) => {
 		if (paymentMethods.value.length > 0 && !lastSelectedMethod.value) {
 			const defaultMethod = paymentMethods.value.find((m) => m.default)
 			lastSelectedMethod.value = defaultMethod || paymentMethods.value[0]
+		}
+
+		// Pre-populate mobile input and focus first quick-amount button on desktop
+		if (props.grandTotal > 0) {
+			mobileCustomAmount.value = props.grandTotal.toFixed(2)
+			nextTick(() => {
+				mobileAmountInputRef.value?.focus()
+				mobileAmountInputRef.value?.select()
+				firstQuickAmountBtnRef.value?.focus()
+			})
 		}
 
 		// Customer credit and balance is pre-fetched when customer changes (see watcher above)

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -358,6 +358,7 @@
 							style="min-width: 300px; contain: layout style paint"
 						>
 							<InvoiceCart
+								ref="invoiceCartRef"
 								:items="cartStore.invoiceItems"
 								:customer="cartStore.customer"
 								:subtotal="cartStore.subtotal"
@@ -1094,6 +1095,7 @@ const { isRTL } = useLocale();
 
 // Component refs
 const itemsSelectorRef = ref(null);
+const invoiceCartRef = ref(null);
 const offersDialogRef = ref(null);
 const containerRef = ref(null);
 const dividerRef = ref(null);
@@ -1211,6 +1213,28 @@ onMounted(async () => {
 		updateLayoutBounds();
 	};
 	window.addEventListener("resize", handleResize, { passive: true });
+
+	// Global keyboard shortcuts
+	const handleGlobalKeydown = (event) => {
+		// Skip if any dialog is open or if user is typing in an input/textarea
+		if (uiStore.isAnyDialogOpen) return;
+		const tag = document.activeElement?.tagName;
+		const isFunctionKey = event.key.startsWith("F") && !isNaN(event.key.slice(1));
+		if (!isFunctionKey && (tag === "INPUT" || tag === "TEXTAREA")) return;
+
+		if (event.key === "F4") {
+			event.preventDefault();
+			itemsSelectorRef.value?.focusSearchInput();
+		} else if (event.key === "F8") {
+			event.preventDefault();
+			invoiceCartRef.value?.focusCustomerSearch();
+		} else if (event.key === "F9") {
+			event.preventDefault();
+			handleProceedToPayment();
+		}
+	};
+	window.addEventListener("keydown", handleGlobalKeydown);
+	onUnmounted(() => window.removeEventListener("keydown", handleGlobalKeydown));
 
 	// Set up real-time stock update listener
 	const cleanup = onStockUpdate(async (stockUpdates) => {


### PR DESCRIPTION
## Summary

- **F4** focuses item search, **F8** focuses customer search, **F9** opens the payment dialog — all work even when an input is focused
- When the payment dialog opens (desktop), the first quick-amount button (exact grand total) is auto-focused — pressing **Enter** pays and completes instantly
- Mobile custom-amount input: **Enter** applies amount and auto-completes if fully paid
- Numpad **Enter**: auto-completes after adding an amount if fully paid
- Typing **0** + Enter on mobile triggers pay-on-account (credit sale) when enabled

## Demo

**Before:**


**After:**


🤖 Generated with [Claude Code](https://claude.com/claude-code)