### PR TITLE
allow_customer_credit_payment added into settings

### DIFF
--- a/POS/src/components/settings/POSSettings.vue
+++ b/POS/src/components/settings/POSSettings.vue
@@ -344,6 +344,11 @@
 												:description="__('Enable sales on credit')"
 											/>
 											<CheckboxField
+												v-model="settings.allow_customer_credit_payment"
+												:label="__('Allow Customer Credit Payment')"
+												:description="__('Allow customers to use available credit balance during payment')"
+											/>
+											<CheckboxField
 												v-model="settings.allow_return"
 												:label="__('Allow Return')"
 												:description="__('Enable product returns')"


### PR DESCRIPTION
Added allow customer credit payment in pos settings the field was already there but where no setting .
<img width="932" height="420" alt="Screenshot 2026-06-11 at 1 17 07 PM" src="https://github.com/user-attachments/assets/e954e959-b0db-4de2-ac27-c0901f33b7cc" />
