### PR TITLE
fix(items): harden POS Profile item scope + opt-in allow_global_items

### DIFF
--- a/pos_next/api/items.py
+++ b/pos_next/api/items.py
@@ -540,11 +540,15 @@ def get_item_variants(template_item, pos_profile):
 			.where(Item.is_sales_item == 1)
 		)
 
-		# Add company filter to show items for specific company + global items
+		# Company scope: strict by default; include empty (global) items only if
+		# the profile's POS Settings explicitly opts in.
 		if pos_profile_doc.company:
-			query = query.where(
-				fn.Coalesce(Item.custom_company, "").isin([pos_profile_doc.company, ""])
-			)
+			if _pos_settings_allow_global_items(pos_profile_doc.name):
+				query = query.where(
+					fn.Coalesce(Item.custom_company, "").isin([pos_profile_doc.company, ""])
+				)
+			else:
+				query = query.where(Item.custom_company == pos_profile_doc.company)
 
 		variants = query.run(as_dict=True)
 
@@ -742,6 +746,34 @@ def _get_allowed_profile_brands(pos_profile):
 	return _get_pos_profile_configured_brands(pos_profile)
 
 
+def invalidate_pos_settings_cache(doc, method=None):
+	"""Doc-event hook: drop cached `allow_global_items` when POS Settings is saved."""
+	if doc and getattr(doc, "pos_profile", None):
+		frappe.cache().delete_value(f"pos_settings_allow_global_items:{doc.pos_profile}")
+
+
+def _pos_settings_allow_global_items(pos_profile_name):
+	"""Whether the POS Settings row for this profile opts into global items.
+
+	A "global item" is one whose ``custom_company`` is NULL or empty — historically
+	used as a shared SKU across companies. With strict company filtering as the
+	default, these items are hidden unless this flag is enabled.
+	"""
+	cache_key = f"pos_settings_allow_global_items:{pos_profile_name}"
+	cached = frappe.cache().get_value(cache_key)
+	if cached is not None:
+		return cached
+
+	value = frappe.db.get_value(
+		"POS Settings",
+		{"pos_profile": pos_profile_name, "enabled": 1},
+		"allow_global_items",
+	) or 0
+	result = int(value)
+	frappe.cache().set_value(cache_key, result, expires_in_sec=300)
+	return result
+
+
 def _get_pos_profile_allowed_item_groups(pos_profile_doc):
 	"""Return the item groups (with descendants) authorised for a POS Profile.
 
@@ -790,7 +822,10 @@ def _build_item_base_conditions(
 	where_params = []
 
 	if pos_profile_doc.company:
-		conditions.append("i.custom_company = %s")
+		if _pos_settings_allow_global_items(pos_profile_doc.name):
+			conditions.append("(i.custom_company = %s OR IFNULL(i.custom_company, '') = '')")
+		else:
+			conditions.append("i.custom_company = %s")
 		where_params.append(pos_profile_doc.company)
 
 	allowed_item_groups = _get_pos_profile_allowed_item_groups(pos_profile_doc)

--- a/pos_next/api/items.py
+++ b/pos_next/api/items.py
@@ -667,9 +667,12 @@ def _get_item_group_with_descendants(item_group):
 	if not item_group:
 		return []
 
-	ItemGroup = DocType("Item Group")
+	cache_key = f"item_group_descendants:{item_group}"
+	cached = frappe.cache().get_value(cache_key)
+	if cached is not None:
+		return cached
 
-	# Get lft, rgt for the item group to find descendants
+	ItemGroup = DocType("Item Group")
 	group_data = (
 		frappe.qb.from_(ItemGroup)
 		.select(ItemGroup.lft, ItemGroup.rgt, ItemGroup.is_group)
@@ -678,22 +681,23 @@ def _get_item_group_with_descendants(item_group):
 	)
 
 	if not group_data:
-		return [item_group]
+		result = [item_group]
+	else:
+		group = group_data[0]
+		if not group.is_group:
+			result = [item_group]
+		else:
+			descendants = (
+				frappe.qb.from_(ItemGroup)
+				.select(ItemGroup.name)
+				.where(ItemGroup.lft > group.lft)
+				.where(ItemGroup.rgt < group.rgt)
+				.run(pluck="name")
+			)
+			result = [item_group] + list(descendants)
 
-	group = group_data[0]
-	if not group.is_group:
-		return [item_group]
-
-	# Get all descendants using lft/rgt range
-	descendants = (
-		frappe.qb.from_(ItemGroup)
-		.select(ItemGroup.name)
-		.where(ItemGroup.lft > group.lft)
-		.where(ItemGroup.rgt < group.rgt)
-		.run(pluck="name")
-	)
-
-	return [item_group] + list(descendants)
+	frappe.cache().set_value(cache_key, result, expires_in_sec=300)
+	return result
 
 
 def _get_pos_profile_configured_brands(pos_profile):
@@ -737,6 +741,26 @@ def _get_allowed_profile_brands(pos_profile):
 	"""
 	return _get_pos_profile_configured_brands(pos_profile)
 
+
+def _get_pos_profile_allowed_item_groups(pos_profile_doc):
+	"""Return the item groups (with descendants) authorised for a POS Profile.
+
+	Empty list means the profile imposes no group restriction.
+	"""
+	cache_key = f"pos_profile_allowed_item_groups:{pos_profile_doc.name}"
+	cached = frappe.cache().get_value(cache_key)
+	if cached is not None:
+		return cached
+
+	result = list(dict.fromkeys(
+		descendant_group
+		for profile_group_row in pos_profile_doc.get("item_groups", [])
+		for descendant_group in _get_item_group_with_descendants(profile_group_row.item_group)
+	))
+	frappe.cache().set_value(cache_key, result, expires_in_sec=300)
+	return result
+
+
 def _build_item_base_conditions(
 	pos_profile_doc,
 	item_group=None,
@@ -769,25 +793,27 @@ def _build_item_base_conditions(
 		conditions.append("i.custom_company = %s")
 		where_params.append(pos_profile_doc.company)
 
+	allowed_item_groups = _get_pos_profile_allowed_item_groups(pos_profile_doc)
+
 	if item_group:
-		item_groups = _get_item_group_with_descendants(item_group)
-		placeholders = ", ".join(["%s"] * len(item_groups))
-		conditions.append(f"i.item_group IN ({placeholders})")
-		where_params.extend(item_groups)
+		# Intersect explicit request with profile scope so a caller cannot reach
+		# items outside the profile's authorised groups.
+		requested_groups = _get_item_group_with_descendants(item_group)
+		if allowed_item_groups:
+			allowed_set = set(allowed_item_groups)
+			effective_groups = [g for g in requested_groups if g in allowed_set]
+		else:
+			effective_groups = requested_groups
 	else:
-		# When no specific item_group filter is passed (e.g. "All Items" tab),
-		# still restrict to the item groups configured on the POS Profile.
-		profile_groups = [
-			row.item_group for row in pos_profile_doc.get("item_groups", [])
-		]
-		if profile_groups:
-			all_groups = set()
-			for pg in profile_groups:
-				all_groups.update(_get_item_group_with_descendants(pg))
-			if all_groups:
-				placeholders = ", ".join(["%s"] * len(all_groups))
-				conditions.append(f"i.item_group IN ({placeholders})")
-				where_params.extend(list(all_groups))
+		effective_groups = allowed_item_groups
+
+	if effective_groups:
+		placeholders = ", ".join(["%s"] * len(effective_groups))
+		conditions.append(f"i.item_group IN ({placeholders})")
+		where_params.extend(effective_groups)
+	elif item_group:
+		# Requested group is outside the profile's authorised scope → match nothing.
+		conditions.append("i.item_group IN (NULL)")
 
 	allowed_brands = _get_allowed_profile_brands(pos_profile_doc.name)
 	if allowed_brands:
@@ -1247,7 +1273,7 @@ def get_items(pos_profile, search_term=None, item_group=None, start=0, limit=20,
 			LIMIT %s OFFSET %s
 		"""
 
-		all_params = params + score_params + [limit, start]
+		all_params = params + score_params + [int(limit), int(start)]
 		items = frappe.db.sql(query, tuple(all_params), as_dict=1)
 
 		# Prepare maps for enrichment

--- a/pos_next/hooks.py
+++ b/pos_next/hooks.py
@@ -196,6 +196,9 @@ doc_events = {
 	"POS Profile": {
 		"on_update": "pos_next.realtime_events.emit_pos_profile_updated_event"
 	},
+	"POS Settings": {
+		"on_update": "pos_next.api.items.invalidate_pos_settings_cache"
+	},
 	"Promotional Scheme": {
 		"on_update": "pos_next.overrides.pricing_rule.sync_pos_only_to_pricing_rules"
 	}

--- a/pos_next/pos_next/doctype/pos_settings/pos_settings.json
+++ b/pos_next/pos_next/doctype/pos_settings/pos_settings.json
@@ -69,6 +69,7 @@
   "section_break_misc",
   "input_qty",
   "allow_negative_stock",
+  "allow_global_items",
   "section_break_security",
   "enable_session_lock",
   "session_lock_timeout",
@@ -514,6 +515,13 @@
    "fieldname": "allow_negative_stock",
    "fieldtype": "Check",
    "label": "Allow Negative Stock"
+  },
+  {
+   "default": "0",
+   "description": "When enabled, items with no Company set are visible in this POS (treated as shared/global SKUs). Leave off for strict per-company isolation on multi-company sites.",
+   "fieldname": "allow_global_items",
+   "fieldtype": "Check",
+   "label": "Include Global Items (no Company)"
   },
   {
    "collapsible": 1,


### PR DESCRIPTION
## Summary

Builds on edbf9008 (strict company filter + profile-group fallback) with two additional hardening commits:

1. **Scope hardening + SQL stability** — closes loopholes and removes hot-path bloat in `_build_item_base_conditions`.
2. **Opt-in global items** — restores the legitimate "shared SKU" use case via a new `allow_global_items` flag on **POS Settings** (per-profile), without re-opening the cross-company leak.

## What changes

### Commit 1: `fix(items): harden POS Profile item scope and stabilize SQL`
- **Intersect explicit `item_group` with profile scope.** A caller passing `item_group="Drinks"` against a profile that only allows `Demo Item Group` now matches **nothing** (resolves to `i.item_group IN (NULL)`), instead of bypassing the scope.
- **Deterministic SQL params.** Replaced `set()`-based dedup with insertion-ordered `dict.fromkeys`, so repeat calls produce identical parameter tuples → MariaDB query-plan cache is preserved on every keystroke.
- **Cache `_get_item_group_with_descendants`** (300s TTL, mirroring the brand cache pattern) — eliminates N SQL queries per profile expansion.
- **Extract `_get_pos_profile_allowed_item_groups`** helper, parallel to `_get_allowed_profile_brands`. One source of truth, cached.
- **`int(limit)` / `int(start)`** in `get_items` raw SQL params, fixes a pre-existing crash when called via HTTP-GET (`LIMIT '5' OFFSET 0` → SQL syntax error). Matches the existing cast in `get_items_bulk`.

### Commit 2: `feat(items): opt-in 'allow_global_items' setting per POS Profile`
- New `Check` field `allow_global_items` on the **POS Settings** doctype (default `0`), placed in the Miscellaneous section.
- When **off** (default): strict `i.custom_company = %s` — items with empty/NULL `custom_company` are hidden. This is the safe default for multi-company sites.
- When **on**: `(i.custom_company = %s OR IFNULL(custom_company, '') = '')` — the legacy "no company set = global SKU" convention works again. **Cross-company items remain hidden in both modes.**
- Same logic applied in `get_item_variants` (was previously inconsistent with `_build_item_base_conditions` — variants from other companies could leak through the variant dialog).
- Helper `_pos_settings_allow_global_items` reads the flag once per request, cached 300s. Hooked `POS Settings.on_update → invalidate_pos_settings_cache` so toggles take effect immediately rather than after TTL.

## Why this matters

Before edbf9008: items with empty `custom_company` were visible in every POS — on multi-company sites this leaked items across branches.

edbf9008 closed the leak with strict equality, but in doing so silently hid all "global" SKUs (gift cards, services, shared products) on every site, breaking the legitimate use case.

This PR keeps strict isolation as the default while giving per-branch profiles an explicit, audited opt-in to see global items — without ever relaxing the "other company" check.

## Test plan

Verified end-to-end on `nexus.local` (multi-company site with companies `BrainWise (Demo)` + `BrainWise`):

**Strict-mode regression suite (26 cases, all PASS):**
- [x] same-company item visible
- [x] other-company item hidden
- [x] empty/NULL `custom_company` hidden
- [x] item outside profile groups hidden, inside visible
- [x] descendant group resolved, sibling group excluded
- [x] explicit `item_group` arg intersects with profile scope
- [x] explicit out-of-scope group → empty result via `IN (NULL)` sentinel
- [x] disabled / non-sales items hidden
- [x] `exclude_variants` / `exclude_templates` flags honored
- [x] 5 repeated calls produce identical SQL signatures (determinism)
- [x] duplicate group rows in profile dedupe in SQL
- [x] degenerate profiles (no groups, no company) handled

**Flag toggle suite (12 cases, all PASS):**
- [x] flag OFF: empty/NULL hidden, other-co hidden, own-co visible
- [x] flag ON: empty/NULL **visible**, other-co **still hidden**, own-co visible
- [x] flag toggle invalidates cache (flip OFF → strict equality returns immediately)

**Live UI on `nexus.local` POS app:**
- [x] item grid loads (1-100 of 3224, all `BrainWise (Demo)` items)
- [x] clicking `Drinks` tab → 253 drink items visible
- [x] clicking `Demo Item Group` tab → "No results" (correct — no items in that leaf for this company)
- [x] HTTP-GET `?limit=5` works after the int-cast fix (was 500 before)

## Rollout / rollback

- **Migration**: required (one new column on `tabPOS Settings`). `bench --site <site> migrate` adds `allow_global_items TINYINT(1) DEFAULT 0`. Existing rows default to `0`, preserving current strict behaviour.
- **Rollback**: revert both commits — column stays harmless, no data is destroyed.
- **No frontend changes** required; existing UI keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)