### PR TITLE
fix(pos_profile): import cint for allow_credit_sale resolution

### DIFF
--- a/pos_next/api/pos_profile.py
+++ b/pos_next/api/pos_profile.py
@@ -4,6 +4,7 @@
 
 import frappe
 from frappe import _
+from frappe.utils import cint
 
 from pos_next.api.utilities import _parse_list_parameter, check_user_company
 


### PR DESCRIPTION
## Summary
- Adds the missing `from frappe.utils import cint` in `pos_next/api/pos_profile.py`.
- `get_receivable_accounts` already calls `cint(...)` at the allow_credit_sale gate; without the import this is a live `NameError` on develop.

## Why its own PR
Split out of #318's `a4f6ffd` ruff sweep so this is reviewable as a real bug fix, not formatting. The rest of that sweep was dropped from #318 (N3).

## Test plan
- [ ] Import `pos_next.api.pos_profile` under site context (loads clean)
- [ ] Call `get_receivable_accounts` for a profile with POS Settings / credit sale enabled — no NameError
- [ ] Same call with credit sale disabled — returns `[]` as before


Made with [Cursor](https://cursor.com)