### PR TITLE
feat: implement F4/F8/F9 keyboard shortcuts

### DIFF
--- a/POS/src/components/sale/InvoiceCart.vue
+++ b/POS/src/components/sale/InvoiceCart.vue
@@ -265,6 +265,7 @@
 
 							<!-- Native Input for Instant Search -->
 							<input
+								ref="customerSearchInputRef"
 								id="cart-customer-search"
 								name="cart-customer-search"
 								:value="customerSearch"
@@ -1619,6 +1620,7 @@ const {
 const customerSearch = ref(""); // Current search query
 const customerSearchContainer = ref(null); // Ref to search container for click-outside detection
 const customerSearchFocused = ref(false); // Track if search input is focused
+const customerSearchInputRef = ref(null); // Ref to the native search input element
 // Use Pinia store for allCustomers (shared with CustomerDialog, synced on customer creation)
 const allCustomers = computed(() => customerSearchStore.allCustomers);
 const customersLoaded = computed(() => customerSearchStore.allCustomers.length > 0);
@@ -2248,6 +2250,12 @@ onMounted(() => {
 onBeforeUnmount(() => {
 	if (typeof document === "undefined") return;
 	document.removeEventListener("mousedown", handleOutsideClick);
+});
+
+defineExpose({
+	focusCustomerSearch() {
+		customerSearchInputRef.value?.focus();
+	},
 });
 </script>
 ```

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -380,6 +380,7 @@
 							style="min-width: 300px; contain: layout style paint"
 						>
 							<InvoiceCart
+								ref="invoiceCartRef"
 								:items="cartStore.invoiceItems"
 								:customer="cartStore.customer"
 								:subtotal="cartStore.subtotal"
@@ -1151,6 +1152,7 @@ const { isRTL } = useLocale();
 
 // Component refs
 const itemsSelectorRef = ref(null);
+const invoiceCartRef = ref(null);
 const offersDialogRef = ref(null);
 const containerRef = ref(null);
 const dividerRef = ref(null);
@@ -1294,6 +1296,27 @@ onMounted(async () => {
 		updateLayoutBounds();
 	};
 	window.addEventListener("resize", handleResize, { passive: true });
+
+	// Global keyboard shortcuts
+	const handleGlobalKeydown = (event) => {
+		// Skip if any dialog is open or if user is typing in an input/textarea
+		if (uiStore.isAnyDialogOpen) return;
+		const tag = document.activeElement?.tagName;
+		if (tag === "INPUT" || tag === "TEXTAREA") return;
+
+		if (event.key === "F4") {
+			event.preventDefault();
+			itemsSelectorRef.value?.focusSearchInput();
+		} else if (event.key === "F8") {
+			event.preventDefault();
+			invoiceCartRef.value?.focusCustomerSearch();
+		} else if (event.key === "F9") {
+			event.preventDefault();
+			handleProceedToPayment();
+		}
+	};
+	window.addEventListener("keydown", handleGlobalKeydown);
+	onUnmounted(() => window.removeEventListener("keydown", handleGlobalKeydown));
 
 	// Set up real-time stock update listener
 	const cleanup = onStockUpdate(async (stockUpdates) => {


### PR DESCRIPTION
## Summary

- **F4** — focuses the item search input (`ItemsSelector.focusSearchInput`, already exposed)
- **F8** — focuses the customer search input in the cart (new `InvoiceCart.focusCustomerSearch` via `defineExpose`)
- **F9** — triggers checkout (`handleProceedToPayment`, includes existing cart/customer validation)

These shortcuts were listed in the README but had zero implementation in the codebase.

## Changes

- `POSSale.vue`: adds `ref="invoiceCartRef"` on `<InvoiceCart>`, declares `invoiceCartRef`, and registers a global `window.keydown` listener (cleaned up on unmount) that dispatches F4/F8/F9
- `InvoiceCart.vue`: adds `ref="customerSearchInputRef"` on the native search `<input>`, declares the ref, and exposes `focusCustomerSearch()` via `defineExpose`

## Guards
- Shortcuts no-op when `uiStore.isAnyDialogOpen` is true
- Shortcuts no-op when `document.activeElement` is an `INPUT` or `TEXTAREA`

## Test plan

- [ ] Open POS, press **F4** — item search input gains focus
- [ ] Press **F8** — customer search input in cart gains focus
- [ ] Add items to cart, press **F9** — payment dialog opens (or warning if no customer required)
- [ ] Open any dialog, press F4/F8/F9 — nothing happens
- [ ] Click into a quantity field, press F4/F8/F9 — nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Reopens #230, which was auto-closed by the stale-PR bot for lack of recent activity. No code changes since — recreated to bring it back into review._