### PR TITLE
fix: enforce one-time-per-customer offers (server gate + offline/online sync)

### DIFF
--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -2088,9 +2088,13 @@ async function handlePaymentCompleted(paymentData) {
 			// the original row as superseded (keeps audit trail, excludes from sync).
 			if (editingOfflineContext?.originalQueueId) {
 				try {
-					await offlineWorker.supersedeOfflineInvoice(
+					// Supersede also releases the original's cached one-time
+					// redemptions (it never syncs); the new invoice records its own.
+					await offlineStore.supersedeInvoice(
 						editingOfflineContext.originalQueueId,
-						offlineReceiptName
+						offlineReceiptName,
+						editingOfflineContext.originalOfflineId,
+						customerValue
 					);
 				} catch (err) {
 					log.error("Failed to supersede original offline invoice:", err);
@@ -2129,6 +2133,12 @@ async function handlePaymentCompleted(paymentData) {
 			};
 			uiStore.setLastOfflinePrintDoc(offlinePrintDoc);
 			cacheOfflineReceiptPayload(offlineReceiptName, offlinePrintDoc);
+
+			// Cache one-time-per-customer redemptions locally (keyed by this
+			// offline invoice's id) so the next offline sale to this customer
+			// can't reuse the offer. Must run before clearCart() empties the cart.
+			await cartStore.recordOfflineRedemptionsForSale(offlineReceiptName);
+
 			uiStore.showPaymentDialog = false;
 			cartStore.clearCart();
 			// Reset cart hash after successful payment
@@ -2181,9 +2191,14 @@ async function handlePaymentCompleted(paymentData) {
 				if (editingOfflineContext?.originalQueueId) {
 					const serverName = result.name || result.message?.name || null;
 					try {
-						await offlineWorker.supersedeOfflineInvoice(
+						// Supersede also releases the original's cached one-time
+						// redemptions (it never syncs); the online submit just now
+						// recorded the redemption server-side.
+						await offlineStore.supersedeInvoice(
 							editingOfflineContext.originalQueueId,
-							serverName
+							serverName,
+							editingOfflineContext.originalOfflineId,
+							cartStore.customer?.name || cartStore.customer || null
 						);
 					} catch (err) {
 						log.error(
@@ -2192,8 +2207,6 @@ async function handlePaymentCompleted(paymentData) {
 						);
 					}
 					editingOfflineContext = null;
-					// Refresh pending count so the OfflineInvoicesDialog badge updates.
-					await offlineStore.updatePendingCount();
 				}
 
 				const invoiceName = result.name || result.message?.name || __("Unknown");

--- a/POS/src/stores/posCart.js
+++ b/POS/src/stores/posCart.js
@@ -275,14 +275,6 @@ export const usePOSCartStore = defineStore("posCart", () => {
 			return;
 		}
 
-		// Capture one-time offer redemptions before submission can clear the cart.
-		const customerName = customer.value?.name || customer.value || null;
-		const oneTimeRuleNames = appliedOffers.value
-			.filter((o) => o.offer?.one_time_per_customer)
-			.map((o) => o.code)
-			.filter(Boolean);
-		const wasOffline = offlineState.isOffline;
-
 		const result = await baseSubmitInvoice(
 			targetDoctype.value,
 			deliveryDate.value,
@@ -294,7 +286,32 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		if (result) {
 			writeOffAmount.value = 0;
 		}
+		// Online submits record one-time redemptions server-side on submit; the
+		// offline checkout path caches them locally via recordOfflineRedemptionsForSale.
 		return result;
+	}
+
+	/** The Pricing Rule names of the currently-applied one-time-per-customer offers. */
+	function appliedOneTimeRuleNames() {
+		return appliedOffers.value
+			.filter((o) => o.offer?.one_time_per_customer)
+			.map((o) => o.code)
+			.filter(Boolean);
+	}
+
+	/**
+	 * Cache the one-time redemptions for an OFFLINE sale so the next offline sale
+	 * to this customer can't reuse the offer (mirrors the server hook, which only
+	 * runs once the invoice syncs). Keyed by the offline invoice id so a later void
+	 * releases exactly its own redemptions. Call before clearCart().
+	 *
+	 * @param {string} offlineId - The queued invoice's offline_id
+	 */
+	async function recordOfflineRedemptionsForSale(offlineId) {
+		const customerName = customer.value?.name || customer.value || null;
+		const ruleNames = appliedOneTimeRuleNames();
+		if (!customerName || !ruleNames.length) return;
+		await offersStore.recordOfflineRedemptions(customerName, ruleNames, offlineId);
 	}
 
 	async function createSalesOrder() {
@@ -1888,6 +1905,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		loadTaxRules,
 		setTaxInclusive,
 		submitInvoice,
+		recordOfflineRedemptionsForSale,
 		applyDiscountToCart,
 		removeDiscountFromCart,
 		applyOffer,

--- a/POS/src/stores/posOffers.js
+++ b/POS/src/stores/posOffers.js
@@ -6,7 +6,8 @@ import { offlineWorker } from "@/utils/offline/workerClient";
 import {
 	getOneTimeRedemptions,
 	setOneTimeRedemptions,
-	addOneTimeRedemptions,
+	addOfflineRedemptions,
+	releaseOfflineRedemptions,
 } from "@/utils/offline/db";
 import { usePOSShiftStore } from "@/stores/posShift";
 
@@ -82,8 +83,10 @@ export const usePOSOffersStore = defineStore("posOffers", () => {
 				});
 				const serverRules = resp?.message || resp || [];
 				if (Array.isArray(serverRules)) {
-					redeemed = Array.from(new Set([...(redeemed || []), ...serverRules]));
-					await setOneTimeRedemptions(customerName, redeemed);
+					// Server is authoritative: replace the cached server set (so a
+					// server-side release self-heals) while preserving not-yet-synced
+					// offline redemptions. The returned effective set is their union.
+					redeemed = await setOneTimeRedemptions(customerName, serverRules);
 				}
 			} catch (error) {
 				// Keep cached redemptions if the server fetch fails.
@@ -96,16 +99,35 @@ export const usePOSOffersStore = defineStore("posOffers", () => {
 
 	/**
 	 * Persist one-time rule redemptions made during an offline checkout so the
-	 * next offline sale to the same customer sees them.
+	 * next offline sale to the same customer sees them. Keyed by invoice id so a
+	 * later void of that offline sale can release exactly its own redemptions.
 	 *
 	 * @param {string} customerName
 	 * @param {string[]} ruleNames
+	 * @param {string} invoiceId - The offline invoice id these redemptions belong to
 	 */
-	async function recordOfflineRedemptions(customerName, ruleNames = []) {
+	async function recordOfflineRedemptions(customerName, ruleNames = [], invoiceId = "_") {
 		if (!customerName || !ruleNames.length) return;
-		await addOneTimeRedemptions(customerName, ruleNames);
+		await addOfflineRedemptions(customerName, ruleNames, invoiceId);
 		for (const ruleName of ruleNames) {
 			addRedeemedOneTimeRule(ruleName);
+		}
+	}
+
+	/**
+	 * Release the cached offline redemptions for a voided/deleted offline sale,
+	 * mirroring the server's release_one_time_offer_usage on cancel. Refreshes the
+	 * in-memory gate if the affected customer is currently selected.
+	 *
+	 * @param {string} invoiceId - The offline invoice id whose redemptions to release
+	 * @param {string} [customerName] - Customer name, if known
+	 */
+	async function releaseOfflineRedemptionsForInvoice(invoiceId, customerName = null) {
+		if (!invoiceId) return;
+		const effective = await releaseOfflineRedemptions(invoiceId, customerName);
+		// Refresh the in-memory gate from the set release just returned (no re-read).
+		if (customerName) {
+			redeemedOneTimeRules.value = effective;
 		}
 	}
 
@@ -467,5 +489,6 @@ export const usePOSOffersStore = defineStore("posOffers", () => {
 		clearOneTimeContext,
 		loadOneTimeContextForCustomer,
 		recordOfflineRedemptions,
+		releaseOfflineRedemptionsForInvoice,
 	};
 });

--- a/POS/src/stores/posSync.js
+++ b/POS/src/stores/posSync.js
@@ -25,6 +25,7 @@ import {
 	cacheUnpaidSummary,
 } from "@/utils/offline";
 import { call } from "@/utils/apiWrapper";
+import { releaseOfflineRedemptions } from "@/utils/offline/db";
 import { logger } from "@/utils/logger";
 import { offlineState } from "@/utils/offline/offlineState";
 import { offlineWorker } from "@/utils/offline/workerClient";
@@ -146,7 +147,42 @@ export const usePOSSyncStore = defineStore("posSync", () => {
 	 * @param {string} id - Invoice ID to delete
 	 */
 	async function deletePending(id) {
+		// Before removing the queued invoice, release any one-time-per-customer
+		// redemptions it cached locally so a void doesn't permanently block the
+		// customer from the offer (mirrors the server's release on cancel).
+		try {
+			const pending = await getPending();
+			const row = pending.find((inv) => inv.id === id || inv.offline_id === id);
+			const offlineId = row?.offline_id || row?.data?.offline_id;
+			if (offlineId) {
+				await releaseOfflineRedemptions(offlineId, row?.data?.customer || null);
+			}
+		} catch (error) {
+			log.error("Failed to release offline redemptions for deleted invoice", error);
+		}
 		await offlineWorker.deleteOfflineInvoice(id);
+		await updatePendingCount();
+	}
+
+	/**
+	 * Mark a queued offline invoice as superseded (by an edit) and release the
+	 * one-time-per-customer redemptions it cached. The superseded row never syncs,
+	 * so its redemptions must be freed; the replacement records its own. Bundling
+	 * release with supersede here keeps it on a single chokepoint, mirroring delete.
+	 * @param {number} queueId - invoice_queue id of the superseded row
+	 * @param {string} replacedBy - id/name of the replacement invoice (audit trail)
+	 * @param {string} [offlineId] - offline_id of the superseded row (its redemption key)
+	 * @param {string} [customer] - customer of the superseded row, if known
+	 */
+	async function supersedeInvoice(queueId, replacedBy, offlineId = null, customer = null) {
+		await offlineWorker.supersedeOfflineInvoice(queueId, replacedBy);
+		if (offlineId) {
+			try {
+				await releaseOfflineRedemptions(offlineId, customer);
+			} catch (error) {
+				log.error("Failed to release offline redemptions for superseded invoice", error);
+			}
+		}
 		await updatePendingCount();
 	}
 
@@ -426,6 +462,7 @@ export const usePOSSyncStore = defineStore("posSync", () => {
 		loadPendingInvoices,
 		updatePendingCount,
 		deleteOfflineInvoice,
+		supersedeInvoice,
 		syncAllPending,
 		preloadDataForOffline,
 		checkOfflineCacheAvailability,

--- a/POS/src/utils/offline/__tests__/oneTimeRedemptions.test.js
+++ b/POS/src/utils/offline/__tests__/oneTimeRedemptions.test.js
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory stand-in for the Dexie `one_time_redemptions` table, keyed by customer.
+const store = new Map();
+
+const fakeTable = {
+	async get(customer) {
+		const row = store.get(customer);
+		return row ? JSON.parse(JSON.stringify(row)) : undefined;
+	},
+	async put(row) {
+		store.set(row.customer, JSON.parse(JSON.stringify(row)));
+	},
+	async toArray() {
+		return Array.from(store.values()).map((r) => JSON.parse(JSON.stringify(r)));
+	},
+};
+
+// Mock Dexie so importing db.js doesn't touch IndexedDB. The constructed instance
+// exposes our fake `one_time_redemptions` table and no-op schema methods.
+vi.mock("dexie", () => {
+	class FakeDexie {
+		constructor() {
+			this.one_time_redemptions = fakeTable;
+		}
+		version() {
+			return { stores: () => {} };
+		}
+		on() {}
+	}
+	return { default: FakeDexie };
+});
+
+vi.mock("@/utils/logger", () => {
+	const noop = { error: () => {}, warn: () => {}, info: () => {}, debug: () => {}, success: () => {} };
+	return { logger: { ...noop, create: () => noop } };
+});
+
+const {
+	getOneTimeRedemptions,
+	setOneTimeRedemptions,
+	addOfflineRedemptions,
+	releaseOfflineRedemptions,
+} = await import("../db");
+
+beforeEach(() => {
+	store.clear();
+});
+
+describe("one-time redemption cache (offline/online)", () => {
+	it("P0: offline redemption is recorded and visible to the gate", async () => {
+		await addOfflineRedemptions("CUST-1", ["RULE-A"], "off-1");
+		expect(await getOneTimeRedemptions("CUST-1")).toEqual(["RULE-A"]);
+	});
+
+	it("effective set is the union of server + offline buckets", async () => {
+		await setOneTimeRedemptions("CUST-1", ["RULE-S"]);
+		await addOfflineRedemptions("CUST-1", ["RULE-A"], "off-1");
+		expect((await getOneTimeRedemptions("CUST-1")).sort()).toEqual(["RULE-A", "RULE-S"]);
+	});
+
+	it("P3: online fetch REPLACES server set (release self-heals) but keeps offline redemptions", async () => {
+		await setOneTimeRedemptions("CUST-1", ["RULE-S1", "RULE-S2"]);
+		await addOfflineRedemptions("CUST-1", ["RULE-OFF"], "off-1");
+		const eff = await setOneTimeRedemptions("CUST-1", ["RULE-S1"]);
+		expect(eff.sort()).toEqual(["RULE-OFF", "RULE-S1"]); // S2 released, offline kept
+	});
+
+	it("P2: voiding one offline invoice releases only its own redemptions", async () => {
+		await addOfflineRedemptions("CUST-1", ["RULE-A"], "off-1");
+		await addOfflineRedemptions("CUST-1", ["RULE-A"], "off-2");
+		await releaseOfflineRedemptions("off-1", "CUST-1");
+		expect(await getOneTimeRedemptions("CUST-1")).toEqual(["RULE-A"]); // off-2 still blocks
+		await releaseOfflineRedemptions("off-2", "CUST-1");
+		expect(await getOneTimeRedemptions("CUST-1")).toEqual([]);
+	});
+
+	it("release returns the effective set when the customer is known (no re-read needed)", async () => {
+		await setOneTimeRedemptions("CUST-1", ["RULE-S"]);
+		await addOfflineRedemptions("CUST-1", ["RULE-OFF"], "off-1");
+		const eff = await releaseOfflineRedemptions("off-1", "CUST-1");
+		expect(eff).toEqual(["RULE-S"]); // offline bucket dropped, server set remains
+	});
+
+	it("P2: release works without knowing the customer (scans all rows)", async () => {
+		await addOfflineRedemptions("CUST-1", ["RULE-A"], "off-1");
+		await addOfflineRedemptions("CUST-2", ["RULE-B"], "off-2");
+		await releaseOfflineRedemptions("off-1");
+		expect(await getOneTimeRedemptions("CUST-1")).toEqual([]);
+		expect(await getOneTimeRedemptions("CUST-2")).toEqual(["RULE-B"]);
+	});
+
+	it("backward compat: a legacy flat `rules` row is read as serverRules", async () => {
+		store.set("CUST-1", { customer: "CUST-1", rules: ["LEGACY-RULE"] });
+		expect(await getOneTimeRedemptions("CUST-1")).toEqual(["LEGACY-RULE"]);
+		await addOfflineRedemptions("CUST-1", ["NEW-RULE"], "off-1");
+		expect((await getOneTimeRedemptions("CUST-1")).sort()).toEqual(["LEGACY-RULE", "NEW-RULE"]);
+	});
+});

--- a/POS/src/utils/offline/db.js
+++ b/POS/src/utils/offline/db.js
@@ -83,11 +83,15 @@ const CURRENT_SCHEMA = {
 	// Stores invoices with outstanding amounts for partial payment management
 	unpaid_invoices: "&name, pos_profile, outstanding_amount, customer",
 
-	// One-time-per-customer offer redemptions cache.
-	// Keyed by customer; `rules` is an array of redeemed Pricing Rule names.
-	// Populated from the server when a customer is selected (online) and
-	// appended to on offline checkout, so the offline offer engine can mirror
-	// the server-side one-time gate in apply_offers.
+	// One-time-per-customer offer redemptions cache. Keyed by customer.
+	// Row shape: { customer, serverRules: string[], offlineRules: { [invoiceId]: string[] } }
+	//   serverRules  — authoritative set from the server (replaced wholesale on
+	//                  each online fetch, so a server-side release self-heals).
+	//   offlineRules — redemptions from not-yet-synced offline sales, keyed by
+	//                  invoice id so a voided offline sale can release just its own.
+	// The effective redeemed set (what the offline gate checks) is the union of
+	// serverRules and every offlineRules entry. Legacy rows store a flat `rules`
+	// array; the helpers read it for backward compatibility.
 	one_time_redemptions: "&customer",
 };
 
@@ -227,7 +231,32 @@ export const setSetting = async (key, value) => {
 };
 
 /**
- * Get the cached one-time-per-customer redeemed Pricing Rule names for a customer.
+ * Normalize a cached row (or undefined) into { serverRules, offlineRules }.
+ * Legacy rows stored a flat `rules` array; treat those as serverRules.
+ */
+const _normalizeRedemptionRow = (row) => {
+	if (!row) return { serverRules: [], offlineRules: {} };
+	const offlineRules = row.offlineRules && typeof row.offlineRules === "object" ? row.offlineRules : {};
+	let serverRules = Array.isArray(row.serverRules) ? row.serverRules : [];
+	// Backward compat: fold a legacy flat `rules` array into serverRules.
+	if (Array.isArray(row.rules)) {
+		serverRules = Array.from(new Set([...serverRules, ...row.rules]));
+	}
+	return { serverRules, offlineRules };
+};
+
+/** The effective redeemed set = serverRules ∪ all offlineRules entries. */
+const _effectiveRedeemed = ({ serverRules, offlineRules }) => {
+	const all = new Set(serverRules);
+	for (const rules of Object.values(offlineRules)) {
+		for (const rule of rules || []) all.add(rule);
+	}
+	return Array.from(all);
+};
+
+/**
+ * Get the effective cached one-time redeemed Pricing Rule names for a customer
+ * (server redemptions plus not-yet-synced offline redemptions).
  * @param {string} customer - Customer name
  * @returns {Promise<string[]>} Redeemed rule names (empty array if none/unknown)
  */
@@ -235,7 +264,7 @@ export const getOneTimeRedemptions = async (customer) => {
 	if (!customer) return [];
 	try {
 		const row = await db.one_time_redemptions.get(customer);
-		return Array.isArray(row?.rules) ? row.rules : [];
+		return _effectiveRedeemed(_normalizeRedemptionRow(row));
 	} catch (error) {
 		log.error(`Error reading one-time redemptions for ${customer}:`, error);
 		return [];
@@ -243,37 +272,90 @@ export const getOneTimeRedemptions = async (customer) => {
 };
 
 /**
- * Replace the cached redeemed rule names for a customer (used after a server fetch).
- * @param {string} customer - Customer name
- * @param {string[]} rules - Redeemed Pricing Rule names
- * @returns {Promise<void>}
+ * Read a customer's redemption row, apply `mutate` to the normalized
+ * { serverRules, offlineRules }, persist it, and return the effective set.
+ * The shared read-mutate-write path for every redemption writer below.
  */
-export const setOneTimeRedemptions = async (customer, rules = []) => {
-	if (!customer) return;
+const _putRedemptionRow = async (customer, mutate) => {
+	const row = _normalizeRedemptionRow(await db.one_time_redemptions.get(customer));
+	mutate(row);
+	await db.one_time_redemptions.put({
+		customer,
+		serverRules: row.serverRules,
+		offlineRules: row.offlineRules,
+	});
+	return _effectiveRedeemed(row);
+};
+
+/**
+ * Replace the authoritative SERVER redemption set for a customer (used after an
+ * online fetch). Preserves not-yet-synced offline redemptions, so a server-side
+ * release self-heals on reconnect without losing offline-only redemptions.
+ * @param {string} customer - Customer name
+ * @param {string[]} serverRules - Redeemed Pricing Rule names from the server
+ * @returns {Promise<string[]>} The effective redeemed set after the update
+ */
+export const setOneTimeRedemptions = async (customer, serverRules = []) => {
+	if (!customer) return [];
 	try {
-		await db.one_time_redemptions.put({ customer, rules: Array.from(new Set(rules)) });
+		return await _putRedemptionRow(customer, (row) => {
+			row.serverRules = Array.from(new Set(serverRules));
+		});
 	} catch (error) {
 		log.error(`Error saving one-time redemptions for ${customer}:`, error);
+		return await getOneTimeRedemptions(customer);
 	}
 };
 
 /**
- * Append redeemed rule names for a customer (used on offline checkout), merging
- * with whatever is already cached.
+ * Record redemptions made during an OFFLINE checkout, keyed by invoice id so a
+ * later void of that invoice can release exactly its own redemptions.
  * @param {string} customer - Customer name
  * @param {string[]} rules - Newly redeemed Pricing Rule names
- * @returns {Promise<string[]>} The merged list of redeemed rule names
+ * @param {string} invoiceId - Offline invoice id these redemptions belong to
+ * @returns {Promise<string[]>} The effective redeemed set after the update
  */
-export const addOneTimeRedemptions = async (customer, rules = []) => {
+export const addOfflineRedemptions = async (customer, rules = [], invoiceId = "_") => {
 	if (!customer || !rules.length) return await getOneTimeRedemptions(customer);
 	try {
-		const existing = await getOneTimeRedemptions(customer);
-		const merged = Array.from(new Set([...existing, ...rules]));
-		await db.one_time_redemptions.put({ customer, rules: merged });
-		return merged;
+		return await _putRedemptionRow(customer, (row) => {
+			const existing = row.offlineRules[invoiceId] || [];
+			row.offlineRules[invoiceId] = Array.from(new Set([...existing, ...rules]));
+		});
 	} catch (error) {
-		log.error(`Error appending one-time redemptions for ${customer}:`, error);
+		log.error(`Error appending offline redemptions for ${customer}:`, error);
 		return await getOneTimeRedemptions(customer);
+	}
+};
+
+/**
+ * Release the offline redemptions recorded for a specific invoice (used when an
+ * offline sale is voided/deleted/superseded before it ever reached the server).
+ * Server redemptions are untouched. If `customer` is unknown, scans all rows.
+ * @param {string} invoiceId - Offline invoice id whose redemptions to release
+ * @param {string} [customer] - Customer name, if known (faster keyed lookup)
+ * @returns {Promise<string[]>} The affected customer's effective set, or [] for a scan
+ */
+export const releaseOfflineRedemptions = async (invoiceId, customer = null) => {
+	if (!invoiceId) return [];
+	try {
+		if (customer) {
+			return await _putRedemptionRow(customer, (row) => {
+				delete row.offlineRules[invoiceId];
+			});
+		}
+		// Unknown customer: scan all rows and drop this invoice's bucket wherever found.
+		for (const raw of await db.one_time_redemptions.toArray()) {
+			if (raw?.offlineRules && invoiceId in raw.offlineRules) {
+				await _putRedemptionRow(raw.customer, (row) => {
+					delete row.offlineRules[invoiceId];
+				});
+			}
+		}
+		return [];
+	} catch (error) {
+		log.error(`Error releasing offline redemptions for invoice ${invoiceId}:`, error);
+		return [];
 	}
 };
 

--- a/POS/src/utils/offline/sync.js
+++ b/POS/src/utils/offline/sync.js
@@ -1,7 +1,7 @@
 import { call } from "@/utils/apiWrapper";
 import { logger } from "@/utils/logger";
 import { CoalescingMutex } from "@/utils/mutex";
-import { db } from "./db";
+import { db, releaseOfflineRedemptions } from "./db";
 import { offlineState } from "./offlineState";
 import { removeOfflineReceiptPayload } from "./offlineReceiptCache";
 import { generateOfflineId } from "./uuid";
@@ -231,13 +231,21 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
  * @param {number} id - Invoice queue ID
  * @param {string} serverInvoice - Server invoice name
  * @param {string} [offlineId] - pos_offline_<uuid> cache key to evict
+ * @param {string} [customer] - customer of the invoice (keyed redemption release)
  */
-const markInvoiceSynced = async (id, serverInvoice, offlineId) => {
+const markInvoiceSynced = async (id, serverInvoice, offlineId, customer = null) => {
 	await db.invoice_queue.update(id, {
 		synced: true,
 		server_invoice: serverInvoice,
 	});
-	if (offlineId) removeOfflineReceiptPayload(offlineId);
+	if (offlineId) {
+		removeOfflineReceiptPayload(offlineId);
+		// The server now owns any one-time redemptions this invoice made
+		// (recorded on submit), so drop the offline-bucket entry. A later online
+		// customer-select repopulates it as an authoritative serverRule. Passing
+		// the customer keeps this a keyed single-row write, not a full-table scan.
+		await releaseOfflineRedemptions(offlineId, customer);
+	}
 };
 
 /**
@@ -305,12 +313,13 @@ const syncInvoiceToServer = async (invoice, retryCount = 0) => {
 	const IN_PROGRESS_WAIT_MS = 2000; // Wait 2 seconds between retries
 
 	const offlineId = invoice.offline_id || invoice.data?.offline_id;
+	const customer = invoice.data?.customer || null;
 
 	// Pre-sync deduplication check
 	if (offlineId) {
 		const syncStatus = await checkOfflineIdSynced(offlineId);
 		if (syncStatus.synced) {
-			await markInvoiceSynced(invoice.id, syncStatus.sales_invoice, offlineId);
+			await markInvoiceSynced(invoice.id, syncStatus.sales_invoice, offlineId, customer);
 			log.debug("Invoice already synced, skipping", {
 				id: invoice.id,
 				offline_id: offlineId,
@@ -330,7 +339,7 @@ const syncInvoiceToServer = async (invoice, retryCount = 0) => {
 
 		if (response.message || response.name) {
 			const serverName = response.name || response.message;
-			await markInvoiceSynced(invoice.id, serverName, offlineId);
+			await markInvoiceSynced(invoice.id, serverName, offlineId, customer);
 			log.success("Invoice synced", {
 				id: invoice.id,
 				offline_id: offlineId,
@@ -398,7 +407,8 @@ export const syncOfflineInvoices = async () => {
 					await markInvoiceSynced(
 						invoice.id,
 						invoiceName,
-						invoice.offline_id || invoice.data?.offline_id
+						invoice.offline_id || invoice.data?.offline_id,
+						invoice.data?.customer || null
 					);
 					log.debug("Invoice is duplicate, marked as synced", { id: invoice.id });
 					result.skipped++;

--- a/pos_next/api/invoices.py
+++ b/pos_next/api/invoices.py
@@ -277,6 +277,17 @@ def _pricing_rule_to_string(value):
 	return ""
 
 
+def is_one_time_eligible_customer(customer, default_customer, is_return=False):
+	"""Whether one-time-per-customer offers can be granted/tracked for this sale.
+
+	The single source of truth shared by apply_offers (grant side) and
+	update_invoice (record side) so the two can't drift: a one-time offer needs an
+	identified, non walk-in (non default-customer) customer and is never tracked on
+	a return/credit note.
+	"""
+	return bool(customer) and customer != default_customer and not is_return
+
+
 def _strip_server_managed_fields(payload):
 	"""Remove fields that are derived server-side and should not be replayed."""
 	if not isinstance(payload, dict):
@@ -886,6 +897,13 @@ def update_invoice(data):
 				item.pricing_rules = ""
 
 		if doctype == "Sales Invoice":
+			# Only stamp rules we can actually track: an identified, non walk-in
+			# customer on a non-return sale (see is_one_time_eligible_customer).
+			can_track_one_time = is_one_time_eligible_customer(
+				invoice_doc.get("customer"),
+				pos_profile_doc.customer if pos_profile_doc else None,
+				invoice_doc.get("is_return"),
+			)
 			one_time_applied = (
 				frappe.get_all(
 					"Pricing Rule",
@@ -895,7 +913,7 @@ def update_invoice(data):
 					},
 					pluck="name",
 				)
-				if applied_rule_names_seen
+				if (applied_rule_names_seen and can_track_one_time)
 				else []
 			)
 			invoice_doc.pos_applied_one_time_rules = (
@@ -3086,6 +3104,31 @@ def apply_offers(invoice_data, selected_offers=None):
 		# rules never apply to anonymous sales (see the loop below).
 		default_customer = profile.get("customer")
 
+		# Fetch this customer's already-redeemed one-time rules once (a customer's
+		# redemption history is small and customer-indexed) so the gate below is an
+		# in-memory membership test rather than one exists() query per rule. Filtering
+		# by the pricing_rule field also keeps us immune to the doctype's autoname.
+		one_time_eligible = is_one_time_eligible_customer(customer, default_customer)
+		redeemed_one_time_rules = (
+			set(
+				frappe.get_all(
+					"One Time Customer Offer Usage",
+					filters={"customer": customer},
+					pluck="pricing_rule",
+				)
+			)
+			if one_time_eligible
+			else set()
+		)
+
+		# One-time-per-customer gate shared by the per-item and transaction loops:
+		# drop the rule when the customer is ineligible (walk-in/anonymous) or has
+		# already redeemed it.
+		def _skip_one_time_rule(record):
+			if not record.get("one_time_per_customer"):
+				return False
+			return not one_time_eligible or record.name in redeemed_one_time_rules
+
 		rule_map = {}
 		if raw_rule_names:
 			rule_records = frappe.get_all(
@@ -3105,15 +3148,8 @@ def apply_offers(invoice_data, selected_offers=None):
 				if record.coupon_code_based:
 					continue
 
-				# One-time-per-customer rules: skip for anonymous sales and for
-				# customers who have already redeemed this rule. Dropping the rule
-				# here keeps its discount out of the per-item loop below (which only
-				# applies rules present in rule_map), mirroring the coupon skip above.
-				if record.one_time_per_customer:
-					if not customer or customer == default_customer:
-						continue
-					if frappe.db.exists("One Time Customer Offer Usage", f"{customer}::{record.name}"):
-						continue
+				if _skip_one_time_rule(record):
+					continue
 
 				# Include both promotional scheme rules and standalone pricing rules
 				rule_map[record.name] = record
@@ -3137,11 +3173,14 @@ def apply_offers(invoice_data, selected_offers=None):
 					"name",
 					"promotional_scheme",
 					"coupon_code_based",
+					"one_time_per_customer",
 					"promotional_scheme_id",
 					"price_or_product_discount",
 				],
 			)
 			for record in txn_rule_records:
+				if _skip_one_time_rule(record):
+					continue
 				rule_map.setdefault(record.name, record)
 
 		if selected_offer_names:

--- a/pos_next/api/sales_invoice_hooks.py
+++ b/pos_next/api/sales_invoice_hooks.py
@@ -114,10 +114,14 @@ def record_one_time_offer_usage(doc, method=None):
 
 	The applied one-time rules are read from ``pos_applied_one_time_rules`` (a
 	JSON list stamped by update_invoice before item.pricing_rules is cleared —
-	the cleared field can't be read back here). Inserts a
-	``One Time Customer Offer Usage`` row per (customer, rule); the doctype's
-	composite name ({customer}::{pricing_rule}) makes a duplicate insert raise
-	DuplicateEntryError, so it stays idempotent and race-safe.
+	the cleared field can't be read back here). Inserts one
+	``One Time Customer Offer Usage`` row per (customer, rule).
+
+	Idempotency / race-safety: the doctype's composite name
+	(``{customer}:{pricing_rule}``) makes a duplicate insert a no-op via
+	``ignore_if_duplicate``. Recording must never fail the sale, so any other
+	insert error (e.g. an over-long composite name) is logged and skipped rather
+	than propagated out of on_submit.
 	"""
 	import json
 
@@ -137,6 +141,8 @@ def record_one_time_offer_usage(doc, method=None):
 	from frappe.utils import now
 
 	for rule in rule_names:
+		if not rule:
+			continue
 		try:
 			frappe.get_doc(
 				{
@@ -147,13 +153,25 @@ def record_one_time_offer_usage(doc, method=None):
 					"redemption_date": now(),
 				}
 			).insert(ignore_permissions=True, ignore_if_duplicate=True)
-		except frappe.DuplicateEntryError:
-			# Customer already recorded for this rule — one-time guard intact.
-			pass
+		except Exception:
+			# Recording must never fail the sale. Log and move on.
+			frappe.log_error(
+				title="One-time offer usage recording failed",
+				message=(
+					f"Could not record redemption of {rule!r} for {doc.customer!r} "
+					f"on invoice {doc.name}: {frappe.get_traceback()}"
+				),
+			)
 
 
 def release_one_time_offer_usage(doc, method=None):
-	"""Release one-time redemptions on cancel so the customer can redeem again."""
+	"""Release one-time redemptions on cancel so the customer can redeem again.
+
+	Keyed on ``sales_invoice`` so only the redemptions this invoice created are
+	released. Return/credit-note cancels are a harmless no-op (returns never
+	created usage rows). On amend, ERPNext cancels the original (releasing here)
+	and the amended invoice re-records on its own submit.
+	"""
 	frappe.db.delete("One Time Customer Offer Usage", {"sales_invoice": doc.name})
 
 


### PR DESCRIPTION
## Summary

PR #319 introduced the **One-Time Offer per Customer** feature, but a review found the limit **was not actually being enforced** — online or offline. This PR fixes the server-side gate, closes a transaction-rule bypass, makes the offline/online frontend consistent, and hardens the recording hook so it can never break a sale.

No schema change and no data migration — the original `One Time Customer Offer Usage` doctype and its `format:{customer}:{pricing_rule}` autoname are kept. All lookups now use field filters instead of reconstructing the composite name.

---

## The bugs this fixes

### 🔴 1. Server gate never matched recorded redemptions
`apply_offers` checked existence with a **double-colon** key — `f"{customer}::{record.name}"` — but the doctype autoname generates a **single-colon** name (`CUST:RULE`). The lookup never matched, so a customer could redeem the same one-time offer **unlimited times online**. Proven on a live site.

**Fix:** field-filter lookup `frappe.db.exists("One Time Customer Offer Usage", {"customer": customer, "pricing_rule": record.name})` — immune to the autoname format.

### 🔴 2. Transaction-scoped one-time offers bypassed the gate entirely
The transaction-rule top-up loop didn't select `one_time_per_customer` and applied no gate, so cart-level one-time offers applied on **every** invoice, including walk-ins and repeat customers.

**Fix:** added the field to the query and routed both loops through a shared `_skip_one_time_rule`.

### 🔴 3. Offline redemption recording was silently dropped
A refactor (commit `cf035dc2`) removed the call that caches a redemption on offline checkout, leaving the whole `recordOfflineRedemptions` chain orphaned. The same customer could re-apply a one-time offer on every offline sale; on sync the server strips the discount, causing a **receipt/cash vs. server grand_total mismatch**.

**Fix:** recording restored in the real offline checkout path (`POSSale.vue`), keyed by the offline invoice id.

### 🟠 4. Walk-in / return sales recorded redemptions
`update_invoice` stamped `pos_applied_one_time_rules` unconditionally, which would write a usage row against the **shared default/walk-in customer** (blocking everyone) or consume a redemption on a credit note.

**Fix:** stamp only for an identified, non-default, non-return customer via the new `is_one_time_eligible_customer` helper.

---

## Changes

### Backend — `pos_next/api/`
- **`invoices.py`**
  - `apply_offers`: field-filter existence check (#1); shared `_skip_one_time_rule` applied in both the per-item and transaction loops (#2); customer's redeemed set fetched **once** into a `set` (1 query instead of one `exists()` per rule).
  - `update_invoice`: walk-in/return guard on stamping (#4).
  - New `is_one_time_eligible_customer(customer, default_customer, is_return)` — single source of truth shared by the grant side and record side.
- **`sales_invoice_hooks.py`**
  - `record_one_time_offer_usage`: never fails the sale — guards an over-long composite name and logs-and-skips any insert error; idempotency via `ignore_if_duplicate`. Removed the redundant per-rule pre-skip.

### Frontend — `POS/src/`
- **`utils/offline/db.js`** — redemption cache row reshaped to `{ serverRules, offlineRules: { [invoiceId]: [...] } }`:
  - `serverRules` — authoritative, **replaced wholesale** on each online fetch so a server-side release self-heals.
  - `offlineRules` — per-invoice unsynced redemptions, so a voided offline sale releases **only its own**.
  - Backward-compatible with legacy flat `rules` rows. Shared `_putRedemptionRow` read-mutate-write helper; `releaseOfflineRedemptions` returns the effective set.
- **`stores/posOffers.js`** — online fetch is authoritative (replace, preserve offline); `recordOfflineRedemptions` keyed by invoice id; new `releaseOfflineRedemptionsForInvoice` refreshes the in-memory gate without a re-read.
- **`stores/posCart.js`** — `recordOfflineRedemptionsForSale` computes applied one-time rules and delegates to the offers store.
- **`stores/posSync.js`** — `deletePending` releases redemptions on void; new **single-chokepoint** `supersedeInvoice` bundles worker-supersede + release.
- **`utils/offline/sync.js`** — `markInvoiceSynced` releases the offline-bucket entry once synced, **keyed by customer** (no full-table scan per invoice on the sync hot path).
- **`pages/POSSale.vue`** — records redemptions on offline checkout; routes both supersede sites through `posSync.supersedeInvoice`.

### Offline ⇄ online parity matrix
| Event | Behavior |
|---|---|
| Offline sale | Redemption cached locally (keyed by offline id) → blocks next offline sale |
| Online sale | Recorded server-side on submit; gate self-heals on next customer-select |
| Offline void / delete | Cached redemption released → customer not wrongly blocked |
| Offline edit (supersede) | Original's redemption released; replacement records its own |
| Sync to server | Offline-bucket entry dropped; repopulated as authoritative `serverRule` |
| Server-side cancel/release | Self-heals on next online fetch (server set replaced) |

---

## Tests
- New `POS/src/utils/offline/__tests__/oneTimeRedemptions.test.js` — **7 passing** vitest cases covering record (P0), server∪offline union, server-authoritative self-heal (P3), per-invoice release (P2), no-customer scan, release-returns-effective-set, and legacy-row backward compat.
- Backend verified live on `pos-dev`: gate now fires (incl. customer names containing `:`), duplicate insert rejected, field-based lookup correct, long-name checkout degrades gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)